### PR TITLE
Exif docs corrections

### DIFF
--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -98,6 +98,7 @@ Tags:
 {{ range $k, $v := .Tags }}
 TAG: {{ $k }}: {{ $v }}
 {{ end }}
+{{ end }}
 ```
 
 #### Exif fields

--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -102,7 +102,7 @@ TAG: {{ $k }}: {{ $v }}
 
 #### Exif fields
 
-Data
+Date
 : "photo taken" date/time
 
 Lat


### PR DESCRIPTION
This pull request fixes 2 minor issues on "Image Processing" page:

- a mismatch between the number of block opening and closing statements which leads to compilation error if you grab that example and try to run it unmodified. It has "with" and it also has "range", so I believe that two {{ end }} statements would make that example more concise and novice-friendly
- a typo
