### PR TITLE
clarify config directory structure. fixes #893

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -54,10 +54,9 @@ In addition to using a single site config file, one can use the `configDir` dire
 │   ├── _default
 │   │   ├── config.toml
 │   │   ├── languages.toml
-│   │   ├── mediaTypes.toml
-│   │   ├── menu.en.toml
-│   │   ├── menu.zh.toml
-│   │   ├── params.toml
+│   │   ├── menus.en.toml
+│   │   ├── menus.zh.toml
+│   │   └── params.toml
 │   ├── production
 │   │   ├── config.toml
 │   │   └── params.toml

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -50,19 +50,20 @@ In addition to using a single site config file, one can use the `configDir` dire
 
 
 ```
-config
-├── _default
-│   ├── config.toml
-│   ├── languages.toml
-│   ├── menus.en.toml
-│   ├── menus.zh.toml
-│   └── params.toml
-├── staging
-│   ├── config.toml
-│   └── params.toml
-└── production
-    ├── config.toml
-    └── params.toml
+├── config
+│   ├── _default
+│   │   ├── config.toml
+│   │   ├── languages.toml
+│   │   ├── mediaTypes.toml
+│   │   ├── menu.en.toml
+│   │   ├── menu.zh.toml
+│   │   ├── params.toml
+│   ├── production
+│   │   ├── config.toml
+│   │   └── params.toml
+│   └── staging
+│       ├── config.toml
+│       └── params.toml
 ```
 
 Considering the structure above, when running `hugo --environment staging`, Hugo will use every settings from `config/_default` and merge `staging`'s on top of those.


### PR DESCRIPTION
I ran `tree examplesite` from my theme and then deleted/renamed config files. 
![image](https://user-images.githubusercontent.com/646061/63899007-12e5fc00-c9b0-11e9-89b8-66bc4164512d.png)

Entries for `menus.en.toml` revised to `menu.en.toml` to match config docs.
