### PR TITLE
Fix typo in # anchor links

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -187,7 +187,7 @@ It's possible to set some options for Markdown rendering in a content's front ma
 * [JSON Spec][json]
 
 [variables]: /variables/
-[aliases]: /content-management/urls/#aliases/
+[aliases]: /content-management/urls/#aliases
 [archetype]: /content-management/archetypes/
 [bylinktitle]: /templates/lists/#by-link-title
 [config]: /getting-started/configuration/ "Hugo documentation for site configuration"

--- a/content/en/templates/lists.md
+++ b/content/en/templates/lists.md
@@ -549,8 +549,8 @@ See the documentation on [`where` function][wherefunction] and
 [sections]: /content-management/sections/
 [sectiontemps]: /templates/section-templates/
 [sitevars]: /variables/site/
-[taxlists]: /templates/taxonomy-templates/#taxonomy-list-templates/
-[taxterms]: /templates/taxonomy-templates/#taxonomy-terms-templates/
+[taxlists]: /templates/taxonomy-templates/#taxonomy-list-templates
+[taxterms]: /templates/taxonomy-templates/#taxonomy-terms-templates
 [taxvars]: /variables/taxonomy/
 [views]: /templates/views/
 [wherefunction]: /functions/where/


### PR DESCRIPTION
Remove all trailing `/` slash in `#` anchor links.
Find `(\[.*\]:.*#.*)/$` and replace with `$1` to do the work.