### PR TITLE
Clarify that `print` takes 1+ arguments

### DIFF
--- a/content/en/functions/print.md
+++ b/content/en/functions/print.md
@@ -1,7 +1,7 @@
 ---
 title: print
 linktitle: print
-description: Prints the default representation of the given argument using the standard `fmt.Print` function.
+description: Prints the default representation of the given arguments using the standard `fmt.Print` function.
 godocref: https://golang.org/pkg/fmt/
 date: 2017-02-01
 publishdate: 2017-02-01
@@ -22,5 +22,6 @@ See [the go doc](https://golang.org/pkg/fmt/) for additional information.
 
 ```
 {{ print "foo" }} → "foo"
+{{ print "foo" "bar" }} → "foobar"
 {{ print (slice 1 2 3) }} → [1 2 3]
 ```


### PR DESCRIPTION
This was really not clear from the doc before.