### PR TITLE
Add note to List Templates about .GroupByParamDate not working

### DIFF
--- a/content/en/templates/lists.md
+++ b/content/en/templates/lists.md
@@ -457,6 +457,10 @@ In the above example, you may want `{{.Title}}` to point the `title` field you h
 
 ### By Page Parameter in Date Format
 
+{{% note %}}
+This feature currently [does not work](https://github.com/gohugoio/hugo/issues/3983).
+{{% /note %}}
+
 The following template takes grouping by `date` a step further and uses Go's layout string. See the [`Format` function][] for more examples of how to use Go's layout string to format dates in Hugo.
 
 {{< code file="layouts/partials/by-page-param-as-date.html" >}}


### PR DESCRIPTION
This should prevent users from [wasting](https://discourse.gohugo.io/t/solved-groupbyparamdate-produces-runtime-error-index-out-of-range/10668) their [time](https://discourse.gohugo.io/t/sorting-by-a-date-param/20755) on an unimplemented feature. I didn't get to work with TOML frontmatter either, but that's beside the point as YAML frontmatter is far more common on the web.