### PR TITLE
Improve documentation on slug behavior

### DIFF
--- a/content/en/content-management/organization/index.md
+++ b/content/en/content-management/organization/index.md
@@ -173,7 +173,7 @@ When defined in the front matter, the `slug` can take the place of the filename 
 
 {{< code file="content/posts/old-post.md" >}}
 ---
-title: New Post
+title: A new post with the filename old-post.md
 slug: "new-post"
 ---
 {{< /code >}}


### PR DESCRIPTION
Slug takes the place of the filename for the path — but the example was somewhat confusing because the title and the slug are the same. Having a different title that points out the filename makes it clear that the slug isn't related to title, but rather filename.