### PR TITLE
Fix metadata list

### DIFF
--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -146,6 +146,7 @@ Hugo uses the page title and description for the title and description metadata.
 The first 6 URLs from the `images` array are used for image metadata.
 
 Various optional metadata can also be set:
+
 - Date, published date, and last modified data are used to set the published time metadata if specified.
 - `audio` and `video` are URL arrays like `images` for the audio and video metadata tags, respectively.
 - The first 6 `tags` on the page are used for the tags metadata.


### PR DESCRIPTION
Seems that there must be an additional newline before the list items in order for hugo to properly render it as a Markdown list.