### PR TITLE
Add alias to multilingual.md

### DIFF
--- a/content/content-management/multilingual.md
+++ b/content/content-management/multilingual.md
@@ -13,7 +13,7 @@ menu:
     weight: 150
 weight: 150	#rem
 draft: false
-aliases: [/content/multilingual/,/content-management/multilingual/]
+aliases: [/content/multilingual/,/content-management/multilingual/,/tutorials/create-a-multilingual-site/]
 toc: true
 ---
 


### PR DESCRIPTION
fixes gohugoio/hugo#4112

Additional alias in multilingual.md resolves a 404 error resulting in a link in the multilingual readme.md in the repo, https://github.com/gohugoio/hugo/blob/master/examples/multilingual/README.md