### PR TITLE
Change incorrect MIME type from image/jpg to image/jpeg

### DIFF
--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -17,7 +17,7 @@ menu:
 ## Properties
 
 ResourceType
-: The main type of the resource. For example, a file of MIME type `image/jpg` has the ResourceType `image`.
+: The main type of the resource. For example, a file of MIME type `image/jpeg` has the ResourceType `image`.
 
 Name
 : Default value is the filename (relative to the owning page). Can be set in front matter.
@@ -35,7 +35,7 @@ Content
 : The content of the resource itself. For most resources, this returns a string with the contents of the file. This can be used to inline some resources, such as `<script>{{ (.Resources.GetMatch "myscript.js").Content | safeJS }}</script>` or `<img src="{{ (.Resources.GetMatch "mylogo.png").Content | base64Encode }}">`.
 
 MediaType
-: The MIME type of the resource, such as `image/jpg`.
+: The MIME type of the resource, such as `image/jpeg`.
 
 MediaType.MainType
 : The main type of the resource's MIME type. For example, a file of MIME type `application/pdf` has for MainType `application`.

--- a/data/docs.json
+++ b/data/docs.json
@@ -1501,8 +1501,8 @@
         ]
       },
       {
-        "type": "image/jpg",
-        "string": "image/jpg",
+        "type": "image/jpeg",
+        "string": "image/jpeg",
         "mainType": "image",
         "subType": "jpg",
         "delimiter": ".",


### PR DESCRIPTION
According to multiple sources, both official ([IANA](https://www.iana.org/assignments/media-types/media-types.xhtml#image) and [RFC2046](https://tools.ietf.org/html/rfc2046)) and otherwise (eg, [Wikipedia](https://en.wikipedia.org/wiki/JPEG) and [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)), the official MIME type for JPEG images is `image/jpeg`, not `image/jpg`.  Change Hugo docs to match.

Note: Hugo itself may need to change: I did a quick grep of Hugo's source code, but did not find anything that looked relevant.