### PR TITLE
update docker image for build/publish

### DIFF
--- a/content/hosting-and-deployment/hosting-on-gitlab.md
+++ b/content/hosting-and-deployment/hosting-on-gitlab.md
@@ -38,7 +38,7 @@ cd your-hugo-site
 In the root directory of your Hugo site, create a `.gitlab-ci.yml` file. The `.gitlab-ci.yml` configures the GitLab CI on how to build your page. Simply add the content below.
 
 {{< code file="gitlab-ci.yml" >}}
-image: publysher/hugo
+image: monachus/hugo
 
 pages:
   script:


### PR DESCRIPTION
The referenced image (`publysher/hugo`) is outdated, leading to the following error: `Current theme does not support Hugo version 0.22.1. Minimum version required is 0.24.1`. The current version of hugo is 0.26. I forked the publysher repo, bumped it to 0.26 and pushed it to my Docker hub (monachus is my username on Docker Hub). 

I'm an engineer at Rancher Labs and an active user of Gitlab. I've enabled notifications for Hugo releases, so as they come out, I'll tag and release an updated Docker image. I'm happy to be the target repo for this piece of documentation.