### PR TITLE
Add note for reserved partial name.

### DIFF
--- a/content/en/templates/partials.md
+++ b/content/en/templates/partials.md
@@ -60,6 +60,10 @@ All partials are called within your templates using the following pattern:
 One of the most common mistakes with new Hugo users is failing to pass a context to the partial call. In the pattern above, note how "the dot" (`.`) is required as the second argument to give the partial context. You can read more about "the dot" in the [Hugo templating introduction](/templates/introduction/).
 {{% /note %}}
 
+{{% note %}}
+`<PARTIAL>` starting with `baseof` is reserved. ([#5373](https://github.com/gohugoio/hugo/issues/5373))
+{{% /note %}}
+
 As shown in the above example directory structure, you can nest your directories within `partials` for better source organization. You only need to call the nested partial's path relative to the `partials` directory:
 
 ```


### PR DESCRIPTION
In https://github.com/gohugoio/hugo/issues/5373, 
I get response that `baseof.*` template is reserved.

I'd like to reflect this spec.
