### PR TITLE
Add notes for installing "extended" Sass/SCSS version

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -34,7 +34,7 @@ Hugo currently provides pre-built binaries for the following:
 * OpenBSD
 * FreeBSD
 
-Hugo may also be compiled from source wherever the Go compiler tool chain can run; e.g., on other operating systems such as DragonFly BSD, OpenBSD, Plan&nbsp;9, Solaris, and others. See <https://golang.org/doc/install/source> for the full set of supported combinations of target operating systems and compilation architectures.
+Hugo may also be compiled from source wherever the Go toolchain can run; e.g., on other operating systems such as DragonFly BSD, OpenBSD, Plan&nbsp;9, Solaris, and others. See <https://golang.org/doc/install/source> for the full set of supported combinations of target operating systems and compilation architectures.
 
 ## Quick Install
 
@@ -82,8 +82,10 @@ go get github.com/magefile/mage
 go get -d github.com/gohugoio/hugo
 cd ${GOPATH:-$HOME/go}/src/github.com/gohugoio/hugo
 mage vendor
-mage install
+HUGO_BUILD_TAGS=extended mage install
 {{< /code >}}
+
+Remove `HUGO_BUILD_TAGS=extended` if you do not want Sass/SCSS support.
 
 {{% note %}}
 If you are a Windows user, substitute the `$HOME` environment variable above with `%USERPROFILE%`.
@@ -420,50 +422,43 @@ Directory of C:\hugo\sites\example.com
 
 ### Snap Package
 
-In any of the [Linux distributions that support snaps][snaps]:
+In any of the [Linux distributions that support snaps][snaps], you may install install the "extended" Sass/SCSS version with this command:
 
-```
-snap install hugo
-```
+    snap install hugo --channel=extended
 
-### Debian and Ubuntu
+To install the non-extended version without Sass/SCSS support:
 
-Debian and Ubuntu provide a `hugo` version via `apt-get`:
+    snap install hugo
 
-```
-sudo apt-get install hugo
-```
-
-#### Pros
-
-* Native Debian/Ubuntu package maintained by Debian Developers
-* Pre-installed bash completion script and `man` pages
-
-#### Cons
-
-* Might not be the latest version, especially if you are using an older, stable version (e.g., Ubuntu 16.04 LTS). Until backports and PPA are available, you may consider installing the Hugo snap package to get the latest version of Hugo.
+To switch between the two, use either `snap refresh hugo --channel=extended` or `snap refresh hugo --channel=stable`.
 
 {{% note %}}
 Hugo-as-a-snap can write only inside the user’s `$HOME` directory---and gvfs-mounted directories owned by the user---because of Snaps’ confinement and security model. More information is also available [in this related GitHub issue](https://github.com/gohugoio/hugo/issues/3143). Use ```sudo snap install hugo --classic``` to disable the default security model if you want hugo to be able to have write access in other paths besides the user’s `$HOME` directory.
 {{% /note %}}
 
+### Debian and Ubuntu
+
+[@anthonyfok](https://github.com/anthonyfok) and friends in the [Debian Go Packaging Team](https://go-team.pages.debian.net/) maintains an official hugo [Debian package](https://packages.debian.org/hugo) which is shared with [Ubuntu](https://packages.ubuntu.com/hugo) and is installable via `apt-get`:
+
+    sudo apt-get install hugo
+
+This installs the "extended" Sass/SCSS version.
+
 ### Arch Linux
 
-You can also install Hugo from the Arch Linux [community](https://www.archlinux.org/packages/community/x86_64/hugo/) repository. Applies also for derivatives such as Manjaro.
+You can also install Hugo from the Arch Linux [community](https://www.archlinux.org/packages/community/x86_64/hugo/) repository. Applies also to derivatives such as Manjaro.
 
 ```
 sudo pacman -Syu hugo
 ```
 
-### Fedora
+### Fedora, Red Hat and CentOS
 
-Fedora provides a package for Hugo. The installation is done with the command :
+Fedora maintains an [official package for Hugo](https://apps.fedoraproject.org/packages/hugo) which may be installed with:
 
-```
-sudo dnf install hugo
-```
+    sudo dnf install hugo
 
-### CentOS, and Red Hat
+For the latest version, the Hugo package maintained by [@daftaupe](https://github.com/daftaupe) at Fedora Copr is recommended:
 
 * <https://copr.fedorainfracloud.org/coprs/daftaupe/hugo/>
 
@@ -471,11 +466,10 @@ See the [related discussion in the Hugo forums][redhatforum].
 
 ## OpenBSD
 
-OpenBSD provides a package for Hugo via `pkg_add`: 
+OpenBSD provides a package for Hugo via `pkg_add`:
 
-```
-doas pkg_add hugo
-```
+    doas pkg_add hugo
+
 
 ## Upgrade Hugo
 


### PR DESCRIPTION
This PR adds instruction for installing "extended" Sass/SCSS version, especially the new "extended" track of Hugo Snap, and made some other revisions along the way.

It is not comprehensive, e.g. the Homebrew version is now built with "extended" but I haven't edited those instructions yet.  I was also thinking of splitting installing.md into two separate pages "installing pre-built binary" and "building from source".  Too much work, maybe next time.  ;-)

@bep, my apologies for not having a discussion with you since we last discussed this two weeks ago at gohugoio/hugo#4908.  The Snap gurus at https://forum.snapcraft.io/t/request-for-new-extended-track-for-hugo-snap/6297 has decided that the use of snap "track" is the best way to go after reading our prior discussions, and have set up one for us after a one-week voting period, and I have been testing it for a few days and everything is working flawlessly.

But yes, I thought I'd better let you know what is going on before publicizing `snap install hugo --channel=extended`, hence this PR.  :-)

For your information, these are being built from Launchpad again automatically:

* https://launchpad.net/~gohugoio/+snap/hugo-extended
    * built from "extended-snap-stable" branch
    * uploads to "extended/stable" channel
* https://launchpad.net/~gohugoio/+snap/hugo-extended-dev
    * built from "extended-snap-master" branch
    * uploads to "extended/edge" channel

```
$ snap info hugo
name:    hugo
summary: A Fast and Flexible Static Site Generator built with love by bep, spf13 and friends
  in Go.
publisher: hugo-authors
contact:   https://discourse.gohugo.io/
license:   unknown
description: |
  Hugo is a static HTML and CSS website generator written in Go. It is
  optimized for speed, easy use and configurability. Hugo takes a directory
  with content and templates and renders them into a full HTML website.
commands:
  - hugo
snap-id:      t6YzDBM3com27avINGL5OD6ZKKG654ez
tracking:     extended/stable
refresh-date: today at 10:17 MDT
channels:                                  
  stable:             0.45     (2338) 33MB -
  candidate:          ↑                    
  beta:               ↑                    
  edge:               0.46-DEV (2335) 33MB -
  extended/stable:    0.45     (2350) 33MB -
  extended/candidate: ↑                    
  extended/beta:      ↑                    
  extended/edge:      0.46-DEV (2351) 33MB -
installed:            0.45     (2350) 33MB -
```

(The "license: unknown" line is a glitch with the snap CLI.  The Snap Store web interface correctly shows Apache-2.0 for our license.)

I currently run `git rebase` for these extended-snap-* branches until I start to learn how to do it automatically via git hooks.

Many thanks for reviewing, and thank you for Hugo 0.45!