### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /public
 nohup.out
+.DS_Store


### PR DESCRIPTION
When adding the showcase item on my OSX machine, it was cumbersome to prevent `.DS_Store` being added to the repo. This change tells Git to ignore these system files making it easier to edit the docs on a Mac.