### PR TITLE
Clarification of cond function

### DIFF
--- a/content/functions/cond.md
+++ b/content/functions/cond.md
@@ -24,3 +24,11 @@ Example:
 ```
 
 Would emit "goose" if the `$geese` array has exactly 1 item, or "geese" otherwise.
+
+{{% warning %}}
+Whenever you use a `cond` function, *both* variable expressions are *always* evaluated. This means that a usage like `cond false (div 1 0) 27` will throw an error because `div 1 0` will be evaluated *even though the condition is false*.
+
+In other words, the `cond` function does *not* provide [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) and does *not* work like a normal [ternary operator](https://en.wikipedia.org/wiki/%3F:) that will pass over the first expression if the condition returns `false`.
+
+You should use `cond` if and only if both variable expressions return values. If either returns `nil`, `cond` is to be avoided.
+{{% /warning %}}


### PR DESCRIPTION
Fixes #442 

The `cond` function does *not* work as many users will expect. This PR adds a warning on the limitations of `cond`.