### PR TITLE
configuration: Remove defaultExtension from docs

### DIFF
--- a/content/getting-started/configuration.md
+++ b/content/getting-started/configuration.md
@@ -73,7 +73,6 @@ canonifyURLs:               false
 config:                     "config.toml"
 contentDir:                 "content"
 dataDir:                    "data"
-defaultExtension:           "html"
 defaultLayout:              "post"
 # Missing translations will default to this content language
 defaultContentLanguage:     "en"
@@ -216,7 +215,6 @@ canonifyURLs =                false
 config =                     "config.toml"
 contentDir =                  "content"
 dataDir =                     "data"
-defaultExtension =            "html"
 defaultLayout =               "post"
 # Missing translations will default to this content language
 defaultContentLanguage =      "en"


### PR DESCRIPTION
As far as I tested, defaultExtension in config has no effect with v0.31.1.
It might be deprecated in ee75e29.
It is misleading to leave the descriptions about defaultExtensions in docs.
Removed them.

@bep 
Thanks for your navigation
(This PR is moved from https://github.com/gohugoio/hugo/pull/4195)