### PR TITLE
Added examples on how to add custom metadata to a taxonomy term

### DIFF
--- a/content/content-management/taxonomies.md
+++ b/content/content-management/taxonomies.md
@@ -84,7 +84,7 @@ Moonrise Kingdom            <- Content
 
 ## Hugo Taxonomy Defaults
 
-Hugo natively supports taxonomies. 
+Hugo natively supports taxonomies.
 
 Without adding a single line to your site's configuration file, Hugo will automatically create taxonomies for `tags` and `categories`. If you do not want Hugo to create any taxonomies, set `disableKinds` in your site's configuration to the following:
 
@@ -228,6 +228,19 @@ By using taxonomic weight, the same piece of content can appear in different pos
 {{% note "Limits to Ordering Taxonomies" %}}
 Currently taxonomies only support the [default `weight => date` ordering of list content](/templates/lists/#default-weight-date). For more information, see the documentation on [taxonomy templates](/templates/taxonomy-templates/).
 {{% /note %}}
+
+## Add custom metadata to a Taxonomy Term
+
+If you need to add custom metadata to your taxonomy terms, you will need to create a page for that term at `/content/<TAXONOMY>/<TERM>/_index.md` and add your metadata in it's front matter. Continuing with our 'Actors' example, let's say you want to add a wikipedia page link to each actor. Your terms pages would be something like this:
+
+{{< code file="/content/actors/bruce-willis/_index.md" >}}
+  ---
+  title: "Bruce Willis"
+  wikipedia: "https://en.wikipedia.org/wiki/Bruce_Willis"
+  ---
+{{< /code >}}
+
+You can later use your custom metadata as shown in the [Taxonomy Terms Templates documentation](/templates/taxonomy-templates/#displaying-custom-meta-data-in-taxonomy-terms-templates).
 
 [`urlize` template function]: /functions/urlize/
 [content section]: /content-management/sections/

--- a/content/templates/taxonomy-templates.md
+++ b/content/templates/taxonomy-templates.md
@@ -117,6 +117,21 @@ type WeightedPages []WeightedPage
 .Pages
 : Returns a slice of pages, which then can be ordered using any of the [list methods][renderlists].
 
+## Displaying custom metadata in Taxonomy Terms Templates
+
+If you need to display custom metadata for each taxonomy term, you will need to create a page for that term at `/content/<TAXONOMY>/<TERM>/_index.md` and add your metadata in it's front matter, [as explained in the taxonomies documentation](/content-management/taxonomies/#add-custom-meta-data-to-a-taxonomy-term). Based on the Actors taxonomy example shown there, within your taxonomy terms template, you may access your custom fields by iterating through the variable `.Data.Pages` as such:
+
+```
+<ul>
+  {{ range .Data.Pages }}
+     <li>
+       <a href="{{ .Permalink }}">{{ .Title }}</a>
+       {{ .Params.wikipedia }}
+     </li>
+  {{ end }}
+</ul>
+```
+
 <!-- Begin /taxonomies/ordering/ -->
 
 ## Order Taxonomies


### PR DESCRIPTION
There is no information on how you can add custom metadata to your
taxonomy terms. What you need to do is add front matter data in the file
/content/<TAXONOMY>/<TERM>/_index.md

Then you will be able to access the taxonomy term as a page in a
taxonomy terms template.

That is why I added instructions in /content-management/taxonomies on
how to add custom metadata. And in /templates/taxonomy-templates/ I
added an example on how you can display that metadata in the taxonomy
terms template.

I think that would be enough to guide the user in how to add custom
metadata to their taxonomy terms.