### PR TITLE
Tweak 'name: weight' to 'name: date' in example

### DIFF
--- a/content/en/content-management/related.md
+++ b/content/en/content-management/related.md
@@ -80,7 +80,7 @@ related:
   indices:
   - name: keywords
     weight: 100
-  - name: weight
+  - name: date
     weight: 10
 ```
 


### PR DESCRIPTION
Per https://github.com/gohugoio/hugoDocs/commit/19e900a17e75cc6c8202d22dafeb4257ee9d6303 I've fixed the demo yaml for the default indices to include `name: date` rather than `name: weight`. Thanks!