### PR TITLE
Make sure `disableKinds` example is wrapped in `taxonomies` section

### DIFF
--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -97,7 +97,8 @@ Without adding a single line to your [site config][config] file, Hugo will autom
 If you do not want Hugo to create any taxonomies, set `disableKinds` in your [site config][config] to the following:
 
 {{< code-toggle copy="false" >}}
-disableKinds = ["taxonomy","taxonomyTerm"]
+[taxonomies]
+  disableKinds = ["taxonomy","taxonomyTerm"]
 {{</ code-toggle >}}
 
 ### Default Destinations


### PR DESCRIPTION
The doc page has an example on how to disable default taxonomies using `disableKinds`, but it seems this key must be wrapped in the `taxonomies` section of the config or it's ignored by Hugo. This patch adds the section.