### PR TITLE
Correct typo "RFC339" to "RFC1123Z"

### DIFF
--- a/content/en/functions/format.md
+++ b/content/en/functions/format.md
@@ -87,7 +87,7 @@ date: 2017-03-03T14:15:59-06:00
 `"Mon, 02 Jan 2006 15:04:05 MST"` (RFC1123)
 : **Returns**: `Fri, 03 Mar 2017 14:15:59 CST`
 
-`"Mon, 02 Jan 2006 15:04:05 -0700"` (RFC339)
+`"Mon, 02 Jan 2006 15:04:05 -0700"` (RFC3339)
 : **Returns**: `Fri, 03 Mar 2017 14:15:59 -0600`
 
 ### Cardinal Numbers and Ordinal Abbreviations

--- a/content/en/functions/format.md
+++ b/content/en/functions/format.md
@@ -87,8 +87,10 @@ date: 2017-03-03T14:15:59-06:00
 `"Mon, 02 Jan 2006 15:04:05 MST"` (RFC1123)
 : **Returns**: `Fri, 03 Mar 2017 14:15:59 CST`
 
-`"Mon, 02 Jan 2006 15:04:05 -0700"` (RFC3339)
+`"Mon, 02 Jan 2006 15:04:05 -0700"` (RFC1123Z)
 : **Returns**: `Fri, 03 Mar 2017 14:15:59 -0600`
+
+More examples can be found in Go's [documentation for the time package][timeconst].
 
 ### Cardinal Numbers and Ordinal Abbreviations
 
@@ -121,3 +123,4 @@ In conjunction with the [`dateFormat` function][dateFormat], you can also conver
 [gdex]: https://golang.org/pkg/time/#example_Time_Format
 [pagevars]: /variables/page/
 [time]: https://golang.org/pkg/time/
+[timeconst]: https://golang.org/pkg/time/#ANSIC


### PR DESCRIPTION
I believe the example under the section "Hugo Date and Time Templating Reference" should be "[RFC3339](https://tools.ietf.org/html/rfc3339)", which is "Date and Time on the Internet: Timestamps" instead of "[RFC339](https://tools.ietf.org/html/rfc339)", which is "MLTNET - A 'MULTI-TELNET' SUBSYSTEM FOR TENEX".