### PR TITLE
Add missing closing and opening comment tags

### DIFF
--- a/content/content-management/organization.md
+++ b/content/content-management/organization.md
@@ -201,9 +201,9 @@ layout: mylayout
 ---
 {{< /code >}}
 <!-- See https://discourse.gohugo.io/t/path-not-works/6387 -->
-<!-- ### `path`
+<!-- ### `path`-->
 
-`path` can be provided in the front matter. This will replace the actual path to the file on disk. Destination will create the destination with the same path, including the section. -->
+<!--`path` can be provided in the front matter. This will replace the actual path to the file on disk. Destination will create the destination with the same path, including the section. -->
 
 ### `url`
 


### PR DESCRIPTION
The comment tags were split between lines and therefore caused the content within them to render as html.