### PR TITLE
Fix typo in http2 server push blog

### DIFF
--- a/content/news/http2-server-push-in-hugo.md
+++ b/content/news/http2-server-push-in-hugo.md
@@ -66,7 +66,7 @@ Also note that this is a template for the home page, so the full `Page` with its
 
 
 ## 3. Add Template For the _redirects File 
-Add `layouts/index.redirects`:
+Add `layouts/index.redir`:
 ```bash
 # Netlify redirects. See https://www.netlify.com/docs/redirects/
 {{  range $p := .Site.Pages -}}


### PR DESCRIPTION
Corrected the template file name to match the definition in `config.toml` above