### PR TITLE
Update docs PR link

### DIFF
--- a/layouts/section/showcase.html
+++ b/layouts/section/showcase.html
@@ -11,7 +11,7 @@
 <hr>
 
 <blockquote>
-If you want to be added to this page, please send a <a href="https://github.com/gohugoio/hugo/pulls">pull request</a>. Check out the <a href="{{ relref . "community/contributing.md#showcase-additions" }}">how-to guide</a>.
+If you want to be added to this page, please send a <a href="https://github.com/gohugoio/hugoDocs/pulls">pull request</a>. Check out the <a href="{{ relref . "community/contributing.md#showcase-additions" }}">how-to guide</a>.
 </blockquote>
 
 {{ partial "footer.html" . }}


### PR DESCRIPTION
This PR updates the docs PR link in the Showcase index to //github.com/gohugoio/hugoDocs/pulls