### PR TITLE
docs: Add note to install Testify

### DIFF
--- a/content/contribute/development.md
+++ b/content/contribute/development.md
@@ -139,6 +139,12 @@ So, let's clone that master repository:
 go get -v -u github.com/gohugoio/hugo
 ```
 
+Hugo relies on [Testify](https://github.com/stretchr/testify) for testing Go code. If you don't already have it, get the Testify testing tools:
+
+```
+go get https://github.com/stretchr/testify
+```
+
 ### Fork the repository
 
 If you're not fimiliar with this term, GitHub's [help pages](https://help.github.com/articles/fork-a-repo/) provide again a simple explanation:

--- a/content/contribute/development.md
+++ b/content/contribute/development.md
@@ -142,7 +142,7 @@ go get -v -u github.com/gohugoio/hugo
 Hugo relies on [Testify](https://github.com/stretchr/testify) for testing Go code. If you don't already have it, get the Testify testing tools:
 
 ```
-go get https://github.com/stretchr/testify
+go get github.com/stretchr/testify
 ```
 
 ### Fork the repository


### PR DESCRIPTION
The Hugo Contributor Guide (Development) instructs users to run "go test ./..." and ensure it passes before moving on. However Hugo requires the Testify package for testing, and running the go test command without Testify results in 'cannot find package' errors and failing tests. It's hard to understand what to do next for users not familiar with Go dependencies. This commit adds a note to the contributor guide instructing users to get Testify if they don't already have it installed. Running the 'go get' command added here results in passing tests in the next step of the contributor guide.
