### PR TITLE
remove unneeded type="text/javascript" from script in example

### DIFF
--- a/content/en/hugo-pipes/fingerprint.md
+++ b/content/en/hugo-pipes/fingerprint.md
@@ -25,5 +25,5 @@ Any so processed asset will bear a `.Data.Integrity` property containing an inte
 ```go-html-template
 {{ $js := resources.Get "js/global.js" }}
 {{ $secureJS := $js | resources.Fingerprint "sha512" }}
-<script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+<script src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
 ```


### PR DESCRIPTION
This makes the snippet easier to read and it's not necessary to include it (plus the internally used scripts use a different type)