### PR TITLE
Update directory-structure.md

### DIFF
--- a/content/en/getting-started/directory-structure.md
+++ b/content/en/getting-started/directory-structure.md
@@ -27,8 +27,7 @@ Running the `hugo new site` generator from the command line will create a direct
 ```
 .
 ├── archetypes
-├── assets
-├── config
+├── config.toml
 ├── content
 ├── data
 ├── layouts
@@ -46,14 +45,14 @@ The following is a high-level overview of each of the directories with links to 
 By default, Hugo will create new content files with at least `date`, `title` (inferred from the file name), and `draft = true`. This saves time and promotes consistency for sites using multiple content types. You can create your own [archetypes][] with custom preconfigured front matter fields as well.
 
 [`assets`][]
-: Stores all the files which need be processed by [Hugo Pipes]({{< ref "/hugo-pipes" >}}). Only the files whose `.Permalink` or `.RelPermalink` are used will be published to the `public` directory.
+: Stores all the files which need be processed by [Hugo Pipes]({{< ref "/hugo-pipes" >}}). Only the files whose `.Permalink` or `.RelPermalink` are used will be published to the `public` directory. Note: assets directory is not created by default.
 
 [`config`](/getting-started/configuration/)
 : Hugo ships with a large number of [configuration directives](https://gohugo.io/getting-started/configuration/#all-variables-yaml).
 The [config directory](/getting-started/configuration/#configuration-directory) is where those directives are stored as JSON, YAML, or TOML files. Every root setting object can stand as its own file and structured by environments.
 Projects with minimal settings and no need for environment awareness can use a single `config.toml` file at its root.
 
-Many sites may need little to no configuration, but Hugo ships with a large number of [configuration directives][] for more granular directions on how you want Hugo to build your website.
+Many sites may need little to no configuration, but Hugo ships with a large number of [configuration directives][] for more granular directions on how you want Hugo to build your website. Note: assets directory is not created by default.
 
 [`content`][]
 : All content for your website will live inside this directory. Each top-level folder in Hugo is considered a [content section][]. For example, if your site has three main sections---`blog`, `articles`, and `tutorials`---you will have three directories at `content/blog`, `content/articles`, and `content/tutorials`. Hugo uses sections to assign default [content types][].


### PR DESCRIPTION
When running hugo new site sitename it does not create the assets or config directories by default. 

I updated the layout example to remove the directories and include config.toml and made a note in the assets and config directory sections to highlight they are not created by default.