### PR TITLE
Update quickstart

### DIFF
--- a/content/getting-started/quick-start.md
+++ b/content/getting-started/quick-start.md
@@ -81,24 +81,38 @@ hugo new posts/my-first-post.md
 ```
 
 
-Edit the newly created content file if you want. Now, start the Hugo server with [drafts](/getting-started/usage/#draft-future-and-expired-content) enabled:
+Having the front-matter skeleton, edit the newly created content at `content/posts/my-first-post.md` and add example content:
+
+~~~
++++
+title = "This is my first post"
+date = "2017-10-10"
+tags = []
+featured_image = ""
+description = "A new post added"
++++
+
+This is an example content.
+~~~
+
+Now, start the Hugo server:
 
 ```
-▶ hugo server -D
-
+▶ hugo server
 Started building sites ...
+
 Built site for language en:
-1 of 1 draft rendered
+0 draft content
 0 future content
 0 expired content
 1 regular pages created
 8 other pages created
 0 non-page files copied
 1 paginator pages created
-0 categories created
 0 tags created
-total in 18 ms
-Watching for changes in /Users/bep/sites/quickstart/{data,content,layouts,static,themes}
+0 categories created
+total in 65 ms
+Watching for changes in /Users/bep/sites/Development/quickstart/{data,content,layouts,static,themes}
 Serving pages from memory
 Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 Press Ctrl+C to stop


### PR DESCRIPTION
Quickstart step 4 makes reference to outdated instructions (https://gohugo.io/getting-started/quick-start/#step-4-add-some-content).

As it shows the command output, it used to build a draft by default, now it is generating a regular post with empty values. To make the post display something when running the server, example content should be added.

Also there is no need to start the server with the `-D` option as new there isn't any draft, and `date` has an example value, but if none is specified it will just ignore it displaying an error in console.