### PR TITLE
Use the common codeblock style for highlight-codeblocks

### DIFF
--- a/themes/gohugoioTheme/src/css/_code.css
+++ b/themes/gohugoioTheme/src/css/_code.css
@@ -33,14 +33,9 @@ pre {
   border-style: solid;
 }
 
-/* The Pygments highlighter comes with its own styles. */
 .highlight pre {
-  background-color: inherit;
-  color: inherit;
-  padding: 0.5em;
-  font-size: .875rem;
+  background-color: #fff;
 }
-
 
 /*We are adding the copy button content here so we can change it with javascript. See the "Clipboard scripts"*/
 .copy:after {


### PR DESCRIPTION
Note: As I can't safely compile assets (E.g. there is no yarn.lock in the repo to be sure I don't update dependency version running "npm run build:production"), the part of updating assets of the dist folders might be done by maintainers in an optional commit.

This PullRequest:
1. Fixes wrong styles for code blocks which use the highlight class.
Example: See the blue background and what happens on hovering the code block on https://gohugo.io/functions/adddate/
2. Unifies the appearance of all code blocks by removing special styles on code-blocks which use highlight.
