### PR TITLE
Update publish_to_ghpages.sh

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -216,6 +216,9 @@ hugo
 
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
+
+#echo "Pushing to github"
+#git push --all
 {{< /code >}}
 
 This will abort if there are pending changes in the working directory and also makes sure that all previously existing output files are removed. Adjust the script to taste, e.g. to include the final push to the remote repository if you don't need to take a look at the gh-pages branch before pushing. Or adding `echo yourdomainname.com >> CNAME` if you set up for your gh-pages to use customize domain.

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -4,7 +4,7 @@ linktitle: Host on GitHub
 description: Deploy Hugo as a GitHub Pages project or personal/organizational site and automate the whole process with a simple shell script.
 date: 2014-03-21
 publishdate: 2014-03-21
-lastmod: 2017-03-30
+lastmod: 2018-09-22
 categories: [hosting and deployment]
 keywords: [github,git,deployment,hosting]
 authors: [Spencer Lyon, Gunnar Morling]
@@ -193,11 +193,7 @@ To automate these steps, you can create a script with the following contents:
 {{< code file="publish_to_ghpages.sh" >}}
 #!/bin/sh
 
-DIR=$(dirname "$0")
-
-cd $DIR/..
-
-if [[ $(git status -s) ]]
+if [ "`git status -s`" ]
 then
     echo "The working directory is dirty. Please commit any pending changes."
     exit 1;

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -221,7 +221,7 @@ cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)
 #git push --all
 {{< /code >}}
 
-This will abort if there are pending changes in the working directory and also makes sure that all previously existing output files are removed. Adjust the script to taste, e.g. to include the final push to the remote repository if you don't need to take a look at the gh-pages branch before pushing. Or adding `echo yourdomainname.com >> CNAME` if you set up for your gh-pages to use customize domain.
+This will abort if there are pending changes in the working directory and also makes sure that all previously existing output files are removed. Adjust the script to taste, e.g. to include the final push to the remote repository if you don't need to take a look at the gh-pages branch before pushing.
 
 ### Deployment of Project Pages from Your `master` Branch
 


### PR DESCRIPTION
1. Fixed the script and made it run with sh (it needed bash before).
2. Added the "git push --all" comment for convenience
3. Removed a redundant suggestion about generating the CNAME file from the script. A few paragraphs below it says that CNAME should be created in the "static" directory, no need for it to (also) be in this script.

The updated script is what I use: https://github.com/adakaleh/candaparerevista.ro/blob/content/urca-l.sh