### PR TITLE
show 'description' when hovered on function nav link

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-docs.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-docs.html
@@ -10,7 +10,7 @@
         <ul class="{{ .Identifier }} desktopmenu animated fadeIn list pl0 bg-light-gray{{if $currentPage.HasMenuCurrent "docs" . }} db{{ else }} dn{{ end }}">
           {{- range .Children }}
           <li class="f6 fw4">
-            <a href="{{.URL}}" class="db link hover-bg-gray hover-white pl3 pr2 pv2 {{if $currentPage.IsMenuCurrent "docs" . }}primary-color {{ else }}black {{end}}">
+            <a href="{{.URL}}" class="db link hover-bg-gray hover-white pl3 pr2 pv2 {{if $currentPage.IsMenuCurrent "docs" . }}primary-color {{ else }}black {{end}}"{{if .Page.Description}} title="{{.Page.Description}}"{{end}}>
               {{ .Name }}
             </a>
           </li>


### PR DESCRIPTION
### Changes
Added `title` attribute with function's description as its value, so that user hovering an entry of a function in sidebar (nav links) sees the function's short description. Attribute is added to `<a>` tag, alternatively it could be added to `<li>` tag too; though it wouldn't make any major difference. Closes #999.
### Previously
```
line 13
            <a href="{{.URL}}" class="db link hover-bg-gray hover-white pl3 pr2 pv2 {{if $currentPage.IsMenuCurrent "docs" . }}primary-color {{ else }}black {{end}}">
```
### Now
```
line 13
            <a href="{{.URL}}" class="db link hover-bg-gray hover-white pl3 pr2 pv2 {{if $currentPage.IsMenuCurrent "docs" . }}primary-color {{ else }}black {{end}}"{{if .Page.Description}} title="{{.Page.Description}}"{{end}}>
```