### PR TITLE
Remove 'ey' typo from Release Notes v0.58.0

### DIFF
--- a/content/en/news/0.58.0-relnotes/index.md
+++ b/content/en/news/0.58.0-relnotes/index.md
@@ -42,7 +42,7 @@ Hugo now has:
 ## Notes
 
 * `home.Pages` now behaves like all the other sections, see [#6240](https://github.com/gohugoio/hugo/issues/6240). If you want to list all the regular pages, use `.Site.RegularPages`.
-* We have added some new image filters to Hugo's image processing. This also means that we have consolidated the resize operations to use the one `gift` library (from the same developer as the one we used before). The operations work as before, but one difference is that we no longer embed ey color profile information in PNG images, but this should also be a more portable solution. Software that supports color profiles will assume that images without an embedded profile are in the sRGB profile. Software that doesn't support color profiles will use the monitor's profile, which is most likely to be sRGB as well.
+* We have added some new image filters to Hugo's image processing. This also means that we have consolidated the resize operations to use the one `gift` library (from the same developer as the one we used before). The operations work as before, but one difference is that we no longer embed color profile information in PNG images, but this should also be a more portable solution. Software that supports color profiles will assume that images without an embedded profile are in the sRGB profile. Software that doesn't support color profiles will use the monitor's profile, which is most likely to be sRGB as well.
 * We have improved the file cache logic for processed images and only stores them once when the same image is bundled in multiple languages. This means that you may want to run `hugo --gc` to clean your image cache.
 
 ## Enhancements


### PR DESCRIPTION
this PR removes a typo 'ey'.

was:
>  we no longer embed ey color profile information in PNG images

now:
>  we no longer embed color profile information in PNG images

I think that can be removed, but maybe it should have been 'any' instead?