### PR TITLE
Update rss.md

### DIFF
--- a/content/templates/rss.md
+++ b/content/templates/rss.md
@@ -119,7 +119,6 @@ In your `header.html` template, you can specify your RSS feed in your `<head></h
 ```
 {{ if .RSSLink }}
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}
 ```
 


### PR DESCRIPTION
`rel="feed"` is not validated by w3c:
> Bad value `feed` for attribute `rel` on element `link`: The string `feed` is not a registered keyword.

https://validator.w3.org/