### PR TITLE
Fix ToC example to use binary true/false

### DIFF
--- a/content/en/content-management/toc.md
+++ b/content/en/content-management/toc.md
@@ -74,7 +74,7 @@ The following is an example of a very basic [single page template][]:
 The following is a [partial template][partials] that adds slightly more logic for page-level control over your table of contents. It assumes you are using a `toc` field in your content's [front matter][] that, unless specifically set to `false`, will add a TOC to any page with a `.WordCount` (see [Page Variables][pagevars]) greater than 400. This example also demonstrates how to use [conditionals][] in your templating:
 
 {{< code file="layouts/partials/toc.html" download="toc.html" >}}
-{{ if and (gt .WordCount 400 ) (ne .Params.toc "false") }}
+{{ if and (gt .WordCount 400 ) (.Params.toc) }}
 <aside>
     <header>
     <h2>{{.Title}}</h2>


### PR DESCRIPTION
The example code seemed to require that `toc` be set to the *string* `"false"` instead of the boolean keyword `false`. However, the text said the `toc` variable should be set to boolean `true`/`false` keywords, not strings. I'm not very familiar with GoLang so I could be completely wrong. I just know that the following Hugo page preamble did not work with the original code, but does work with the proposed fix.

```
+++

toc = false

+++
```