### PR TITLE
Adding new Blogger utility to tools/migrations

### DIFF
--- a/content/tools/migrations.md
+++ b/content/tools/migrations.md
@@ -65,6 +65,7 @@ Alternatively, you can use the new [Jekyll import command](/commands/hugo_import
 ## Blogger
 
 - [blogimport](https://github.com/natefinch/blogimport) - A tool to import from Blogger posts to Hugo.
+- [blogger-to-hugo](https://bitbucket.org/petraszd/blogger-to-hugo) - Another tool to import Blogger posts to Hugo. It also downloads embedded images so they will be stored locally.
 
 ## Contentful
 


### PR DESCRIPTION
I needed to migration Blogger's blog to hugo. I've tried to use existing tool, but it didn't work. Which is no surprise since it was not updated for 4 years. So, I needed to create utility myself.

https://bitbucket.org/petraszd/blogger-to-hugo

The main problem: I am not a Go programmer. So, that utility is written with Python. Anyway, it may be helpful to others. So, I would like to those others to know that such tool exists. 