### PR TITLE
Clarify that .Lastmod automatically uses .GitInfo.AuthorDate

### DIFF
--- a/content/variables/git.md
+++ b/content/variables/git.md
@@ -51,4 +51,8 @@ The `GitInfo` object contains the following fields:
 `.Subject`
 : commit message subject (e.g., `tpl: Add custom index function`)
 
+## `.Lastmod`
+
+If the `.GitInfo` feature is enabled, **and** if the `lastmod` field in the content's front matter is not set, `.Lastmod` (on `Page`) is fetched from Git i.e. `.GitInfo.AuthorDate`.
+
 [configuration]: /getting-started/configuration/

--- a/content/variables/page.md
+++ b/content/variables/page.md
@@ -79,7 +79,12 @@ See [`.Scratch`](/functions/scratch/) for page-scoped, writable variables.
 `config`.
 
 `.Lastmod`
-: the date the content was last modified; `.Lastmod` pulls from the `lastmod` field in a content's front matter. If `lastmod` is not set, Hugo will default to the `date` field. See also `.ExpiryDate`, `.Date`, and `.PublishDate`.
+: the date the content was last modified. `.Lastmod` pulls from the `lastmod` field in a content's front matter.
+
+ - If `lastmod` is not set, and `.GitInfo` feature is disabled, the front matter `date` field will be used.
+ - If `lastmod` is not set, and `.GitInfo` feature is enabled, `.GitInfo.AuthorDate` will be used instead.
+
+See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 
 `.LinkTitle`
 : access when creating links to the content. If set, Hugo will use the `linktitle` from the front matter before `title`.
@@ -266,3 +271,5 @@ The top-level key will be preferred. Therefore, the following method, when appli
 {{ $.Param "favorites.flavor" }}
 => vanilla
 ```
+
+[gitinfo]: /variables/git/


### PR DESCRIPTION
If the `lastmod` field in the content front matter is not set if `.GitInfo` is
enabled, Page's .Lastmod is auto-set to .GitInfo.AuthorDate.