### PR TITLE
Use singular post when creating first page

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -77,7 +77,7 @@ echo 'theme = "ananke"' >> config.toml
 ## Step 4: Add Some Content
 
 ```
-hugo new posts/my-first-post.md
+hugo new post/my-first-post.md
 ```
 
 


### PR DESCRIPTION
The permalink configuration documentation uses `post` instead of `posts`. This is a source of confusion because copying and pasting example configurations will not work. The documentation should be internally consistent to reduce these kinds of problems for new users.

I personally hit this problem when I was trying to get up and running. Otherwise the quick start documentation made it very easy to replicate my blog content and permalinks in Hugo :+1: