### PR TITLE
Update lookup-order.md

### DIFF
--- a/content/en/templates/lookup-order.md
+++ b/content/en/templates/lookup-order.md
@@ -28,14 +28,14 @@ Hugo takes the parameters listed below into consideration when choosing a layout
 Kind
 : The page `Kind` (the home page is one). See the example tables below per kind. This also determines if it is a **single page** (i.e. a regular content page. We then look for a template in `_default/single.html` for HTML) or a **list page** (section listings, home page, taxonomy lists, taxonomy terms. We then look for a template in `_default/list.html` for HTML).
 
+Layout
+: Can be set in page front matter.
+
 Output Format
 : See [Custom Output Formats](/templates/output-formats). An output format has both a `name` (e.g. `rss`, `amp`, `html`) and a `suffix` (e.g. `xml`, `html`). We prefer matches with both (e.g. `index.amp.html`, but look for less specific templates.
 
 Language
 : We will consider a language code in the template name. If the site language is `fr`, `index.fr.amp.html` will win over `index.amp.html`, but `index.amp.html` will be chosen before `index.fr.html`.
-
-Layout
-: Can be set in page front matter.
 
 Type
 : Is value of `type` if set in front matter, else it is the name of the root section (e.g. "blog"). It will always have a value, so if not set, the value is "page". 


### PR DESCRIPTION
The document starts with "Hugo takes the parameters listed below into consideration when choosing a layout for a given page. They are listed in a priority order."
So it lists parameters from lower priority to higher priority.
But according to examples output format and language priority is higher than Layout priority.
It is quite confusing to read.