### PR TITLE
Remove language assuming knowledge of GitHub OAuth

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-netlify.md
+++ b/content/en/hosting-and-deployment/hosting-on-netlify.md
@@ -35,7 +35,7 @@ The following examples use GitHub, but other git providers will follow a similar
 
 ![Screenshot of the homepage for app.netlify.com, containing links to the most popular hosted git solutions.](/images/hosting-and-deployment/hosting-on-netlify/netlify-signup.jpg)
 
-Selecting GitHub will bring up a typical modal you've seen through other application that use GitHub for authentication. Select "Authorize application."
+Selecting GitHub will bring up an authorization modal for authentication. Select "Authorize application."
 
 ![Screenshot of the authorization popup for Netlify and GitHub.](/images/hosting-and-deployment/hosting-on-netlify/netlify-first-authorize.jpg)
 


### PR DESCRIPTION
The old wording made it sound like everyone has seen this modal before. Beginners may be discouraged if this is the first time they've come across the GitHub authorization modal. My thoughts are this is similar to what is described here: https://css-tricks.com/words-avoid-educational-writing/#article-header-id-6