### PR TITLE
Use index.md instead of _index.md in example

### DIFF
--- a/content/en/content-management/organization/index.md
+++ b/content/en/content-management/organization/index.md
@@ -46,7 +46,7 @@ Without any additional configuration, the following will just work:
 .
 └── content
     └── about
-    |   └── _index.md  // <- https://example.com/about/
+    |   └── index.md  // <- https://example.com/about/
     ├── posts
     |   ├── firstpost.md   // <- https://example.com/posts/firstpost/
     |   ├── happy


### PR DESCRIPTION
The about directory in the example has no children, but the example used _index.md. This is confusing to beginners.