### PR TITLE
Fix statement about version installed with apt-get

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -456,7 +456,7 @@ Hugo installed via Snap can write only inside the user’s `$HOME` directory---a
 
     sudo apt-get install hugo
 
-This installs the "extended" Sass/SCSS version.
+This installs the non-extended version without Sass/SCSS support.
 
 ### Arch Linux
 

--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -456,7 +456,7 @@ Hugo installed via Snap can write only inside the user’s `$HOME` directory---a
 
     sudo apt-get install hugo
 
-This installs the non-extended version without Sass/SCSS support.
+What this installs depends on your Debian/Ubuntu version. On Ubuntu bionic (18.04), this installs the non-extended version without Sass/SCSS support. On Ubuntu disco (19.04), this installs the extended version with Sass/SCSS support.
 
 ### Arch Linux
 


### PR DESCRIPTION
When I use `sudo apt-get install hugo` on Ubuntu this installs the non-extended version, not the extended version as this page states. After installing this way the version I have is:
```
hugo version
Hugo Static Site Generator v0.40.1 linux/amd64 BuildDate: 2018-04-25T17:16:11Z
```