### PR TITLE
Remove 'fundamentals' category from function pages

### DIFF
--- a/content/functions/range.md
+++ b/content/functions/range.md
@@ -6,7 +6,7 @@ godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-02-01
-categories: [functions,fundamentals]
+categories: [functions]
 menu:
   docs:
     parent: "functions"

--- a/content/functions/title.md
+++ b/content/functions/title.md
@@ -6,7 +6,7 @@ godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-02-01
-categories: [functions,fundamentals]
+categories: [functions]
 menu:
   docs:
     parent: "functions"

--- a/content/functions/with.md
+++ b/content/functions/with.md
@@ -6,7 +6,7 @@ godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-03-12
-categories: [functions,fundamentals]
+categories: [functions]
 menu:
   docs:
     parent: "functions"


### PR DESCRIPTION
Fixes https://github.com/gohugoio/hugoDocs/issues/406