### PR TITLE
Update TOC page to consider Goldmark capabilities for configuring heading levels

### DIFF
--- a/content/en/content-management/toc.md
+++ b/content/en/content-management/toc.md
@@ -18,7 +18,11 @@ toc: true
 ---
 
 {{% note "TOC Heading Levels are Fixed" %}}
-Currently, the `{{.TableOfContents}}` [page variable](/variables/page/) does not allow you to specify which heading levels you want the TOC to render. [See the related GitHub discussion (#1778)](https://github.com/gohugoio/hugo/issues/1778). As such, the resulting `<nav id="TableOfContents"><ul></ul></nav>` is going to start at `<h1>` when pulling from `{{.Content}}`.
+
+Previously, there was no out-of-the-box way to specify which heading levels you want the TOC to render. [See the related GitHub discussion (#1778)](https://github.com/gohugoio/hugo/issues/1778). As such, the resulting `<nav id="TableOfContents"><ul></ul></nav>` was going to start at `<h1>` when pulling from `{{.Content}}`.
+
+Hugo [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0) made a switch to [Goldmark](https://github.com/yuin/goldmark/) as the default library for Markdown which has improved and configurable implementation of TOC. Take a look at [how to configure TOC](/getting-started/configuration-markup/#table-of-contents) for Goldmark renderer.
+
 {{% /note %}}
 
 ## Usage

--- a/content/en/content-management/toc.md
+++ b/content/en/content-management/toc.md
@@ -47,7 +47,7 @@ A collection of textile samples lay spread out on the table - Samsa was a travel
 
 Hugo will take this Markdown and create a table of contents from `## Introduction`, `## My Heading`, and `### My Subheading` and then store it in the [page variable][pagevars]`.TableOfContents`.
 
-The built-in `.TableOfContents` variables outputs a `<nav id="TableOfContents">` element with a child `<ul>`, whose child `<li>` elements begin with any `<h1>`'s (i.e., `#` in markdown) inside your content.'
+The built-in `.TableOfContents` variables outputs a `<nav id="TableOfContents">` element with a child `<ul>`, whose child `<li>` elements begin with appropriate HTML headings. See [the available settings](/getting-started/configuration-markup/#table-of-contents) to configure what heading levels you want to include in TOC.
 
 {{% note "Table of contents not available for MMark" %}}
 Hugo documents created in the [MMark](/content-management/formats/#mmark) Markdown dialect do not currently display TOCs. TOCs are, however, compatible with all other supported Markdown formats.


### PR DESCRIPTION
Hi, I've noticed that [Table of Contents documentation page](https://gohugo.io/content-management/toc/) is a bit outdated. It doesn't mention that [v0.60.0](https://gohugo.io/news/0.60.0-relnotes/) introduced [Goldmark](https://gohugo.io/getting-started/configuration-markup/#goldmark) as the default markdown handler in Hugo.

This is my attempt to fill in these minor gaps.

I'm not sure if you want to delete the old note on TOC headings or not, but I left it (and changed a bit) to clearly specify that TOC configuration has become available very recently, and to not loose the link to [useful GitHub discussion](https://github.com/gohugoio/hugo/issues/1778).