### PR TITLE
Add Talkayrd, a new commenting system, and fix txtpen link

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -48,7 +48,8 @@ See [Partial Templates][partials] to learn how to add the Disqus partial to your
 There are a few alternatives to commenting on static sites for those who do not want to use Disqus:
 
 * [Static Man](https://staticman.net/)
-* [txtpen](https://txtpen.com)
+* [Talkyard](https://www.talkyard.io/blog-comments) (Open source, & serverless hosting)
+* [txtpen](https://txtpen.github.io/hn/)
 * [IntenseDebate](http://intensedebate.com/)
 * [Graph Comment][]
 * [Muut](http://muut.com/)


### PR DESCRIPTION
Talkayrd is open source, like Isso, and with installation instructions especially for Hugo.

Also fix the link for `txtpen` — the `https://txtpen.com` website is offline, since many months back (at least since February), but `https://txtpen.github.io/hn/` works.