### PR TITLE
Clarify: summaryLength uses words not characters

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -254,7 +254,7 @@ stepAnalysis (false)
 : Display memory and timing of different steps of the program.
 
 summaryLength (70)
-: The length of text to show in a [`.Summary`](/content-management/summaries/#hugo-defined-automatic-summary-splitting).
+: The length of text in words to show in a [`.Summary`](/content-management/summaries/#hugo-defined-automatic-summary-splitting).
 
 taxonomies
 : See [Configure Taxonomies](/content-management/taxonomies#configure-taxonomies).


### PR DESCRIPTION
I had to look up if characters or words… Just a little improvement to the docs.