### PR TITLE
Update output-formats.md

### DIFF
--- a/content/en/templates/output-formats.md
+++ b/content/en/templates/output-formats.md
@@ -40,9 +40,9 @@ To add or modify a media type, define it in a `mediaTypes` section in your [site
 {{< code-toggle file="config" >}}
 [mediaTypes]
   [mediaTypes."text/enriched"]
-  suffix = "enr"
+  suffixes = ["enr"]
   [mediaTypes."text/html"]
-  suffix = "asp"
+  suffixes = ["asp"]
 {{</ code-toggle >}}
 
 The above example adds one new media type, `text/enriched`, and changes the suffix for the built-in `text/html` media type.
@@ -52,7 +52,7 @@ The above example adds one new media type, `text/enriched`, and changes the suff
 ```toml
 [mediaTypes]
 [mediaTypes."text/html"]
-suffix = "htm"
+suffixes = ["htm"]
 
 # Redefine HTML to update its media type.
 [outputFormats]


### PR DESCRIPTION
"suffix" is now "suffixes" and takes an array.

>Error: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").
>
>This had its limitations. For one, it was only possible with one file extension per MIME type.
>
>Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
identifier:
