### PR TITLE
Better deploy script example

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -67,30 +67,31 @@ You're almost done. In order to automate next steps create a `deploy.sh` script.
 The following are the contents of the `deploy.sh` script:
 
 ```
-#!/bin/bash
+#!/bin/sh
 
-echo -e "\033[0;32mDeploying updates to GitHub...\033[0m"
+# If a command fails then the deploy stops
+set -e
+
+printf "\033[0;32mDeploying updates to GitHub...\033[0m\n"
 
 # Build the project.
 hugo # if using a theme, replace with `hugo -t <YOURTHEME>`
 
 # Go To Public folder
 cd public
+
 # Add changes to git.
 git add .
 
 # Commit changes.
-msg="rebuilding site `date`"
-if [ $# -eq 1 ]
-  then msg="$1"
+msg="rebuilding site $(date)"
+if [ -n "$*" ]; then
+	msg="$*"
 fi
 git commit -m "$msg"
 
 # Push source and build repos.
 git push origin master
-
-# Come Back up to the Project Root
-cd ..
 ```
 
 


### PR DESCRIPTION
## Improvements

* Changed shebang from `#!/bin/bash` to `#!/bin/sh` (sh is more portable)
* Use `printf` instead of `echo` (in posix sh `echo` with arguments is undefined)
* Use `set -e` so that if `cd` fails the deploy will fail instead of wrongly commit & pushing in the wrong repo
* Changed the script to work with any number of arguments as a commit message, instead of only tolerating one