### PR TITLE
Update hosting-on-gitlab.md

### DIFF
--- a/content/hosting-and-deployment/hosting-on-gitlab.md
+++ b/content/hosting-and-deployment/hosting-on-gitlab.md
@@ -22,6 +22,8 @@ aliases: [/tutorials/hosting-on-gitlab/]
 
 [GitLab](https://gitlab.com/) makes it incredibly easy to build, deploy, and host your Hugo website via their free GitLab Pages service, which provides [native support for Hugo, as well as numerous other static site generators](https://gitlab.com/pages/hugo).
 
+N.B. You need to exercise caution when deploying your Hugo website with a custom domain to Gitlab Pages. Sometimes Gitlab introduces changes that can cause site outage with no prior user notification.
+
 ## Assumptions
 
 * Working familiarity with Git for version control


### PR DESCRIPTION
I am sending this proposal because Hugo users need to be warned in advance about the implications of hosting their Hugo site with a custom domain on Gitlab Pages.

See the current Gitlab Pages custom domains notification: https://about.gitlab.com/2018/02/05/gitlab-pages-custom-domain-validation/

And the past IP change that broke custom domains on Gitlab Pages last May: https://gitlab.com/gitlab-com/marketing/issues/883

Gitlab Pages is a free service  but not the only one and others tend to warn people via email about breaking changes unlike Gitlab. So there is no excuse.