### PR TITLE
add THEME location for lookup order under Main RSS

### DIFF
--- a/content/templates/rss.md
+++ b/content/templates/rss.md
@@ -40,7 +40,9 @@ Hugo provides the ability for you to define any RSS type you wish and can have d
 
 1. `/layouts/rss.xml`
 2. `/layouts/_default/rss.xml`
-3.  Embedded rss.xml
+3. `/themes/<THEME>/layouts/rss.xml`
+4. `/themes/<THEME>/layouts/_default/rss.xml`
+5. Embedded rss.xml
 
 ### Section RSS
 


### PR DESCRIPTION
I'm doing all my templates in my theme, `/<THEME>/layout/rss.xml`, seems to work fine, so I'm guessing that the documentation for the lookup order for the main RSS template can be updated to include <THEME>.

Please tell me if I'm wrong!