### PR TITLE
Add explanation on how to set config params via environment variables

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -351,6 +351,8 @@ This is really useful if you use a service such as Netlify to deploy your site. 
 
 {{% note "Setting Environment Variables" %}}
 Names must be prefixed with `HUGO_` and the configuration key must be set in uppercase when setting operating system environment variables.
+
+To set config params, prefix the name with `HUGO_PARAMS_`
 {{% /note %}}
 
 {{< todo >}}


### PR DESCRIPTION
Hi there,

I was looking for documentation on how to override config params with environment variables. It's possible to do by prefixing the name with `HUGO_PARAMS_`. This wasn't explicitly documented, so it took a bit of exploration of viper and some local testing to figure out. Hopefully adding this saves future users the same pain.

This PR adds a sentence to the documentation stating how to do it.  I thought best to keep it simple. A more comprehensive example may be useful.