### PR TITLE
Document internal social templates

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -59,6 +59,9 @@ There are a few predefined variables that Hugo is aware of. See [Page Variables]
 aliases
 : an array of one or more aliases (e.g., old published paths of renamed content) that will be created in the output directory structure . See [Aliases][aliases] for details.
 
+audio
+: an array of paths to audio files related to the page; used by the `opengraph` [internal template](/templates/internal) to populate `og:audio`.
+
 date
 : the datetime at which the content was created; note this value is auto-populated according to Hugo's built-in [archetype][].
 
@@ -73,6 +76,9 @@ expiryDate
 
 headless
 : if `true`, sets a leaf bundle to be [headless][headless-bundle].
+
+images
+: an array of paths to images related to the page; used by [internal templates](/templates/internal) such as `_internal/twitter_cards.html`.
 
 isCJKLanguage
 : if `true`, Hugo will explicitly treat the content as a CJK language; both `.Summary` and `.WordCount` work properly in CJK languages.
@@ -101,6 +107,9 @@ publishDate
 resources
 : used for configuring page bundle resources. See [Page Resources][page-resources].
 
+series
+: an array of series this page belongs to, as a subset of the `series` [taxonomy](/content-management/taxonomies/); used by the `opengraph` [internal template](/templates/internal) to populate `og:see_also`.
+
 slug
 : appears as the tail of the output URL. A value specified in front matter will override the segment of the URL based on the filename.
 
@@ -113,6 +122,9 @@ type
 url
 : the full path to the content from the web root. It makes no assumptions about the path of the content file. It also ignores any language prefixes of
 the multilingual feature.
+
+videos
+: an array of paths to videos related to the page; used by the `opengraph` [internal template](/templates/internal) to populate `og:video`.
 
 weight
 : used for [ordering your content in lists][ordering]. Lower weight gets higher precedence. So content with lower weight will come first.

--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -50,6 +50,8 @@ You can then include the Google Analytics internal template:
 {{ template "_internal/google_analytics_async.html" . }}
 ```
 
+A `.Site.GoogleAnalytics` variable is also exposed from the config.
+
 ## Disqus
 
 Hugo also ships with an internal template for [Disqus comments][disqus], a popular commenting system for both static and dynamic websites. In order to effectively use Disqus, you will need to secure a Disqus "shortname" by [signing up for the free service][disqussignup].
@@ -75,6 +77,8 @@ To add Disqus, include the following line in templates where you want your comme
 ```
 {{ template "_internal/disqus.html" . }}
 ```
+
+A `.Site.DisqusShortname` variable is also exposed from the config.
 
 ### Conditional Loading of Disqus Comments
 
@@ -108,6 +112,85 @@ You can then render your custom Disqus partial template as follows:
 
 ```
 {{ partial "disqus.html" . }}
+```
+
+## Open Graph
+An internal template for the [Open Graph protocol](http://ogp.me/), metadata that enables a page to become a rich object in a social graph.
+This format is used for Facebook and some other sites.
+
+### Configure Open Graph
+
+Hugo's Open Graph template is configured using a mix of configuration variables and [front-matter](/content-management/front-matter/) on individual pages.
+
+{{< code-toggle file="config" >}}
+[params]
+  title = "My cool site"
+  images = ["site-feature-image.jpg"]
+  description = "Text about my cool site"
+[taxonomies]
+  series = "series"
+{{</ code-toggle >}}
+
+{{< code-toggle file="content/blog/my-post" >}}
+title = "Post title"
+description = "Text about this post"
+date = "2006-01-02"
+images = ["post-cover.png"]
+audio = []
+video = []
+series = []
+tags = []
+{{</ code-toggle >}}
+
+Hugo uses the page title and description for the title and description metadata.
+The first 6 URLs from the `images` array are used for image metadata.
+
+Various optional metadata can also be set:
+- Date, published date, and last modified data are used to set the published time metadata if specified.
+- `audio` and `video` are URL arrays like `images` for the audio and video metadata tags, respectively.
+- The first 6 `tags` on the page are used for the tags metadata.
+- The `series` taxonomy is used to specify related "see also" pages by placing them in the same series.
+
+### Use the Open Graph Template
+
+To add Open Graph metadata, include the following line between the `<head>` tags in your templates:
+
+```
+{{ template "_internal/opengraph.html" . }}
+```
+
+## Twitter Cards
+An internal template for [Twitter Cards](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards),
+metadata used to attach rich media to Tweets linking to your site.
+
+### Configure Twitter Cards
+
+Hugo's Twitter Card template is configured using a mix of configuration variables and [front-matter](/content-management/front-matter/) on individual pages.
+
+{{< code-toggle file="config" >}}
+[params]
+  images = ["site-feature-image.jpg"]
+  description = "Text about my cool site"
+{{</ code-toggle >}}
+
+{{< code-toggle file="content/blog/my-post" >}}
+title = "Post title"
+description = "Text about this post"
+images = ["post-cover.png"]
+{{</ code-toggle >}}
+
+If `images` aren't specified in the page front-matter, then hugo searches for [image page resources](/content-management/image-processing/) with `feature`, `cover`, or `thumbnail` in their name.
+If no image resources with those names are found, the images defined in the [site config](getting-started/configuration/) are used instead.
+If no images are found at all, then an image-less Twitter `summary` card is used instead of `summary_large_image`.
+
+Hugo uses the page title and description for the card's title and description fields. The page summary is used if no description is given.
+
+### Use the Twitter Cards Template
+
+To add Twitter card metadata, include the following line between the `<head>` tags in your templates:
+
+```
+{{ template "_internal/twitter_cards.html" . }}
 ```
 
 ## The Internal Templates


### PR DESCRIPTION
Adds documentation for the `opengraph` and `twitter_cards` internal templates. This involves details about what front-matter affect the templates, along with mentioning the "images", "videos", etc. front-matter in the front-matter documentation.

Fixes #319 and partially fixes #318.

I haven't written any documentation on `.Site.Authors` and `.Site.Social` since I can't find any information on it myself. I've tried to cover all other important functionality for the templates.