### PR TITLE
Remove caddy-hugo

### DIFF
--- a/content/en/tools/frontends.md
+++ b/content/en/tools/frontends.md
@@ -19,7 +19,6 @@ toc: false
 ---
 
 * [enwrite](https://github.com/zzamboni/enwrite). Enwrite enables evernote-powered, statically generated blogs and websites. Now posting to your blog or updating your website is as easy as writing a new note in Evernote!
-* [caddy-hugo](https://github.com/hacdias/caddy-hugo). `caddy-hugo` is an add-on for [Caddy](https://caddyserver.com/) that delivers a good UI to edit the content of your Hugo website.
 * [Lipi](https://github.com/SohanChy/Lipi). Lipi is a native GUI frontend written in Java to manage your Hugo websites.
 * [Netlify CMS](https://netlifycms.org). Netlify CMS is an open source, serverless solution for managing Git based content in static sites, and it works on any platform that can host static sites. A [Hugo/Netlify CMS starter](https://github.com/netlify-templates/one-click-hugo-cms) is available to get new projects running quickly.
 * [Hokus CMS](https://www.hokus.io). Hokus CMS is an open source, multiplatform, easy to use, desktop application for Hugo. Build from simple to complex user interfaces for Hugo websites by choosing from a dozen ready-to-use components — all for free, with no vendor lock-in.


### PR DESCRIPTION
Filebrowser, the Caddy plugin that integrates Hugo with Caddy, recently underwent a rewrite. As part of that rewrite, its Hugo integration [was removed completely](https://github.com/filebrowser/filebrowser/releases/tag/v2.0.0-rc.1). The caddy-hugo entry should be removed from Hugo's documentation since the Filebrowser Caddy plugin no longer integrates Hugo with Caddy.