### PR TITLE
change cache assets default example to 1 year

### DIFF
--- a/content/en/hosting-and-deployment/hugo-deploy.md
+++ b/content/en/hosting-and-deployment/hugo-deploy.md
@@ -90,14 +90,14 @@ cloudFrontDistributionID = <ID>
 # Samples:
 
 [[deployment.matchers]]
-#  Cache static assets for 20 years.
+#  Cache static assets for 1 year.
 pattern = "^.+\\.(js|css|svg|ttf)$"
-cacheControl = "max-age=630720000, no-transform, public"
+cacheControl = "max-age=31536000, no-transform, public"
 gzip = true
 
 [[deployment.matchers]]
 pattern = "^.+\\.(png|jpg)$"
-cacheControl = "max-age=630720000, no-transform, public"
+cacheControl = "max-age=31536000, no-transform, public"
 gzip = false
 
 [[deployment.matchers]]


### PR DESCRIPTION
Why a year?
The short answer is, the protocol doesn’t allow any value longer than a year. In the absence of a “cache this asset forever” header, a year is the longest possible time we can cache for.

REF: https://ashton.codes/set-cache-control-max-age-1-year/