### PR TITLE
Remove mention of Amber and Ace

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -43,7 +43,7 @@ sections:
     link: templates/
     color_classes: bg-primary-color-light black
     image: /images/home-page-templating-example.png
-    copy: "Hugo's Go-based templating provides just the right amount of logic to build anything from the simple to complex. If you prefer Jade/Pug-like syntax, you can also use Amber, Ace, or any combination of the three."
+    copy: "Hugo's Go-based templating provides just the right amount of logic to build anything from the simple to complex."
 ---
 
 Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again.


### PR DESCRIPTION
Amber and Ace are deprecated and soon to be removed from the next version. There's no need to advertise a feature that's going away.