### PR TITLE
Fix typo in syntax highlighting.

### DIFF
--- a/content/content-management/syntax-highlighting.md
+++ b/content/content-management/syntax-highlighting.md
@@ -106,7 +106,7 @@ The full set of supported options for Pygments is: `encoding`, `outencoding`, `n
 
 ## Generate Syntax Highlighter CSS
 
-If you run with `pygmentsUseClassic=true` in your site config, you need a style sheet.
+If you run with `pygmentsUseClasses=true` in your site config, you need a style sheet.
 
 You can generate one with Hugo:
 


### PR DESCRIPTION
It said that PygmentsUseClassic was needed for style sheets, instead of PygmentsUseClasses.