### PR TITLE
Change theme folder name to 'gohugo-theme-ananke' in getting started

### DIFF
--- a/content/getting-started/quick-start.md
+++ b/content/getting-started/quick-start.md
@@ -64,11 +64,11 @@ See [themes.gohugo.io](https://themes.gohugo.io/) for a list of themes to consid
 ```bash
 cd quickstart;\
 git init;\
-git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke;\
+git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/gohugo-theme-ananke;\
 
 # Edit your config.toml configuration file
 # and add the Ananke theme.
-echo 'theme = "ananke"' >> config.toml
+echo 'theme = "gohugo-theme-ananke"' >> config.toml
 ```
 
 


### PR DESCRIPTION
After going through the quick start, the site wouldn't load for me on localhost. Changing the folder name in the themes folder from `ananke` to `gohugo-theme-ananke` did the trick, as it seems the suggested theme has some hardcoded references to using that name (e.g. in `site-scripts.html` https://github.com/budparr/gohugo-theme-ananke/blob/master/layouts/partials/site-scripts.html)