### PR TITLE
Updated link to Go Docs to more helpful page

### DIFF
--- a/content/en/templates/introduction.md
+++ b/content/en/templates/introduction.md
@@ -20,7 +20,7 @@ toc: true
 ---
 
 {{% note %}}
-The following is only a primer on Go Templates. For an in-depth look into Go Templates, check the official [Go docs](http://golang.org/pkg/html/template/).
+The following is only a primer on Go Templates. For an in-depth look into Go Templates, check the official [Go docs](https://golang.org/pkg/text/template/).
 {{% /note %}}
 
 Go Templates provide an extremely simple template language that adheres to the belief that only the most basic of logic belongs in the template or view layer.


### PR DESCRIPTION
The text/template page is a better resource for how Hugo templates work as is talks about the tags and what they do.

would it be helpful if I was to start adding to the Hugo docs from the golang text/template docs