### PR TITLE
Update Installing.md

### DIFF
--- a/content/getting-started/installing.md
+++ b/content/getting-started/installing.md
@@ -66,22 +66,15 @@ choco install hugo -confirm
 #### Prerequisite Tools
 
 * [Git][installgit]
-* [Go 1.5+][installgo]
-* [govendor][]
-
-#### Vendored Dependencies
-
-Hugo uses [govendor][] to vendor dependencies, but we don't commit the vendored packages themselves to the Hugo git repository. Therefore, a simple `go get` is *not* supported because the command is not vendor aware. *You must use `govendor` to fetch Hugo's dependencies.*
+* [Go 1.7+][installgo]
 
 #### Fetch from GitHub
 
 {{< code file="from-gh.sh" >}}
-go get github.com/kardianos/govendor
-govendor get github.com/gohugoio/hugo
-go install github.com/gohugoio/hugo
+go get github.com/gohugoio/hugo
 {{< /code >}}
 
-`govendor get` will fetch Hugo and all its dependent libraries to `$GOPATH/src/github.com/gohugoio/hugo`, and `go install` compiles everything into a final `hugo` (or `hugo.exe`) executable inside `$GOPATH/bin/`.
+`go get` will fetch Hugo and all its dependent libraries to `$GOPATH/src/github.com/gohugoio/hugo`, and compiles everything into a final `hugo` (or `hugo.exe`) executable inside `$GOPATH/bin/`.
 
 {{% note %}}
 If you are a Windows user, substitute the `$HOME` environment variable above with `%USERPROFILE%`.


### PR DESCRIPTION
Adjust required Go version for compilation to 1.7+.
Remove requirement for govendor and separate go install command

When trying to follow this guide as-is on Go 1.6, govendor would download/install, but running `govendor get github.com/gohugoio/hugo` produced the error "Package "/home/stuart/src/go\n/src/github.com/gohugoio/hugo" not a go package or not in GOPATH."

Running instead `go get -v github.com/gohugoio/hugo` downloaded Hugo and all dependencies, but would not compile, giving an error of "github.com/gohugoio/hugo/commands/gendocshelper.go:61: enc.SetIndent undefined (type *json.Encoder has no field or method SetIndent)"

In order to resolve this problem it was necessary to upgrade my version of Go as the SetIndent method was not introduced into encoding/json until 1.7 (https://golang.org/doc/go1.7#minor_library_changes).

In my case I upgraded to Go 1.8 as that is what was available via a ppa, so without testing specifically on 1.7 I cannot confirm this works, but with the change being in the official docs I would assume it would.