### PR TITLE
Document more os.Stat fields

### DIFF
--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -249,7 +249,7 @@ Gets a value from the current `Page's` params set in front matter, with a fall b
 {{</* param testparam */>}}
 ```
 
-Since `testparam` is a param defined in front matter of this page wi the value `Hugo Rocks!`, the above will print:
+Since `testparam` is a param defined in front matter of this page with the value `Hugo Rocks!`, the above will print:
 
 {{< param testparam >}}
 

--- a/content/en/functions/os.Stat.md
+++ b/content/en/functions/os.Stat.md
@@ -4,7 +4,7 @@ description: Gets a file information of a given path.
 godocref:
 date: 2018-08-07
 publishdate: 2018-08-07
-lastmod: 2018-08-07
+lastmod: 2018-12-03
 categories: [functions]
 menu:
   docs:
@@ -21,13 +21,13 @@ aliases: []
 If your current project working directory has a single file named `README.txt` (30 bytes):
 ```
 {{ $stat := os.Stat "README.txt" }}
-{{ $stat.Name }} → "README.txt"
+{{ $stat.Name }} → README.txt
 {{ $stat.Size }} → 30
+{{ $stat.Mode }} → -rw-r--r--
+{{ $stat.ModTime }} → 2018-12-04 04:36:00.638169904 +0000 UTC
+{{ $stat.IsDir }} → false
 ```
 
-Function [`os.Stat`][Stat] returns [`os.FileInfo`][osfileinfo].
-For further information of `os.FileInfo`, see [golang page][osfileinfo].
+Function `os.Stat` returns [`os.FileInfo`][osfileinfo]. For further information on `os.FileInfo`, see the [golang page][osfileinfo].
 
-
-[Stat]: /functions/os.Stat/
 [osfileinfo]: https://golang.org/pkg/os/#FileInfo

--- a/content/en/functions/os.Stat.md
+++ b/content/en/functions/os.Stat.md
@@ -21,7 +21,7 @@ aliases: []
 If your current project working directory has a single file named `README.txt` (30 bytes):
 ```
 {{ $stat := os.Stat "README.txt" }}
-{{ $stat.Name }} → README.txt
+{{ $stat.Name }} → "README.txt"
 {{ $stat.Size }} → 30
 {{ $stat.Mode }} → -rw-r--r--
 {{ $stat.ModTime }} → 2018-12-04 04:36:00.638169904 +0000 UTC


### PR DESCRIPTION
Add os.Stat examples for:
- `.Mode`
- `.ModTime`
- `.IsDir`

Remove duplicate link.

Fix grammar in param shortcode example.