### PR TITLE
Arch Linux: Partial upgrades are unsupported

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -451,7 +451,7 @@ Hugo-as-a-snap can write only inside the user’s `$HOME` directory---and gvfs-m
 You can also install Hugo from the Arch Linux [community](https://www.archlinux.org/packages/community/x86_64/hugo/) repository. Applies also for derivatives such as Manjaro.
 
 ```
-sudo pacman -Sy hugo
+sudo pacman -Syu hugo
 ```
 
 ### Fedora


### PR DESCRIPTION
Using `pacman -Sy` is considered [bad practice](https://wiki.archlinux.org/index.php/System_maintenance#Upgrading_the_system) and should not be recommended here.