### PR TITLE
Escape code fencing

### DIFF
--- a/content/tools/syntax-highlighting.md
+++ b/content/tools/syntax-highlighting.md
@@ -103,7 +103,7 @@ The keywords in the `highlight` shortcode mirror those of Pygments from the comm
 
 It is also possible to add syntax highlighting with GitHub flavored code fences. To enable this, set the `PygmentsCodeFences` to `true` in Hugo's [configuration file](/getting-started/configuration/);
 
-```
+````
 ```
 <section id="main">
   <div>
@@ -114,7 +114,7 @@ It is also possible to add syntax highlighting with GitHub flavored code fences.
   </div>
 </section>
 ```
-```
+````
 
 {{% note "Disclaimers on Pygments" %}}
 * Pygments is relatively slow and _causes a performance hit when building your site_, but Hugo has been designed to cache the results to disk.


### PR DESCRIPTION
Looks like the code fencing is misformatted here.

![oops](https://user-images.githubusercontent.com/1851748/30528319-90430ed8-9bf7-11e7-824d-5ba58dd31a19.png)

I believe the intention is to escape the backticks in the code fences so that the example looks like this.

![ah](https://user-images.githubusercontent.com/1851748/30528326-a2a51a80-9bf7-11e7-986e-c513d4eaea7c.png)
