### PR TITLE
Fix link to font assets

### DIFF
--- a/themes/gohugoioTheme/layouts/_default/baseof.html
+++ b/themes/gohugoioTheme/layouts/_default/baseof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     {{/* https://www.zachleat.com/web/preload/ */}}
-    <link rel="preload" href="{{ "files/muli-latin-200.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ "files/muli-latin-400.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ "files/muli-latin-800.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ "fonts/muli-latin-200.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ "fonts/muli-latin-400.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{ "fonts/muli-latin-800.woff2" | absURL }}" as="font" type="font/woff2" crossorigin>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
      {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}


### PR DESCRIPTION
Fixes #796.

Note that while this remedies the existing 404 issue, the source trees here and in the theme repo are out of sync and addressing that may remove font preloading altogether.