### PR TITLE
Typo in quick-start.md commend => command

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -86,7 +86,7 @@ echo 'theme = "ananke"' >> config.toml
 
 ## Step 4: Add Some Content
 
-You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use `new` command to do few things for you (like add title and date):
+You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use the `new` command to do few things for you (like add title and date):
 
 ```
 hugo new posts/my-first-post.md

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -86,7 +86,7 @@ echo 'theme = "ananke"' >> config.toml
 
 ## Step 4: Add Some Content
 
-You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use `new` commend to do few things for you (like add title and date):
+You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use `new` command to do few things for you (like add title and date):
 
 ```
 hugo new posts/my-first-post.md


### PR DESCRIPTION
Hello Hugophers, found this typo following the Quick Start in the Step 4: Add Some Content section. While commend is a word, in this case we mean command.