### PR TITLE
fix typo in /getting-started/configuration/

### DIFF
--- a/content/en/content-management/formats.md
+++ b/content/en/content-management/formats.md
@@ -39,7 +39,7 @@ Before you begin writing your content in markdown, Blackfriday has a known issue
 
 ## Configure BlackFriday Markdown Rendering
 
-You can configure multiple aspects of Blackfriday as show in the following list. See the docs on [Configuration][config] for the full list of explicit directions you can give to Hugo when rendering your site.
+You can configure multiple aspects of Blackfriday as shown in the following list. See the docs on [Configuration][config] for the full list of explicit directions you can give to Hugo when rendering your site.
 
 {{< readfile file="/content/en/readfiles/bfconfig.md" markdown="true" >}}
 


### PR DESCRIPTION
I noticed a small typo on the `/getting-started/configuration/` page. This pull request makes the fix.