### PR TITLE
Updated quickstart to split theme download and theme config add into separate blocks

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -61,7 +61,7 @@ The above will create a new Hugo site in a folder named `quickstart`.
 
 See [themes.gohugo.io](https://themes.gohugo.io/) for a list of themes to consider. This quickstart uses the beautiful [Ananke theme](https://themes.gohugo.io/gohugo-theme-ananke/).
 
-First download the theme from Github and add it to your site's `theme` directory:
+First, download the theme from Github and add it to your site's `theme` directory:
 
 ```bash
 cd quickstart

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -61,6 +61,8 @@ The above will create a new Hugo site in a folder named `quickstart`.
 
 See [themes.gohugo.io](https://themes.gohugo.io/) for a list of themes to consider. This quickstart uses the beautiful [Ananke theme](https://themes.gohugo.io/gohugo-theme-ananke/).
 
+First download the theme from Github and add it to your site's `theme` directory:
+
 ```bash
 cd quickstart
 
@@ -74,7 +76,11 @@ git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/anan
 #   - Extract that .zip file to get a "gohugo-theme-ananke-master" directory.
 #   - Rename that directory to "ananke", and move it into the "themes/" directory.
 # End of note for non-git users.
+```
 
+Then, add the theme to the site configuration:
+
+```bash
 # Edit your config.toml configuration file
 # and add the Ananke theme.
 echo 'theme = "ananke"' >> config.toml


### PR DESCRIPTION
When going through the quickstart, I missed the step where you add the theme to config.toml because it's in the same code block as the instructions for downloading the theme. I propose splitting the two steps into separate code blocks.