### PR TITLE
Change order of page title

### DIFF
--- a/themes/gohugoioTheme/layouts/_default/baseof.html
+++ b/themes/gohugoioTheme/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
      {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
-    <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Title }} | {{ . }}{{ end }}{{ end }}</title>
+    <title>{{ block "title" . }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
 


### PR DESCRIPTION
For the `<title>` element, it's customary to have the name of the page first, and then the site's name. This is especially useful when there are a lot of tabs open in a browser.

This PR implements that format for Hugo's docs, which annoyingly, don't already do this!

**Before:**

![screen shot 2017-12-14 at 5 05 07 pm](https://user-images.githubusercontent.com/2343007/34016834-5cbc6a7a-e0f1-11e7-8476-e0a17c016277.png)

**After:**

![screen shot 2017-12-14 at 5 05 46 pm](https://user-images.githubusercontent.com/2343007/34016843-62d8b5da-e0f1-11e7-86b7-dc4c37f0a8bc.png)
