### PR TITLE
WIP- Make "Last Updated" table searchable

### DIFF
--- a/layouts/maintenance/list.html
+++ b/layouts/maintenance/list.html
@@ -1,4 +1,14 @@
 {{ define "main" }}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.min.css">
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+<script type="text/javascript">
+ $(document).ready(function() {
+     $('#recent').DataTable( {
+         "order": [[ 0, 'desc' ]]
+     } );
+ } );
+</script>
 <div class="w-100 ph4 pb5 pb6-ns pt1 mt4 pt3-ns">
     <div class="flex-l">
         <div class="order-2 w-100 w-20-l ph5-m ph0-l mb4 sticky">
@@ -7,29 +17,28 @@
                 <ul>
                     <li><a href="#last-updated">Last Updated</a></li>
                     <li><a href="#least-recently-updated">Least Recently Updated</a></li>
-                     <li><a href="#todos">Pages marked with TODO</a></li>
+                    <li><a href="#todos">Pages marked with TODO</a></li>
                 </ul>
             </aside>
         </div>
         <div class="w-100">
             {{ $byLastMod :=  .Site.RegularPages.ByLastmod  }}
-            {{ $recent := ($byLastMod | last 10).Reverse }}
-            {{ $leastRecent := $byLastMod | first 10 }}            
+            {{ $recent := ($byLastMod | last 500).Reverse }}
+            {{ $leastRecent := $byLastMod | first 10 }}
             <h2 id="last-updated">Last Updated</h2>
-            {{ partial "maintenance-pages-table" $recent }}
+            {{ partial "maintenance-pages-table" (dict "id" "recent" "pages" $recent) }}
             <h2 id="least-recently-updated">Least Recently Updated</h2>
-            {{ partial "maintenance-pages-table" $leastRecent }}
+            {{ partial "maintenance-pages-table" (dict "id" "least-recent" "pages" $leastRecent) }}
 
             {{/* Don't think this is possible with where directly. Should investigate. */}}
             {{ .Scratch.Set "todos" slice }}
             {{ range .Site.RegularPages }}
-                 {{ if .HasShortcode "todo" }}
-                 {{ $.Scratch.Add "todos" . }}
-                 {{ end }}
+                {{ if .HasShortcode "todo" }}
+                    {{ $.Scratch.Add "todos" . }}
+                {{ end }}
             {{ end }}
             <h2 id="todos">Pages marked with TODO</h2>
-            {{ partial "maintenance-pages-table" (.Scratch.Get "todos") }}
-
+            {{ partial "maintenance-pages-table" (dict "id" "todos" "pages" (.Scratch.Get "todos")) }}
         </div>
     </div>
 </div>

--- a/layouts/partials/maintenance-pages-table.html
+++ b/layouts/partials/maintenance-pages-table.html
@@ -1,24 +1,24 @@
-<table class="collapse ba br2 b--black-10 pv2 ph3">
-	<thead>
-		<tr>
-			<th class="pv2 ph3 tl f6 fw6 ttu">LastMod</th>
-			<th class="pv2 ph3 tl f6 fw6 ttu">Link</th>
-			<th class="pv2 ph3 tl f6 fw6 ttu">GitHub</th>
-		</tr>
-	</thead>
-	<tbody>
-		{{ range  . }}
-		<tr class="striped--light-gray">
-			<td class="pv2 ph3">{{ .Lastmod.Format "2006-01-02" }}</td>
-			<td class="pv2 ph3">
-				<a href="{{ .Permalink }}">{{ .Title }}</a>
-			</td>
-			<td class="pv2 ph3">
-				<a href="{{.Site.Params.ghrepo}}blob/master/content/{{.Path}}">
-					{{ with .GitInfo }}{{ .Subject }}{{ else }}Source{{ end }}
-				</a>
-			</td>
-		</tr>
-		{{ end }}
-	</tbody>
+<table id="{{ .id }}" class="collapse ba br2 b--black-10 pv2 ph3">
+    <thead>
+	<tr>
+	    <th class="pv2 ph3 tl f6 fw6 ttu">LastMod</th>
+	    <th class="pv2 ph3 tl f6 fw6 ttu">Link</th>
+            <th class="pv2 ph3 tl f6 fw6 ttu">GitHub</th>
+	</tr>
+    </thead>
+    <tbody>
+	{{ range .pages }}
+	    <tr class="striped--light-gray">
+		<td class="pv2 ph3">{{ .Lastmod.Format "2006-01-02" }}</td>
+		<td class="pv2 ph3">
+		    <a href="{{ .Permalink }}">{{ .Title }}</a>
+		</td>
+		<td class="pv2 ph3">
+		    <a href="{{.Site.Params.ghrepo}}blob/master/content/{{.Path}}">
+			{{ with .GitInfo }}{{ .Subject }}{{ else }}Source{{ end }}
+		    </a>
+		</td>
+	    </tr>
+	{{ end }}
+    </tbody>
 </table>

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]
-command = "hugo -b $DEPLOY_PRIME_URL"
+command = "hugo -b $DEPLOY_PRIME_URL --enableGitInfo"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.36"


### PR DESCRIPTION
[**PREVIEW**][1]

---

- The maintenance-pages-table partial now takes a dict argument with keys "id"
  and "pages".
  - "id" is the unique table id to be assigned to each maintenance page table.
  - "pages" is the list of pages (which was the original one and only context
     passed to this partial).
- Increase "Last Updated" table entries from 10 to 500.
- Use https://datatables.net/ table filtering/searching/ordering script to
  manage that huge "Last Updated" table.

---

**Need help**

How do I not make that table fit the whole page? Once that is fixed, I believe this PR would be ready for merging.. WDYT @bep?

I know that this happens because of:

```html
<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.min.css">
```

But I cannot also completely remove that, else the formatting of paging links at the bottom of the table get messed up. 

[1]: https://deploy-preview-352--gohugoio.netlify.com/maintenance/