### PR TITLE
Replace the outdated Emacs package with new one

### DIFF
--- a/content/tools/editors.md
+++ b/content/tools/editors.md
@@ -30,7 +30,7 @@ The Hugo community uses a wide range of preferred tools and has developed plug-i
 
 ## Emacs
 
-* [hugo.el](https://github.com/yewton/hugo.el). Some helper functions for creating a Website with Hugo. Note that Hugo also supports [Org-mode][formats].
+* [emacs-easy-hugo](https://github.com/masasam/emacs-easy-hugo). Emacs major mode for managing hugo blogs. Note that Hugo also supports [Org-mode][formats].
 * [ox-hugo.el](https://ox-hugo.scripter.co). Native Org-mode exporter that exports to Blackfriday Markdown with Hugo front-matter. `ox-hugo` supports two common Org blogging flows --- exporting multiple Org sub-trees in a single file to multiple Hugo posts, and exporting a single Org file to a single Hugo post. It also leverages the Org tag and property inheritance features. See [*Why ox-hugo?*](https://ox-hugo.scripter.co/doc/why-ox-hugo/) for more.
 
 ## Vim


### PR DESCRIPTION
I have not maintained https://github.com/yewton/hugo.el actively 😓 
And now there is more [modern and convenient package](https://github.com/masasam/emacs-easy-hugo) for Hugo.