### PR TITLE
Correct hyperlink for 'markdownify' function

### DIFF
--- a/content/en/functions/RenderString.md
+++ b/content/en/functions/RenderString.md
@@ -36,4 +36,4 @@ Some examples:
 ```
 
 
-**Note** that this method is more powerful than the similar [markdownify](functions/markdownify/) function as it also supports [Render Hooks](/getting-started/configuration-markup/#markdown-render-hooks) and it has options to render other markup formats.
+**Note** that this method is more powerful than the similar [markdownify](/functions/markdownify/) function as it also supports [Render Hooks](/getting-started/configuration-markup/#markdown-render-hooks) and it has options to render other markup formats.


### PR DESCRIPTION
### Changes
added a slash '/', so that link is referenced from root of the domain and not current page

### Previously
```
**Note** that this method is more powerful than the similar [markdownify](functions/markdownify/) function as it also supports [Render Hooks](/getting-started/configuration-markup/#markdown-render-hooks) and it has options to render other markup formats.
```
### Now
```
**Note** that this method is more powerful than the similar [markdownify](/functions/markdownify/) function as it also supports [Render Hooks](/getting-started/configuration-markup/#markdown-render-hooks) and it has options to render other markup formats.
```