### PR TITLE
Update MathJax Tutorial with another method

### DIFF
--- a/content/tutorials/mathjax.md
+++ b/content/tutorials/mathjax.md
@@ -90,14 +90,14 @@ With this setup, everything is in place for a natural usage of MathJax on pages 
 An alternative solution is to edit the `_default` template as follows in addition to adding the mathjax script to your site's head. Add `mathjax: true` to the frontmatter of any page that will use this method to display maths. Where a template uses `{{ .Content }}` replace it with:
 
       {{ if .Params.MathJax }} 
-          {{ $p := slice (dict "regex" "(\\$\\$)(.*?)(\\$\\$)" "delim" "$$" "tag" "block" "redelimL" "$$$$" "redelimR" "$$$$") (dict "regex" "(\\$)(.*?)(\\$)" "delim" "$" "tag" "inlineA" "redelimL" "$$" "redelimR" "$$") (dict "regex" "(\\\\\\()(.*?)(\\\\\\))" "delim" "$" "tag" "inlineB" "redelimL" "\\(" "redelimR" "\\)")  }} 
+          {{ $p := slice (dict "regex" "(\\$\\$)((.|[\r\n\t])*?)(\\$\\$)" "delim" "$$" "tag" "block" "redelimL" "$$$$" "redelimR" "$$$$") (dict "regex" "(\\$)((.|[\r\n\t])*?)(\\$)" "delim" "$" "tag" "inlineA" "redelimL" "$$" "redelimR" "$$") (dict "regex" "(\\\\\\()((.|[\r\n\t])*?)(\\\\\\))" "delim" "$" "tag" "inlineB" "redelimL" "\\(" "redelimR" "\\)")  }} 
           {{ $alpha := .RawContent | replaceRE (index $p 0).regex (print "<mathjax " (index $p 0).tag "=' $2 '/>") }} 
           {{ $beta := $alpha | replaceRE (index $p 1).regex (print "<mathjax " (index $p 1).tag "=' $2 '/>") }} 
           {{ $gamma := $beta | replaceRE (index $p 2).regex (print "<mathjax " (index $p 2).tag "=' $2 '/>") }} 
           {{ $process := $gamma | markdownify }} 
-          {{ $ungamma := $process | replaceRE (print "(<mathjax " (index $p 2).tag "=')(.*?)('/>)") (print (index $p 2).redelimL " $2 " (index $p 2).redelimR) }} 
-          {{ $unbeta := $ungamma | replaceRE (print "(<mathjax " (index $p 1).tag "=')(.*?)('/>)") (print (index $p 1).redelimL " $2 " (index $p 1).redelimR) }} 
-          {{ $unalpha := $unbeta | replaceRE (print "(<mathjax " (index $p 0).tag "=')(.*?)('/>)") (print (index $p 0).redelimL " $2 " (index $p 0).redelimR) }} 
+          {{ $ungamma := $process | replaceRE (print "(<mathjax " (index $p 2).tag "=')((.|[\r\n\t])*?)('/>)") (print (index $p 2).redelimL " $2 " (index $p 2).redelimR) }} 
+          {{ $unbeta := $ungamma | replaceRE (print "(<mathjax " (index $p 1).tag "=')((.|[\r\n\t])*?)('/>)") (print (index $p 1).redelimL " $2 " (index $p 1).redelimR) }} 
+          {{ $unalpha := $unbeta | replaceRE (print "(<mathjax " (index $p 0).tag "=')((.|[\r\n\t])*?)('/>)") (print (index $p 0).redelimL " $2 " (index $p 0).redelimR) }} 
           {{ $unalpha | safeHTML }}
       {{ else }}
           {{ .Content }}

--- a/content/tutorials/mathjax.md
+++ b/content/tutorials/mathjax.md
@@ -89,19 +89,19 @@ With this setup, everything is in place for a natural usage of MathJax on pages 
 
 An alternative solution is to edit the `_default` template as follows in addition to adding the mathjax script to your site's head. Add `mathjax: true` to the frontmatter of any page that will use this method to display maths. Where a template uses `{{ .Content }}` replace it with:
 
-    {{ if .Params.MathJax }} 
-        {{ $p := slice (dict "regex" "(\\$\\$)(.*?)(\\$\\$)" "delim" "$$" "tag" "block" "redelimL" "$$$$" "redelimR" "$$$$") (dict "regex" "(\\$)(.*?)(\\$)" "delim" "$" "tag" "inlineA" "redelimL" "$$" "redelimR" "$$") (dict "regex" "(\\\\\\()(.*?)(\\\\\\))" "delim" "$" "tag" "inlineB" "redelimL" "\\(" "redelimR" "\\)")  }} 
-        {{ $alpha := .RawContent | replaceRE (index $p 0).regex (print "<mathjax " (index $p 0).tag "=' $2 '/>") }} 
-        {{ $beta := $alpha | replaceRE (index $p 1).regex (print "<mathjax " (index $p 1).tag "=' $2 '/>") }} 
-        {{ $gamma := $beta | replaceRE (index $p 2).regex (print "<mathjax " (index $p 2).tag "=' $2 '/>") }} 
-        {{ $process := $gamma | markdownify }} 
-        {{ $ungamma := $process | replaceRE (print "(<mathjax " (index $p 2).tag "=')(.*?)('/>)") (print (index $p 2).redelimL " $2 " (index $p 2).redelimR) }} 
-        {{ $unbeta := $ungamma | replaceRE (print "(<mathjax " (index $p 1).tag "=')(.*?)('/>)") (print (index $p 1).redelimL " $2 " (index $p 1).redelimR) }} 
-        {{ $unalpha := $unbeta | replaceRE (print "(<mathjax " (index $p 0).tag "=')(.*?)('/>)") (print (index $p 0).redelimL " $2 " (index $p 0).redelimR) }} 
-        {{ $unalpha | safeHTML }}
-    {{ else }}
-        {{ .Content }}
-    {{ end }}
+      {{ if .Params.MathJax }} 
+          {{ $p := slice (dict "regex" "(\\$\\$)(.*?)(\\$\\$)" "delim" "$$" "tag" "block" "redelimL" "$$$$" "redelimR" "$$$$") (dict "regex" "(\\$)(.*?)(\\$)" "delim" "$" "tag" "inlineA" "redelimL" "$$" "redelimR" "$$") (dict "regex" "(\\\\\\()(.*?)(\\\\\\))" "delim" "$" "tag" "inlineB" "redelimL" "\\(" "redelimR" "\\)")  }} 
+          {{ $alpha := .RawContent | replaceRE (index $p 0).regex (print "<mathjax " (index $p 0).tag "=' $2 '/>") }} 
+          {{ $beta := $alpha | replaceRE (index $p 1).regex (print "<mathjax " (index $p 1).tag "=' $2 '/>") }} 
+          {{ $gamma := $beta | replaceRE (index $p 2).regex (print "<mathjax " (index $p 2).tag "=' $2 '/>") }} 
+          {{ $process := $gamma | markdownify }} 
+          {{ $ungamma := $process | replaceRE (print "(<mathjax " (index $p 2).tag "=')(.*?)('/>)") (print (index $p 2).redelimL " $2 " (index $p 2).redelimR) }} 
+          {{ $unbeta := $ungamma | replaceRE (print "(<mathjax " (index $p 1).tag "=')(.*?)('/>)") (print (index $p 1).redelimL " $2 " (index $p 1).redelimR) }} 
+          {{ $unalpha := $unbeta | replaceRE (print "(<mathjax " (index $p 0).tag "=')(.*?)('/>)") (print (index $p 0).redelimL " $2 " (index $p 0).redelimR) }} 
+          {{ $unalpha | safeHTML }}
+      {{ else }}
+          {{ .Content }}
+      {{ end }}
 
 The idea here is to use regular expressions to hide the LaTeX code from the markdown engine inside a pseudo-tag, then process the markdown before undoing the process. Benefits of this method are that you can write your LaTeX inside `$$`, `$` or `\(,\)` as usual without having to remember extra symbols. The markdown you create will also be more portable and it renders properly to what you would write if you wrote the HTML by hand rather than including extraneous `<code>` or `<div>` tags. As it requires `mathjax: true` in the frontbatter to be enables it is also backwards compatible if you have used a different method of enabling MathJax in the past.
 


### PR DESCRIPTION
I have added a third method of integrating MathJax, advantages are no longer requiring backticks or `<div>`s  to be entered and more natural rendered code. Disadvantages, it might make builds slightly longer?