### PR TITLE
Change to Asciidoc URI

### DIFF
--- a/content/content-management/formats.md
+++ b/content/content-management/formats.md
@@ -214,7 +214,7 @@ Markdown syntax is simple enough to learn in a single sitting. The following are
 * [Markdown Tutorial (Interactive), Garen Torikian][mdtutorial]
 
 [`emojify` function]: /functions/emojify/
-[ascii]: http://asciidoc.org/
+[ascii]: http://asciidoctor.org/
 [bfconfig]: /getting-started/configuration/#configuring-blackfriday-rendering
 [blackfriday]: https://github.com/russross/blackfriday
 [mmark]: https://github.com/miekg/mmark


### PR DESCRIPTION
If merged, this change implements the following minor change:

- changes the link to asciidoc from asciidoc.org to asciidoctor.org. 

Asciidoctor extends the language much more than the python implementation, and if folks click on the python link they will likely run into processor issues when Asciidoctor attempts to process the .adoc files.

Other Asciidoctor links are correct.