### PR TITLE
Update Warning for Theme Links

### DIFF
--- a/content/en/themes/creating.md
+++ b/content/en/themes/creating.md
@@ -19,8 +19,8 @@ toc: true
 wip: true
 ---
 
-{{% warning "Use Relative Links" %}}
-If you're creating a theme with plans to share it with the community, use relative URLs since users of your theme may not publish from the root of their website. See [relURL](/functions/relurl) and [absURL](/functions/absurl).
+{{% warning "Use Absolute Links" %}}
+If you're creating a theme with plans to share it on the [Hugo Themes website](https://themes.gohugo.io/) please note that your theme's demo will be available in a sub-directory of website and for the theme's assets to load properly you will need to create absolute paths in the templates  by using either the [absURL](/functions/absurl) function or `.Permalink`. Also make sure not to use a forward slash `/` in the beginning of a `PATH`, because Hugo will turn it into a relative URL and the `absURL` function will have no effect.
 {{% /warning %}}
 
 Hugo can initialize a new blank theme directory within your existing `themes` using the `hugo new` command:


### PR DESCRIPTION
The advice in this page is actually the opposite. Relative URLs output the wrong URL for theme assets on the Hugo website.

See relevant advice in the Theme's repository's [README](https://github.com/gohugoio/hugoThemes#common-permalink-issues)

I hadn't noticed this page (if I had noticed it I would have sent this PR earlier).

The reason I am merging this PR right away is due to [this](https://github.com/gohugoio/hugoThemes/issues/504#issuecomment-443253163) comment by a confused theme author. 

If you feel that this could be improved feel free to reword and amend as you see fit but the bottom line is that for themes that are going to be published on Hugo Themes authors should create absolute paths in their templates.

cc: @bep @digitalcraftsman @kaushalmodi