### PR TITLE
Correct GitLab project pipelines URL

### DIFF
--- a/content/hosting-and-deployment/hosting-on-gitlab.md
+++ b/content/hosting-and-deployment/hosting-on-gitlab.md
@@ -70,7 +70,7 @@ git push -u origin master
 
 ## Wait for Your Page to Build
 
-That's it! You can now follow the CI agent building your page at https://gitlab.com/<YourUsername>/<your-hugo-site>/pipelines.
+That's it! You can now follow the CI agent building your page at `https://gitlab.com/<YourUsername>/<your-hugo-site>/pipelines`.
 
 After the build has passed, your new website is available at `https://<YourUsername>.gitlab.io/<your-hugo-site>/`.
 


### PR DESCRIPTION
The < and > characters in the URL weren't getting escaped, instead acting as if they were HTML elements. This meant the URL was displayed as https://gitlab.com///pipelines, instead of `https://gitlab.com/<YourUsername>/<your-hugo-site>/pipelines`.