### PR TITLE
Update roadmap to link to the correct milestones page

### DIFF
--- a/content/about/roadmap.md
+++ b/content/about/roadmap.md
@@ -42,7 +42,7 @@ Feel free to [contribute to Hugo's development][devcontribute], [improve Hugo's 
 [doccontribute]: /contribute/documentation/
 [hosting and deployment]: /hosting-and-deployment/
 [migrate]: /tools/migrations/
-[milestones]: https://github.com/gohugoio/hugo/milestone/14
+[milestones]: https://github.com/gohugoio/hugo/milestones/
 [newissue]: https://github.com/gohugoio/hugo/issues/
 [related forum thread]: https://discourse.gohugo.io/t/web-based-editor/155
 [themes]: /themes/


### PR DESCRIPTION
The roadmap page used to link to the `0.20` milestone page. This commit changes it to link to the index of the milestones page (in a way that we don't have do update it every version).