### PR TITLE
Use actual width in image processing examples

### DIFF
--- a/layouts/shortcodes/imgproc.html
+++ b/layouts/shortcodes/imgproc.html
@@ -12,7 +12,7 @@
 {{ end }}
 {{ $image := .Scratch.Get "image" }}
 <figure style="padding: 0.25rem; margin: 2rem 0; background-color: #cccc">
-	<img style="max-width: 100%; height: auto;" src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}">
+	<img style="max-width: 100%; width: auto; height: auto;" src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}">
 	<figcaption>
 	<small>
 	{{ with .Inner }}


### PR DESCRIPTION
The image processing examples are rendered within containers with a
'nested-img' parent CSS class, which by default makes images responsive
by resizing them to the size of their containers.

That doesn't work well for the examples as the small images end up
stretched.

Since there can be other images in the same 'nested-img' context, we
keep that class in the parent and set the example images width to auto,
such that they will render with their actual size.

On small screens, larger images will still be sized down via the
max-width property.

## Testing

Tested manually in Chrome 75.0.3770.90 and Firefox 67.0

Affected URLs:
- https://gohugo.io/content-management/image-processing/
- https://gohugo.io/about/new-in-032/
- https://gohugo.io/content-management/organization/
- https://gohugo.io/news/lets-celebrate-hugos-5th-birthday/

### Before

![image](https://user-images.githubusercontent.com/88819/59692290-e14cf980-91e4-11e9-93f6-5b355f0b5912.png)

### After

![image](https://user-images.githubusercontent.com/88819/59692329-fa55aa80-91e4-11e9-9c36-9f657fdbd683.png)

---

Fixes #812