### PR TITLE
Remove delimiters in YAML and TOML examples

### DIFF
--- a/content/getting-started/configuration.md
+++ b/content/getting-started/configuration.md
@@ -34,10 +34,9 @@ In your `config` file, you can direct Hugo as to how you want your website rende
 
 ## YAML Configuration
 
-The following is a typical example of a YAML configuration file. Note the document opens with 3 hyphens and closes with 3 periods. The values nested under `params:` will populate the [`.Site.Params`][] variable for use in [templates][]:
+The following is a typical example of a YAML configuration file. The values nested under `params:` will populate the [`.Site.Params`][] variable for use in [templates][]:
 
 {{< code file="config.yml">}}
----
 baseURL: "https://yoursite.example.com/"
 title: "My Hugo Site"
 footnoteReturnLinkContents: "↩"
@@ -51,7 +50,6 @@ params:
     - "foo1"
     - "foo2"
   SidebarRecentLimit: 5
-...
 {{< /code >}}
 
 ### All Variables, YAML
@@ -59,7 +57,6 @@ params:
 The following is the full list of Hugo-defined variables in an example YAML file. The values provided in this example represent the default values used by Hugo.
 
 {{< code file="config.yml" download="config.yml" >}}
----
 archetypeDir:               "archetypes"
 # hostname (and path) to the root, e.g. http://spf13.com/
 baseURL:                    ""
@@ -172,14 +169,13 @@ watch:                      true
 taxonomies:
   - category:               "categories"
   - tag:                    "tags"
----
 {{< /code >}}
 
 ## TOML Configuration
 
 The following is an example of a TOML configuration file. The values under `[params]` will populate the `.Site.Params` variable for use in [templates][]:
 
-```
+{{< code file="config.toml">}}
 contentDir = "content"
 layoutDir = "layouts"
 publishDir = "public"
@@ -195,14 +191,13 @@ title = "My Hugo Site"
 [params]
   subtitle = "Hugo is Absurdly Fast!"
   author = "John Doe"
-```
+{{< /code >}}
 
 ### All Variables, TOML
 
 The following is the full list of Hugo-defined variables in an example TOML file. The values provided in this example represent the default values used by Hugo.
 
 {{< code file="config.toml" download="config.toml">}}
-+++
 archetypeDir =                "archetypes"
 # hostname (and path) to the root, e.g. http://spf13.com/
 baseURL =                     ""
@@ -309,14 +304,18 @@ watch =                       true
 [taxonomies]
   category = "categories"
   tag = "tags"
-+++
 {{< /code >}}
 
 {{% note %}}
 If you are developing your site on a \*nix machine, here is a handy shortcut for finding a configuration option from the command line:
 ```
-~/sites/yourhugosite
+cd ~/sites/yourhugosite
 hugo config | grep emoji
+```
+
+which shows output like
+
+```
 enableemoji: true
 ```
 {{% /note %}}


### PR DESCRIPTION
The use of `---` and `...` delimiters in the YAML examples seem to
suggest that those delimiters are necessary in a .yaml/.yml file when in
fact they are optional. Also, it seems to be common practice to *not*
use `---` and `...` in .yaml/.yml files. Similarly, it's less common to
use `+++` in .toml files. The examples on TOML's Github repo don't use
it, and Hugo-generated .toml files don't use it either.  This commit
removes the delimiters mentioned above to conform with the more common
styles.

Additionally this modifies the example for shortcut to find
configuration option

- add `cd` to make it clear that user has to change to the hugo site's
  directory first
- separate the command and the output of the command