### PR TITLE
Fix search box text being invisible in Safari

### DIFF
--- a/themes/gohugoioTheme/layouts/partials/site-search.html
+++ b/themes/gohugoioTheme/layouts/partials/site-search.html
@@ -1,6 +1,6 @@
 <form id="site-search-form" action="" role="search">
   <fieldset class="bn ma0 pa0">
     <label class="clip" for="search-input">Search</label>
-    <input type="search" id="search-input" class="needs-js bg-left bg-transparent bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" name="search-input" value="" style="background: url('/images/icon-search.png') no-repeat 0 8px /16px 16px;;">
+    <input type="search" id="search-input" class="needs-js bg-left bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" name="search-input" value="" style="background: transparent url('/images/icon-search.png') no-repeat 0 8px /16px 16px;">
   </fieldset>
 </form>


### PR DESCRIPTION
Here's how the search box is rendered in Safari (12.0.3 on macOS and on iOS 12.1.4), with white text ('test') on a white background:

<img width="476" alt="Screen shot showing white text 'test' on white search box background" src="https://user-images.githubusercontent.com/171986/54978727-6619d580-4f5e-11e9-8893-66a26f3ad36c.png">

This is virtually unusable.

For some reason (Purgecss misfire?) the CSS class `.bg-transparent` does not appear in the built CSS file, so the assignment of the class to the `input` element is meaningless.

The inline style declared on the `input` element using the `background` shortcut declaration lacks a background-color. Chrome and Firefox interpret that as a transparent background, but Safari just ignores it, falling back to its default white background. This means text typed into the search field renders as white on white, effectively invisible. 

This PR explicitly declares a transparent background color so the search box should render correctly in all three browsers (white text on black background).