### PR TITLE
Update link to Chroma style gallery

### DIFF
--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -120,7 +120,7 @@ You can generate one with Hugo:
 hugo gen chromastyles --style=monokai > syntax.css
 ```
 
-Run `hugo gen chromastyles -h` for more options. See https://help.farbox.com/pygments.html for a gallery of available styles.
+Run `hugo gen chromastyles -h` for more options. See https://xyproto.github.io/splash/docs/ for a gallery of available styles.
 
 
 ## Highlight Shortcode


### PR DESCRIPTION
The link to the style gallery is old – it looks like it dates back to Pygments, it does not include all of the styles available in Chroma (I noticed because it was missing the Solarized styles).

I've changed the link to point to the updated style gallery [linked in Chroma's official README](https://github.com/alecthomas/chroma#styles).