### PR TITLE
Update and simplify Disqus documentation

### DIFF
--- a/content/content-management/comments.md
+++ b/content/content-management/comments.md
@@ -19,7 +19,7 @@ toc: true
 
 Hugo ships with support for [Disqus](https://disqus.com/), a third-party service that provides comment and community capabilities to websites via JavaScript.
 
-Your theme may already support Disqus, but if not, it is easy to add to your templates via [Hugo's built-in Disqus partial][disquspartial].
+Your theme may already support Disqus, but if not, it is easy to add to your templates via [Hugo's built-in Disqus template][disqustemplate].
 
 ## Add Disqus
 
@@ -43,9 +43,9 @@ For many websites, this is enough configuration. However, you also have the opti
 * `disqus_title`
 * `disqus_url`
 
-### Render Hugo's Built-in Disqus Partial Template
+### Render Hugo's Built-in Disqus Template
 
-See [Partial Templates][partials] to learn how to add the Disqus partial to your Hugo website's templates.
+See [Internal Templates][disqustemplate] to learn how to add Disqus to your Hugo website.
 
 ## Comments Alternatives
 
@@ -72,13 +72,12 @@ Written using Go, Socket.io, and [MongoDB][], Kaiju is very fast and easy to dep
 It is in early development but shows promise. If you have interest, please help by contributing via pull request, [opening an issue in the Kaiju GitHub repository][kaijuissue], or [Tweeting about it][tweet]. Every bit helps. -->
 
 [configuration]: /getting-started/configuration/
-[disquspartial]: /templates/partials/#disqus
+[disqustemplate]: /templates/internal/#disqus
 [disqussetup]: https://disqus.com/profile/signup/
 [forum]: https://discourse.gohugo.io
 [front matter]: /content-management/front-matter/
 [Graph Comment]: https://graphcomment.com/
 [kaijuissue]: https://github.com/spf13/kaiju/issues/new
 [issotutorial]: https://stiobhart.net/2017-02-24-isso-comments/
-[partials]: /templates/partials/
 [MongoDB]: https://www.mongodb.com/
 [tweet]: https://twitter.com/spf13

--- a/content/templates/internal.md
+++ b/content/templates/internal.md
@@ -56,7 +56,7 @@ You can then include the Google Analytics internal template:
 
 ## Disqus
 
-Hugo also ships with an internal template for [Disqus comments][disqus], a popular commenting system for both static and dynamic websites. In order to effectively use Disqus, you will need to secure a Disqus "shortname" by [signing up for the free service][disqussignup].
+Hugo also ships with an internal template for Disqus, a popular commenting system for both static and dynamic websites. In order to use Disqus, you will need to secure a Disqus "shortname" by [signing up for the free service](https://disqus.com/profile/signup/).
 
 ### Configure Disqus
 
@@ -84,54 +84,4 @@ To add Disqus, include the following line in templates where you want your comme
 {{ template "_internal/disqus.html" . }}
 ```
 
-### Conditional Loading of Disqus Comments
-
-Users have noticed that enabling Disqus comments when running the Hugo web server on `localhost` (i.e. via `hugo server`) causes the creation of unwanted discussions on the associated Disqus account.
-
-You can create the following `layouts/partials/disqus.html`:
-
-{{% code file="layouts/partials/disqus.html" download="disqus.html" %}}
-```html
-<div id="disqus_thread"></div>
-<script type="text/javascript">
-
-(function() {
-    // Don't ever inject Disqus on localhost--it creates unwanted
-    // discussions from 'localhost:1313' on your Disqus account...
-    if (window.location.hostname == "localhost")
-        return;
-
-    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-    var disqus_shortname = '{{ .Site.DisqusShortname }}';
-    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-})();
-</script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-```
-{{% /code %}}
-
-The `if` statement skips the initialization of the Disqus comment injection when you are running on `localhost`.
-
-You can then render your custom Disqus partial template as follows:
-
-```golang
-{{ partial "disqus.html" . }}
-```
-
-```
-_internal/_default/robots.txt
-_internal/_default/rss.xml
-_internal/_default/sitemap.xml
-_internal/_default/sitemapindex.xml
-
-_internal/disqus.html
-_internal/google_news.html
-_internal/google_analytics.html
-_internal/google_analytics_async.html
-_internal/opengraph.html
-_internal/pagination.html
-_internal/schema.html
-_internal/twitter_cards.html
-```
+Be aware that this template will not load Disqus when you are previewing your website locally. When running on `localhost` (i.e. via `hugo server`), initialization of Disqus is skipped to avoid creating unwanted discussions on your Disqus account.


### PR DESCRIPTION
As of Hugo 0.25 ([this PR](https://github.com/gohugoio/hugo/pull/3639)), the internal Disqus template does not load on localhost - as such, the suggestion that users create a separate partial solely for this purpose is redundant. This PR replaces that advice with an explanation of when Disqus initializes, and also updates several old Disqus links on the Comments page.