### PR TITLE
Add `assetDir` key to config list

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -44,6 +44,9 @@ config file(s).
 archetypeDir ("archetypes")
 : The directory where Hugo finds archetype files (content templates).
 
+assetDir ("assets")
+: The directory where Hugo finds asset files used in [Hugo Pipes](/hugo-pipes/).
+
 baseURL
 : Hostname (and path) to the root, e.g. http://bep.is/
 


### PR DESCRIPTION
# References
- `assetDir` Added in this commit: https://github.com/gohugoio/hugo/commit/dea71670c059ab4d5a42bd22503f18c087dd22d4
- Hugo Pipes documentation referencing the Asset Directory key: https://gohugo.io/hugo-pipes/introduction/#asset-directory