### PR TITLE
Explain how to add non-404 custom error pages.

### DIFF
--- a/content/templates/404.md
+++ b/content/templates/404.md
@@ -52,4 +52,16 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 * Amazon AWS S3. When setting a bucket up for static web serving, you can specify the error file from within the S3 GUI.
 * Caddy Server. Using `errors { 404 /404.html }`. [Details here](https://caddyserver.com/docs/errors)
 
+## Serving Other Custom Error Pages
+
+The above technique works only for 404 errors. To create additional custom error pages, such as 401 and 403, place them in the `static/` directory, and adjust your server settings for each file as noted in {{< relref "#Automatic Loading" >}}. 
+
+Note that unlike the 404.html file, these pages are static can not make use of Hugo's variable substitution. They must be complete `html` files.
+
+```
+▾ static/
+    403.html
+```
+
+
 [pagevars]: /variables/page/

--- a/content/templates/404.md
+++ b/content/templates/404.md
@@ -62,9 +62,7 @@ The above technique works only for 404 errors. To create additional custom error
     403.md
 ```
 
-Then adjust your server settings as noted in {{< relref "#Automatic Loading" >}}. 
-
-Note that Hugo automatically creates directories for each file in the `content/`directory. Thus `403.md’ becomes `403/index.html` on the live site. For the above examples, the actual paths will be `401/index.html’ and `403/index.html`. On Apache servers, your `.htaccess` file might contain something like this:
+Then adjust your server settings as noted in {{< relref "#Automatic Loading" >}}. Note that Hugo automatically creates directories for each file in the `content/`directory. Thus `403.md` becomes `403/index.html` on the live site. For the above examples, the actual paths will be `401/index.html` and `403/index.html`. On Apache servers, your `.htaccess` file might contain something like this:
 
 ```
 Options -Indexes

--- a/content/templates/404.md
+++ b/content/templates/404.md
@@ -56,7 +56,7 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 
 The above technique works only for 404 errors. To create additional custom error pages, such as 401 and 403, place them in the `static/` directory, and adjust your server settings for each file as noted in {{< relref "#Automatic Loading" >}}. 
 
-Note that unlike the 404.html file, these pages are static can not make use of Hugo's variable substitution. They must be complete `html` files.
+Note that unlike the `404.html` file in `layouts/`, these pages are static and can not make use of Hugo's variable substitution. They must be complete `html` files.
 
 ```
 ▾ static/

--- a/content/templates/404.md
+++ b/content/templates/404.md
@@ -54,13 +54,23 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 
 ## Serving Other Custom Error Pages
 
-The above technique works only for 404 errors. To create additional custom error pages, such as 401 and 403, place them in the `static/` directory, and adjust your server settings for each file as noted in {{< relref "#Automatic Loading" >}}. 
-
-Note that unlike the `404.html` file in `layouts/`, these pages are static and can not make use of Hugo's variable substitution. They must be complete `html` files.
+The above technique works only for 404 errors. To create additional custom error pages, such as 401 and 403, create appropriate `.md` files in the `content/` directory.
 
 ```
-▾ static/
-    403.html
+▾ content/
+    401.md
+    403.md
+```
+
+Then adjust your server settings as noted in {{< relref "#Automatic Loading" >}}. 
+
+Note that Hugo automatically creates directories for each file in the `content/`directory. Thus `403.md’ becomes `403/index.html` on the live site. For the above examples, the actual paths will be `401/index.html’ and `403/index.html`. On Apache servers, your `.htaccess` file might contain something like this:
+
+```
+Options -Indexes
+ErrorDocument 404 /404.html
+ErrorDocument 401 /401/
+ErrorDocument 403 /403/
 ```
 
 


### PR DESCRIPTION
I spent too long last night doing what seemed logical at the time to create a custom 403 error page. I tried every permutation before realizing the system worked as intended, and 404 is handled differently from all other errors. A search shows many others waste time with the same experiments. I saw the discussions about this changing at some point in the future, but for now it would save needless frustration to explain the work-around. 