### PR TITLE
Format URL

### DIFF
--- a/content/en/templates/rss.md
+++ b/content/en/templates/rss.md
@@ -29,7 +29,7 @@ RSS pages are of the type `Page` and have all the [page variables](/variables/pa
 
 ### Section RSS
 
-A [section’s][section] RSS will be rendered at `/<SECTION>/index.xml` (e.g., https://spf13.com/project/index.xml).
+A [section’s][section] RSS will be rendered at `/<SECTION>/index.xml` (e.g., `https://spf13.com/project/index.xml`).
 
 Hugo provides the ability for you to define any RSS type you wish and can have different RSS files for each section and taxonomy.
 


### PR DESCRIPTION
Per https://discourse.gohugo.io/t/typo-error-on-templates-rss-section-rss/22267?u=maiki, the ending parentheses renders the URL incorrectly.