### PR TITLE
Update description of .Pages based on its new behavior in Hugo 0.57+

### DIFF
--- a/content/en/readfiles/pages-vs-site-pages.md
+++ b/content/en/readfiles/pages-vs-site-pages.md
@@ -1,9 +1,32 @@
-| Variable             | Current context | Pages included                                                                                                                                                                                           |
-|----------------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `.Site.Pages`        | **any** page    | ALL pages of the site: content, sections, taxonomies, etc. -- Superset of everything!                                                                                                                     |
-| `.Site.RegularPages` | **any** page    | Only regular (content) pages -- Subset of `.Site.Pages`                                                                                                                                                   |
-| `.Pages`             | _List_ page     | Regular pages under that _list_ page representing the homepage, section, taxonomy term (`/tags`) or taxonomy (`/tags/foo`) page -- Subset of `.Site.Pages` or `.Site.RegularPages`, depending on context. |
-| `.Pages`             | _Single_ page   | empty slice                                                                                                                                                                                              |
+* A _regular_ page is a "post" page or a "content" page.
+  * A _leaf bundle_ is a regular page.
+* A _list_ page can list _regular_ pages and other _list_ pages. Some
+  examples are: homepage, section pages, _taxonomy term_ (`/tags/`) and
+  _taxonomy_ (`/tags/foo/`) pages.
+  * A _branch bundle_ is a _list_ page.
+
+`site.Pages`
+: Collection of **all** pages of the site: _regular_ pages,
+    sections, taxonomies, etc. -- Superset of everything!
+
+`site.RegularPages`
+: Collection of only _regular_ pages.
+
+The above `site. ..` page collections can be accessed from any scope in
+the templates.
+
+Below variables return a collection of pages only from the scope of
+the current _list_ page:
+
+`.Pages`
+: Collection of _regular_ pages and _only first-level_
+    section pages under the current _list_ page.
+
+`.RegularPages`
+: Collection of only _regular_ pages under the
+    current _list_ page.
+
 
 Note
-: In the **home** context (`index.html`), `.Pages` is the same as `.Site.RegularPages`.
+: From the scope of _regular_ pages, `.Pages` and
+    `.RegularPages` return an empty slice.


### PR DESCRIPTION
Also document the new `.RegularPages` now available in all pages,
starting from Hugo v0.57.0.

Fixes https://github.com/gohugoio/hugoDocs/issues/890.