### PR TITLE
Clarify Netlify's Hugo versions handling

### DIFF
--- a/content/hosting-and-deployment/hosting-on-netlify.md
+++ b/content/hosting-and-deployment/hosting-on-netlify.md
@@ -61,7 +61,7 @@ Once selected, you'll be brought to a screen for basic setup. Here you can selec
 
 ### Build with a Specific Hugo Version
 
-Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify. See [this blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/) for more details.
+Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify.
 
 If you want to tell Netlify to build with a specific version (hugo <= 0.20), you can append an underscore followed by the version number to the build command:
 
@@ -102,6 +102,8 @@ Once the build is finished---this should only take a few seconds--you should now
 [Visit the live site][visit].
 
 Now every time you push changes to your hosted git repository, Netlify will rebuild and redeploy your site.
+
+See [this blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/) for more details on how Netlify handles Hugo versions.
 
 ## Use Hugo Themes with Netlify
 

--- a/content/hosting-and-deployment/hosting-on-netlify.md
+++ b/content/hosting-and-deployment/hosting-on-netlify.md
@@ -61,7 +61,7 @@ Once selected, you'll be brought to a screen for basic setup. Here you can selec
 
 ### Build with a Specific Hugo Version
 
-Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify.
+Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify. See [this blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/) for more details.
 
 If you want to tell Netlify to build with a specific version (hugo <= 0.20), you can append an underscore followed by the version number to the build command:
 

--- a/content/hosting-and-deployment/hosting-on-netlify.md
+++ b/content/hosting-and-deployment/hosting-on-netlify.md
@@ -103,7 +103,7 @@ Once the build is finished---this should only take a few seconds--you should now
 
 Now every time you push changes to your hosted git repository, Netlify will rebuild and redeploy your site.
 
-See [this blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/) for more details on how Netlify handles Hugo versions.
+See [this blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/) for more details about how Netlify handles Hugo versions.
 
 ## Use Hugo Themes with Netlify
 

--- a/content/hosting-and-deployment/hosting-on-netlify.md
+++ b/content/hosting-and-deployment/hosting-on-netlify.md
@@ -61,7 +61,7 @@ Once selected, you'll be brought to a screen for basic setup. Here you can selec
 
 ### Build with a Specific Hugo Version
 
-Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify. You can see the full list of [available Hugo versions in Netlify's Docker file][hugoversions].
+Setting the build command to `hugo` will build your site according to the current default Hugo version used by Netlify.
 
 If you want to tell Netlify to build with a specific version (hugo <= 0.20), you can append an underscore followed by the version number to the build command:
 


### PR DESCRIPTION
Hugo version can be forced even to the last release via Netlify console or `netlify.toml`, so "You can see the full list of available Hugo versions in Netlify’s Docker file" doesn't provide any relevant information, it even makes the user think he's bound to Netlify's Docker available Hugo versions.