### PR TITLE
shortcode-templates.md: update year example

### DIFF
--- a/content/templates/shortcode-templates.md
+++ b/content/templates/shortcode-templates.md
@@ -150,7 +150,7 @@ Let's assume you would like to keep mentions of your copyright year current in y
 ```
 
 {{< code file="/layouts/shortcodes/year.html" >}}
-{{ .Page.Now.Year }}
+{{ now.Format "2006" }}
 {{< /code >}}
 
 ### Single Positional Example: `youtube`


### PR DESCRIPTION
The example used a deprecated way to get the current year:
`Page's Now is deprecated and will be removed in Hugo 0.31. Use now (the template func).`