### PR TITLE
Add Hokus CMS to frontends list

### DIFF
--- a/content/en/tools/frontends.md
+++ b/content/en/tools/frontends.md
@@ -22,6 +22,7 @@ toc: false
 * [caddy-hugo](https://github.com/hacdias/caddy-hugo). `caddy-hugo` is an add-on for [Caddy](https://caddyserver.com/) that delivers a good UI to edit the content of your Hugo website.
 * [Lipi](https://github.com/SohanChy/Lipi). Lipi is a native GUI frontend written in Java to manage your Hugo websites.
 * [Netlify CMS](https://netlifycms.org). Netlify CMS is an open source, serverless solution for managing Git based content in static sites, and it works on any platform that can host static sites. A [Hugo/Netlify CMS starter](https://github.com/netlify-templates/one-click-hugo-cms) is available to get new projects running quickly.
+* [Hokus CMS](https://www.hokus.io). Hokus CMS is an open source, multiplatform, easy to use, desktop application for Hugo. Build from simple to complex user interfaces for Hugo websites by choosing from a dozen ready-to-use components — all for free, with no vendor lock-in.
 
 
 ## Commercial Services


### PR DESCRIPTION
Added Hokus CMS  to content/en/tools/frontends.md.
I've asked for permission (for @bep) before doing it and he said that's OK. Of course, the content can be changed if it hurts any policy.