### PR TITLE
LastMod should be Lastmod?

### DIFF
--- a/content/functions/format.md
+++ b/content/functions/format.md
@@ -1,6 +1,6 @@
 ---
 title: .Format
-description: Formats built-in Hugo dates---`.Date`, `.PublishDate`, and `.LastMod`---according to Go's layout string.
+description: Formats built-in Hugo dates---`.Date`, `.PublishDate`, and `.Lastmod`---according to Go's layout string.
 godocref: https://golang.org/pkg/time/#example_Time_Format
 date: 2017-02-01
 publishdate: 2017-02-01
@@ -23,7 +23,7 @@ toc: true
 
 * `.PublishDate`
 * `.Date`
-* `.LastMod`
+* `.Lastmod`
 
 Assuming a key-value of `date: 2017-03-03` in a content file's front matter, your can run the date through `.Format` followed by a layout string for your desired output at build time:
 


### PR DESCRIPTION
Trying to use LastMod gives errors, however Lastmod works.  So, I'd guess the documentation should be updated. Or it should be LastMod and hugo needs fixed :) 

```
 Failed to add template "post/single.html" in path "layouts/post/single.html": template: layouts/post/single.html:18: function "LastMod" not defined
```