### PR TITLE
Add `/` to taxonomy urls

### DIFF
--- a/content/en/templates/single-page-templates.md
+++ b/content/en/templates/single-page-templates.md
@@ -49,14 +49,14 @@ This single page template makes use of Hugo [base templates][], the [`.Format` f
     {{ with .Params.topics }}
     <ul id="topics">
       {{ range . }}
-        <li><a href="{{ "topics" | absURL}}{{ . | urlize }}">{{ . }}</a> </li>
+        <li><a href="{{ "topics" | absURL}}/{{ . | urlize }}">{{ . }}</a> </li>
       {{ end }}
     </ul>
     {{ end }}
     {{ with .Params.tags }}
     <ul id="tags">
       {{ range . }}
-        <li> <a href="{{ "tags" | absURL }}{{ . | urlize }}">{{ . }}</a> </li>
+        <li> <a href="{{ "tags" | absURL }}/{{ . | urlize }}">{{ . }}</a> </li>
       {{ end }}
     </ul>
     {{ end }}


### PR DESCRIPTION
Hey people!
Thank you for writing these excellent docs!

While c/p an example from the taxonomy page I noticed that slashes are missing from the urls.
So here they are :)

Have a great day!