### PR TITLE
Add config option "summaryLength"

### DIFF
--- a/content/en/content-management/summaries.md
+++ b/content/en/content-management/summaries.md
@@ -21,28 +21,26 @@ With the use of the `.Summary` [page variable][pagevariables], Hugo generates su
 
 ## Summary Splitting Options
 
-* Hugo-defined Summary Split
-* User-defined Summary Split
+* Automatic Summary Split
+* Manual Summary Split
 
 It is natural to accompany the summary with links to the original content, and a common design pattern is to see this link in the form of a "Read More ..." button. See the `.RelPermalink`, `.Permalink`, and `.Truncated` [page variables][pagevariables].
 
-### Hugo-defined: Automatic Summary Splitting
+### Automatic Summary Splitting
 
-By default, Hugo automatically takes the first 70 words of your content as its summary and stores it into the `.Summary` page variable for use in your templates. Taking the Hugo-defined approach to summaries may save time, but it has pros and cons:
-
-Pros
-: Automatic, no additional work on your part.
-
-Cons
-: All HTML tags are stripped from the summary, and the first 70 words, whether they belong to a heading or to different paragraphs, are all put into one paragraph.
+By default, Hugo automatically takes the first 70 words of your content as its summary and stores it into the `.Summary` page variable for use in your templates. You may customize the summary length by setting `summaryLength` in your [site configuration](/getting-started/configuration/).
 
 {{% note %}}
-The Hugo-defined summaries are set to use word count calculated by splitting the text by one or more consecutive white space characters. If you are creating content in a `CJK` language and want to use Hugo's automatic summary splitting, set `hasCJKLanguage` to `true` in you [site configuration](/getting-started/configuration/).
+You can customize how HTML tags in the summary are loaded using funcitons such as `plainify` and `safeHTML`.
 {{% /note %}}
 
-### User-defined: Manual Summary Splitting
+{{% note %}}
+The Hugo-defined summaries are set to use word count calculated by splitting the text by one or more consecutive whitespace characters. If you are creating content in a `CJK` language and want to use Hugo's automatic summary splitting, set `hasCJKLanguage` to `true` in your [site configuration](/getting-started/configuration/).
+{{% /note %}}
 
-Alternatively, you may add the <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> summary divider where you want to split the article. For [org content][org], use `# more` where you want to split the article. Content that comes before the summary divider will be used as that content's summary and stored in the `.Summary` page variable with all HTML formatting intact.
+### Manual Summary Splitting
+
+In addition, you may add the <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> summary divider where you want to split the article. For [org content][org], use `# more` where you want to split the article. Content that comes before the summary divider will be used as that content's summary and stored in the `.Summary` page variable with all HTML formatting intact.
 
 {{% note "Summary Divider"%}}
 The concept of a *summary divider* is not unique to Hugo. It is also called the "more tag" or "excerpt separator" in other literature.

--- a/content/en/content-management/summaries.md
+++ b/content/en/content-management/summaries.md
@@ -31,7 +31,7 @@ It is natural to accompany the summary with links to the original content, and a
 By default, Hugo automatically takes the first 70 words of your content as its summary and stores it into the `.Summary` page variable for use in your templates. You may customize the summary length by setting `summaryLength` in your [site configuration](/getting-started/configuration/).
 
 {{% note %}}
-You can customize how HTML tags in the summary are loaded using funcitons such as `plainify` and `safeHTML`.
+You can customize how HTML tags in the summary are loaded using functions such as `plainify` and `safeHTML`.
 {{% /note %}}
 
 {{% note %}}

--- a/content/en/content-management/summaries.md
+++ b/content/en/content-management/summaries.md
@@ -40,7 +40,11 @@ The Hugo-defined summaries are set to use word count calculated by splitting the
 
 ### Manual Summary Splitting
 
-In addition, you may add the <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> summary divider where you want to split the article. For [org content][org], use `# more` where you want to split the article. Content that comes before the summary divider will be used as that content's summary and stored in the `.Summary` page variable with all HTML formatting intact.
+Alternatively, you may add the <code>&#60;&#33;&#45;&#45;more&#45;&#45;&#62;</code> summary divider where you want to split the article. 
+
+For [Org mode content][org], use `# more` where you want to split the article. 
+
+Content that comes before the summary divider will be used as that content's summary and stored in the `.Summary` page variable with all HTML formatting intact.
 
 {{% note "Summary Divider"%}}
 The concept of a *summary divider* is not unique to Hugo. It is also called the "more tag" or "excerpt separator" in other literature.


### PR DESCRIPTION
*Updated to include "summaryLength" configuration option from
https://github.com/gohugoio/hugo/pull/3924
*Took line about HTML loading in summary and updated it to clarify the user has options to show html or not instead of implying there are no options
*Fixed typos

Thank you for the help @kaushalmodi! 🙏 😃