### PR TITLE
Anaka theme uses /post/ and NOT /posts/

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -89,7 +89,7 @@ echo 'theme = "ananke"' >> config.toml
 You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use the `new` command to do few things for you (like add title and date):
 
 ```
-hugo new posts/my-first-post.md
+hugo new post/my-first-post.md
 ```
 
 {{< asciicast eUojYCfRTZvkEiqc52fUsJRBR >}}


### PR DESCRIPTION
This should solve #862 

Not sure about the **asciicast** though :-(