### PR TITLE
Add warning about MMark and TOCs

### DIFF
--- a/content/content-management/toc.md
+++ b/content/content-management/toc.md
@@ -45,6 +45,10 @@ Hugo will take this Markdown and create a table of contents from `## Introductio
 
 The built-in `.TableOfContents` variables outputs a `<nav id="TableOfContents">` element with a child `<ul>`, whose child `<li>` elements begin with any `<h1>`'s (i.e., `#` in markdown) inside your content.'
 
+{{% note "Table of contents not available for MMark" %}}
+Hugo documents created in the [MMark](/content-management/formats/#mmark) Markdown dialect do not currently display TOCs. TOCs are, however, compatible with all other supported Markdown formats.
+{{% /note %}}
+
 ## Template Example: Basic TOC
 
 The following is an example of a very basic [single page template][]:


### PR DESCRIPTION
As noted [here](https://github.com/miekg/mmark/issues/120) and [here](https://github.com/gohugoio/hugo/issues/3719), MMark documents do not currently produce TOCs. I've added a simple note here to that effect. Happy to change wording, add it in other places, etc. Just want to make sure others don't unknowingly walk into the same issue.