### PR TITLE
Document anchorize and Resource.Content

### DIFF
--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -31,17 +31,20 @@ Permalink
 RelPermalink
 : The relative URL to the resource. Resources of type `page` will have no value.
 
+Content
+: The content of the resource itself. For most resources, this returns a string with the contents of the file. This can be used to inline some resources, such as `<script>{{ (.Resources.GetMatch "myscript.js").Content | safeJS }}</script>` or `<img src="{{ (.Resources.GetMatch "mylogo.png").Content | base64Encode }}">`.
+
 MediaType
 : The MIME type of the resource, such as `image/jpg`.
 
-MediaType.MainType 
+MediaType.MainType
 : The main type of the resource's MIME type. For example, a file of MIME type `application/pdf` has for MainType `application`.
 
-MediaType.SubType 
+MediaType.SubType
 : The subtype of the resource's MIME type. For example, a file of MIME type `application/pdf` has for SubType `pdf`. Note that this is not the same as the file extension - PowerPoint files have a subtype of `vnd.mspowerpoint`.
 
 MediaType.Suffixes
-: A slice of possible suffixes for the resource's MIME type. 
+: A slice of possible suffixes for the resource's MIME type.
 
 ## Methods
 ByType

--- a/content/en/functions/anchorize.md
+++ b/content/en/functions/anchorize.md
@@ -1,0 +1,26 @@
+---
+title: anchorize
+description: Takes a string and sanitizes it the same way as Blackfriday does for markdown headers.
+date: 2018-10-13
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [markdown,strings]
+signature: ["anchorize INPUT"]
+hugoversion: "0.39"
+workson: []
+relatedfuncs: [humanize]
+---
+
+The template function uses the [`SanitizedAnchorName` logic from Blackfriday](https://github.com/russross/blackfriday#sanitized-anchor-names).
+Since the same sanitizing logic is used as the markdown parser, you can determine the ID of a header for linking with anchor tags.
+
+```
+{{anchorize "This is a header"}} → "this-is-a-header"
+{{anchorize "This is also          a header"}} → "this-is-also-a-header"
+{{anchorize "main.go"}} → "main-go"
+{{anchorize "Article 123"}} → "article-123"
+{{anchorize "<- Let's try this, shall we?"}} → "let-s-try-this-shall-we"
+{{anchorize "Hello, 世界"}} → "hello-世界"
+```

--- a/content/en/functions/humanize.md
+++ b/content/en/functions/humanize.md
@@ -14,7 +14,7 @@ keywords: [strings,casing]
 signature: ["humanize INPUT"]
 workson: []
 hugoversion:
-relatedfuncs: []
+relatedfuncs: [anchorize]
 deprecated: false
 aliases: []
 ---
@@ -28,4 +28,3 @@ If the input is either an int64 value or the string representation of an integer
 {{humanize "52"}} → "52nd"
 {{humanize 103}} → "103rd"
 ```
-


### PR DESCRIPTION
Partial fix for #452. Adds documentation for the `anchorize` function and the `Resource.Content` property.