### PR TITLE
Remove unused metaDataFormat setting

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -138,9 +138,6 @@ logFile ("")
 menu
 : See [Add Non-content Entries to a Menu](/content-management/menus/#add-non-content-entries-to-a-menu).
 
-metaDataFormat ("toml")
-: Front matter meta-data format. Valid values: `"toml"`, `"yaml"`, or `"json"`.
-
 newContentEditor ("")
 : The editor to use when creating new content.
 


### PR DESCRIPTION
I believe we stopped using the metadata format in config value and it now pulls from archetype files:

In https://github.com/gohugoio/hugo/issues/3706
On July 16, 2017, @bep said
"In short, you will now get the metadata format of your archetype files. See #3632 -- but we should do something with this metaDataFormat config value we're not using anymore. Not sure what."