### PR TITLE
Updated the directory path for creating section list.html

### DIFF
--- a/content/templates/lists.md
+++ b/content/templates/lists.md
@@ -45,7 +45,7 @@ Since section lists and taxonomy lists (N.B., *not* [taxonomy terms lists][taxte
 
 #### Default Section Templates
 
-1. `layouts/_default/section.html`
+1. `layouts/_default/section/list.html`
 2. `layouts/_default/list.html`
 
 #### Default Taxonomy List Templates


### PR DESCRIPTION
After scratching my head for a couple of minutes and trying to figure out why my custom section list.html was not overriding the default one, I decided to try and follow the convention for single.html and it works. This should help others save that time.