### PR TITLE
Bring archetypes in from theme.

### DIFF
--- a/archetypes/functions.md
+++ b/archetypes/functions.md
@@ -4,10 +4,14 @@ description: ""
 godocref: ""
 publishdate: ""
 lastmod: ""
-categories: []
+categories: [functions]
 tags: []
-weight: 00
-slug: ""
+ns: ""
+signature: []
+workson: []
+hugoversion: ""
 aliases: []
+relatedfuncs: []
 toc: false
+deprecated: false
 ---


### PR DESCRIPTION
Fixes #43.

Copies the `default` and `functions` archetypes from the theme into the Hugo site itself.

The remaining two archetypes in the theme aren't copied over because they are for now defunct sections of Docs.