### PR TITLE
Fix dead links

### DIFF
--- a/content/en/templates/files.md
+++ b/content/en/templates/files.md
@@ -104,12 +104,12 @@ And here is the result as [called directly in the Hugo docs][] and rendered for 
 
 {{< readfile file="/content/en/readfiles/testing.txt" markdown="true">}}
 
-[called directly in the Hugo docs]: https://github.com/gohugoio/hugo/blob/master/docs/content/templates/files.md
+[called directly in the Hugo docs]: https://github.com/gohugoio/hugoDocs/blob/master/content/en/templates/files.md
 [dirindex]: https://github.com/gohugoio/hugo/blob/master/docs/layouts/shortcodes/directoryindex.html
 [osfileinfo]: https://golang.org/pkg/os/#FileInfo
 [readDir]: /functions/readdir/
 [readFile]: /functions/readfile/
 [sc]: /content-management/shortcodes/
 [sct]: /templates/shortcode-templates/
-[readfilesource]: https://github.com/gohugoio/hugo/blob/master/
-[testfile]: https://github.com/gohugoio/hugo/blob/master/docs/testfile
+[readfilesource]: https://github.com/gohugoio/hugoDocs/blob/master/layouts/shortcodes/readfile.html
+[testfile]: https://github.com/gohugoio/hugoDocs/blob/master/content/en/readfiles/testing.txt


### PR DESCRIPTION
Links that should point to the `hugoDocs` point to `hugo` project.
When visiting the links, they show up as 404 currently