### PR TITLE
Add missing syntax highlighting variables to list of all settings

### DIFF
--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -68,7 +68,7 @@ To make the transition from Pygments to Chroma seamless, they share a common set
 pygmentsOptions
 :  A comma separated list of options. See below for a full list.
 
-pygmentsCodefences
+pygmentsCodeFences
 : Set to true to enable syntax highlighting in code fences with a language tag in markdown (see below for an example).
 
 pygmentsStyle
@@ -83,7 +83,7 @@ pygmentsStyle
 pygmentsUseClasses
 : Set to `true` to use CSS classes to format your highlighted code. See [Generate Syntax Highlighter CSS](#generate-syntax-highlighter-css).
 
-pygmentsCodefencesGuessSyntax
+pygmentsCodeFencesGuessSyntax
 : Set to `true` to try to do syntax highlighting on code fenced blocks in markdown without a language tag.
 
 pygmentsUseClassic

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -214,6 +214,12 @@ pluralizeListTitles (true)
 publishDir ("public")
 : The directory to where Hugo will write the final static site (the HTML files etc.).
 
+pygmentsOptions ("")
+:  A comma separated list of options for syntax highlighting. See the [Syntax Highlighting Options](/content-management/syntax-highlighting/#options) for the full list of available options.
+
+pygmentsCodeFences (false)
+: Enables syntax highlighting in [code fences with a language tag](/content-management/syntax-highlighting/#highlight-in-code-fences) in markdown.
+
 pygmentsCodeFencesGuessSyntax (false)
 : Enable syntax guessing for code fences without specified language.
 
@@ -222,6 +228,9 @@ pygmentsStyle ("monokai")
 
 pygmentsUseClasses (false)
 : Enable using external CSS for syntax highlighting.
+
+pygmentsUseClassic (false)
+: Enable using Pygments instead of the much faster Chroma for syntax highlighting.
 
 related
 : See [Related Content](/content-management/related/#configure-related-content).


### PR DESCRIPTION
The list of all configuration variables was missing some (newer?) variables relating to syntax highlighting. I've added the missing variables to the full liston the [configuration page](https://gohugo.io/getting-started/configuration/).

Some instances of `pygmentsCodeFences` were also capitalised differently and I've updated those, though it's only for the sake of consistency.