### PR TITLE
Fix URL typo

### DIFF
--- a/content/content-management/urls.md
+++ b/content/content-management/urls.md
@@ -118,7 +118,7 @@ aliases:
 ---
 {{< /code >}}
 
-Now when you visit any of the locations specified in aliases---i.e., *assuming the same site domain*---you'll be redirected to the page they are specified on. For example, a visitor to `example.com/posts/my-original-url/` will be immediately redirected to `example.com/posts/my-awesome-blog-post/`.
+Now when you visit any of the locations specified in aliases---i.e., *assuming the same site domain*---you'll be redirected to the page they are specified on. For example, a visitor to `example.com/posts/my-original-url/` will be immediately redirected to `example.com/posts/my-awesome-post/`.
 
 ### Example: Aliases in Multilingual
 


### PR DESCRIPTION
Remove extra word in URL, as pointed out in [the forums](https://discourse.gohugo.io/t/typo-in-docs/10558?u=maiki).