### PR TITLE
Fix typos for absLangURL and relLangURL functions

### DIFF
--- a/content/en/templates/menu-templates.md
+++ b/content/en/templates/menu-templates.md
@@ -65,7 +65,7 @@ The following is an example:
 {{< /code >}}
 
 {{% note "`absLangURL` and `relLangURL`" %}}
-Use the [`absLangUrl`](/functions/abslangurl) or [`relLangUrl`](/functions/rellangurl) functions if your theme makes use of the [multilingual feature](/content-management/multilingual/). In contrast to `absURL` and `relURL`, these two functions add the correct language prefix to the url.
+Use the [`absLangURL`](/functions/abslangurl) or [`relLangURL`](/functions/rellangurl) functions if your theme makes use of the [multilingual feature](/content-management/multilingual/). In contrast to `absURL` and `relURL`, these two functions add the correct language prefix to the url.
 {{% /note %}}
 
 ## Section Menu for Lazy Bloggers


### PR DESCRIPTION
Replaces the [PR made on the wrong repository](https://github.com/gohugoio/hugo/pull/5631/commits).
