### PR TITLE
removed dead link (resolves #626)

### DIFF
--- a/content/en/content-management/cross-references.md
+++ b/content/en/content-management/cross-references.md
@@ -68,9 +68,6 @@ The above examples render as follows for this very page as well as a reference t
 {{</* relref "/blog/post.md#who" */>}} => /blog/post/#who:badcafe
 ```
 
-More information about document unique identifiers and headings can be found [below]({{< ref "#hugo-heading-anchors" >}}).
-
-
 ## Ref and RelRef Configuration
 
 The behaviour can, since Hugo 0.45, be configured in `config.toml`:


### PR DESCRIPTION
Spent some time searching for where I thought this link might want to lead, but couldn't find anything. Ultimately, it seemed like the entire sentence should just be removed rather than just the link.