### PR TITLE
Add missing forward slash to baseurl example

### DIFF
--- a/content/content-management/organization.md
+++ b/content/content-management/organization.md
@@ -47,7 +47,7 @@ While Hugo supports content nested at any level, the top levels (i.e. `content/<
 
 ## Path Breakdown in Hugo
 
-The following demonstrates the relationships between your content organization and the output URL structure for your Hugo website when it renders. These examples assume you are [using pretty URLs][pretty], which is the default behavior for Hugo. The examples also assume a key-value of `baseurl = "https://example.com"` in your [site's configuration file][config].
+The following demonstrates the relationships between your content organization and the output URL structure for your Hugo website when it renders. These examples assume you are [using pretty URLs][pretty], which is the default behavior for Hugo. The examples also assume a key-value of `baseurl = "https://example.com/"` in your [site's configuration file][config].
 
 ### Index Pages: `_index.md`
 


### PR DESCRIPTION
A missing slash in baseurl can trip up a lot of new users (like it did me)