### PR TITLE
Fix link in rss.md

### DIFF
--- a/content/en/templates/rss.md
+++ b/content/en/templates/rss.md
@@ -29,7 +29,7 @@ RSS pages are of the type `Page` and have all the [page variables](/variables/pa
 
 ### Section RSS
 
-A [section’s][section] RSS will be rendered at `/<SECTION>/index.xml` (e.g., https://spf13.com/project/index.xml).
+A [section’s][section] RSS will be rendered at `/<SECTION>/index.xml` (e.g., [https://spf13.com/project/index.xml](https://spf13.com/project/index.xml)).
 
 Hugo provides the ability for you to define any RSS type you wish and can have different RSS files for each section and taxonomy.
 


### PR DESCRIPTION
Hi,
There is currently a problem with the html rendering. 

A doc link in `bla bla bla (there is a http://example.com).` would redirect to ` http://example.com)`.

I saw this in https://gohugo.io/templates/rss/#section-rss 

So this just a little fix while I don't know how to fix the md->html rendering in itself.

