### PR TITLE
Removing unnecessary javascript

### DIFF
--- a/content/en/content-management/formats.md
+++ b/content/en/content-management/formats.md
@@ -171,21 +171,7 @@ MathJax.Hub.Config({
   }
 });
 </script>
-
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Queue(function() {
-    // Fix <code> tags after MathJax finishes running. This is a
-    // hack to overcome a shortcoming of Markdown. Discussion at
-    // https://github.com/mojombo/jekyll/issues/199
-    var all = MathJax.Hub.getAllJax(), i;
-    for(i = 0; i < all.length; i += 1) {
-        all[i].SourceElement().parentNode.className += ' has-jax';
-    }
-});
-</script>
 {{< /code >}}
-
-
 
 As before, this content should be included in the HTML source of each page that will be using MathJax. The next code snippet contains the CSS that is used to have verbatim MathJax blocks render with the same font style as the body of the page.
 


### PR DESCRIPTION
This block of javascript currently seems to break MathJax rendering (at least on my site, rendered and viewed under Chrome browser).  Just remove?

https://stackoverflow.com/questions/56648378/rendering-latex-on-hugo-websites-with-mathjax