### PR TITLE
Added remarks about additional parameters in ref/relref

### DIFF
--- a/content/en/functions/ref.md
+++ b/content/en/functions/ref.md
@@ -5,7 +5,7 @@ description: Looks up a content page by logical name.
 godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
-lastmod: 2017-02-01
+lastmod: 2019-12-28
 categories: [functions]
 menu:
   docs:
@@ -28,6 +28,12 @@ aliases: []
 {{% note "Usage Note" %}}
 `ref` looks up Hugo "Regular Pages" only. It can't be used for the homepage, section pages, etc.
 {{% /note %}}
+
+It is also possible to pass a additional arguments to link to another language or an alternative output format. Therefore, pass a mao of arguments instead of just the path. 
+
+``` 
+{{ ref . (dict "path" "about.md" "lang" "ja" "outputFormat" "rss") }} 
+```
 
 These functions are used in two of Hugo's built-in shortcodes. You can see basic usage examples of both `ref` and `relref` in the [shortcode documentation](/content-management/shortcodes/#ref-and-relref).
 

--- a/content/en/functions/ref.md
+++ b/content/en/functions/ref.md
@@ -29,7 +29,7 @@ aliases: []
 `ref` looks up Hugo "Regular Pages" only. It can't be used for the homepage, section pages, etc.
 {{% /note %}}
 
-It is also possible to pass a additional arguments to link to another language or an alternative output format. Therefore, pass a mao of arguments instead of just the path. 
+It is also possible to pass additional arguments to link to another language or an alternative output format. Therefore, pass a map of arguments instead of just the path.
 
 ``` 
 {{ ref . (dict "path" "about.md" "lang" "ja" "outputFormat" "rss") }} 

--- a/content/en/functions/relref.md
+++ b/content/en/functions/relref.md
@@ -5,7 +5,7 @@ description: Looks up a content page by relative path.
 godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
-lastmod: 2017-02-01
+lastmod: 2019-12-28
 categories: [functions]
 menu:
   docs:
@@ -28,6 +28,12 @@ aliases: []
 {{% note "Usage Note" %}}
 `relref` looks up Hugo "Regular Pages" only. It can't be used for the homepage, section pages, etc.
 {{% /note %}}
+
+It is also possible to pass additional arguments to link to another language or an alternative output format. Therefore, pass a map of arguments instead of just the path. 
+
+``` 
+{{ relref . (dict "path" "about.md" "lang" "ja" "outputFormat" "rss") }}
+```
 
 These functions are used in two of Hugo's built-in shortcodes. You can see basic usage examples of both `ref` and `relref` in the [shortcode documentation](/content-management/shortcodes/#ref-and-relref).
 


### PR DESCRIPTION
It is possible to pass additional parameters to the `ref` and `relref` functions to determine the language and output format of the document linked to, as described in the [Links and Cross References](https://gohugo.io/content-management/cross-references/#use-ref-and-relref) docs.

I added this information to the documentation of the two functions to make it easier to find if someone needs this features in templates (as I did).

The arguments that can be passed to `ref`/`relref` are defined in the [`refArgs`](https://github.com/gohugoio/hugo/blob/b5f39d23b86f9cb83c51da9fe4abb4c19c01c3b7/hugolib/page__ref.go#L113) struct.