### PR TITLE
Added documentation for a new migration tool: BlogMl2Hugo

### DIFF
--- a/content/tools/migrations.md
+++ b/content/tools/migrations.md
@@ -70,3 +70,8 @@ Alternatively, you can use the new [Jekyll import command](/commands/hugo_import
 ## Contentful
 
 - [contentful2hugo](https://github.com/ArnoNuyts/contentful2hugo) - A tool to create content-files for Hugo from content on [Contentful](https://www.contentful.com/).
+
+
+## BlogML
+
+- [BlogML2Hugo](https://github.com/jijiechen/BlogML2Hugo) - A tool that helps you convert BlogML xml file to Hugo markdown files. Users need to take care of links to attachments and images by themselves. This helps the blogs that export BlogML files (e.g. BlogEngine.NET) tramsform to hugo sites easily.


### PR DESCRIPTION
This tool helps authors convert their exported BlogML xml files to Hugo friendly markdown files. 
Many blog engines can generate BlogML files, e.g. [BlogEngine.NET](https://github.com/rxtur/BlogEngine.NET).