### PR TITLE
Added exitwp-for-hugo

### DIFF
--- a/content/en/tools/migrations.md
+++ b/content/en/tools/migrations.md
@@ -47,6 +47,7 @@ Alternatively, you can use the new [Jekyll import command](/commands/hugo_import
 ## WordPress
 
 - [wordpress-to-hugo-exporter](https://github.com/SchumacherFM/wordpress-to-hugo-exporter) - A one-click WordPress plugin that converts all posts, pages, taxonomies, metadata, and settings to Markdown and YAML which can be dropped into Hugo. (Note: If you have trouble using this plugin, you can [export your site for Jekyll](https://wordpress.org/plugins/jekyll-exporter/) and use Hugo's built in Jekyll converter listed above.)
+- [exitwp-for-hugo](https://github.com/wooni005/exitwp-for-hugo) - A python script which works with the xml export from Wordpress and converts Wordpress pages and posts to Markdown and YAML for hugo.
 - [blog2md](https://github.com/palaniraja/blog2md) - Works with [exported xml](https://en.support.wordpress.com/export/) file of your free YOUR-TLD.wordpress.com website. It also saves approved comments to `YOUR-POST-NAME-comments.md` file along with posts.
 
 ## Tumblr


### PR DESCRIPTION
I found this python script a much more successful way of moving from Wordpress to Hugo than the 'wordpress to hugo exporter' plugin.