### PR TITLE
Remove background color from code shortcode

### DIFF
--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -1,6 +1,6 @@
 {{ $file := .Get "file" }}
 {{ $isHTML := strings.HasSuffix $file "html" }}
-<div class="code relative bg-primary-color" id="{{ $file | urlize}}">
+<div class="code relative" id="{{ $file | urlize}}">
 	{{- with $file -}}
 		<div class="filename san-serif f6 dib lh-solid pl2 pv2">{{.}}</div>
 	{{- end -}}


### PR DESCRIPTION
The current background color makes the code blocks virtually unreadable.

Turns this:
<img width="560" alt="screen shot 2017-09-29 at 7 51 03 pm" src="https://user-images.githubusercontent.com/115347/31039898-a8f5a736-a54f-11e7-916f-ac23b6860e38.png">

Into this:

<img width="561" alt="screen shot 2017-09-29 at 7 51 33 pm" src="https://user-images.githubusercontent.com/115347/31039902-b16a4ad4-a54f-11e7-9182-a02a65cbb0e5.png">

