### PR TITLE
Add warning about privacy options only work with internal templates

### DIFF
--- a/content/en/about/hugo-and-gdpr.md
+++ b/content/en/about/hugo-and-gdpr.md
@@ -28,7 +28,7 @@ toc: true
  Note that:
 
  * These settings have their defaults setting set to _off_, i.e. how it worked before Hugo `0.41`. You must do your own evaluation of your site and apply the appropriate settings.
-  * These settings work with the [internal templates](/templates/internal/). Some theme may contain custom templates for embedding services like Google Analytics. In that case these options have no effect.
+ * These settings work with the [internal templates](/templates/internal/). Some theme may contain custom templates for embedding services like Google Analytics. In that case these options have no effect.
  * We will continue this work and improve this further in future Hugo versions.
 
 ## All Privacy Settings

--- a/content/en/about/hugo-and-gdpr.md
+++ b/content/en/about/hugo-and-gdpr.md
@@ -28,6 +28,7 @@ toc: true
  Note that:
 
  * These settings have their defaults setting set to _off_, i.e. how it worked before Hugo `0.41`. You must do your own evaluation of your site and apply the appropriate settings.
+  * These settings work with the [internal templates](https://gohugo.io/templates/internal/). Some theme may contain custom templates for embedding services like Google Analytics. In that case these options have no effect.
  * We will continue this work and improve this further in future Hugo versions.
 
 ## All Privacy Settings

--- a/content/en/about/hugo-and-gdpr.md
+++ b/content/en/about/hugo-and-gdpr.md
@@ -28,7 +28,7 @@ toc: true
  Note that:
 
  * These settings have their defaults setting set to _off_, i.e. how it worked before Hugo `0.41`. You must do your own evaluation of your site and apply the appropriate settings.
-  * These settings work with the [internal templates](https://gohugo.io/templates/internal/). Some theme may contain custom templates for embedding services like Google Analytics. In that case these options have no effect.
+  * These settings work with the [internal templates](/templates/internal/). Some theme may contain custom templates for embedding services like Google Analytics. In that case these options have no effect.
  * We will continue this work and improve this further in future Hugo versions.
 
 ## All Privacy Settings


### PR DESCRIPTION
Based on [this discussion](https://discourse.gohugo.io/t/how-privacy-options-work/12925) I'd like to add a warning to the documentation of the privacy options about these options work only with the internal templates.

I used a theme with custom Google Analytics template for instance and the privacy options had no effect until I modified the theme.