### PR TITLE
Add tip about clearing browser cache

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -127,7 +127,7 @@ theme = "ananke"
 Replace the `title` above with something more personal. Also, if you already have a domain ready, set the `baseURL`. Note that this value is not needed when running the local development server. 
 
 {{% note %}}
-**Tip:** Make the changes to the site configuration or any other file in your site while the Hugo server is running, and you will see the changes in the browser right away.
+**Tip:** Make the changes to the site configuration or any other file in your site while the Hugo server is running, and you will see the changes in the browser right away, though you may need to [clear your cache](https://kb.iu.edu/d/ahic).
 {{% /note %}}
 
 


### PR DESCRIPTION
A forum user expressed confusion about why the wrong site was being served; it turned out he had not cleared his cache, and the old site was showing up.  I have proposed an addition to the last tip about seeing browser changes right away (in the "Site Configuration" section) that suggests you may need to clear the cache and provides a link to a page detailing how to do it.