### PR TITLE
fix typo of Blackfriday's Markdown extension name

### DIFF
--- a/content/readfiles/bfconfig.md
+++ b/content/readfiles/bfconfig.md
@@ -52,7 +52,7 @@
 `extensions`
 : default: **`[]`** <br>
     Purpose: Enable one or more Blackfriday's Markdown extensions (**`EXTENSION_*`**). <br>
-    Example: Include `hardLineBreak` in the list to enable Blackfriday's `EXTENSION_HARD_LINK_BREAK`. <br>
+    Example: Include `hardLineBreak` in the list to enable Blackfriday's `EXTENSION_HARD_LINE_BREAK`. <br>
     *See [Blackfriday extensions](#blackfriday-extensions) section for information on all extensions.*
 
 `extensionsmask`


### PR DESCRIPTION
The correct extension name is `EXTENSION_HARD_LINE_BREAK`.
https://github.com/russross/blackfriday/blob/6d1ef893fcb01b4f50cb6e57ed7df3e2e627b6b2/markdown.go#L37
