### PR TITLE
Add missing css lang argument

### DIFF
--- a/content/tools/syntax-highlighting.md
+++ b/content/tools/syntax-highlighting.md
@@ -203,7 +203,7 @@ body {
 Here is the same example but with triple back ticks to denote the fenced code block:
 
 {{< nohighlight >}}
-```
+```css
 body {
   font-family: "Noto Sans", sans-serif;
 }


### PR DESCRIPTION
Makes the triple-backtick example equivalent to triple-tilde example.