### PR TITLE
Update author docs

### DIFF
--- a/content/en/getting-started/code-toggle.md
+++ b/content/en/getting-started/code-toggle.md
@@ -30,12 +30,13 @@ permalinks:
   posts: /:year/:month/:title/
 params:
   Subtitle: "Hugo is Absurdly Fast!"
-  AuthorName: "Jon Doe"
   GitHubUser: "spf13"
   ListOfFoo:
     - "foo1"
     - "foo2"
   SidebarRecentLimit: 5
+Author:
+  name: "Jon Doe"
 {{< /code-toggle >}}
 
 ## Another Config Toggler!

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -326,6 +326,9 @@ params:
     - "foo1"
     - "foo2"
   SidebarRecentLimit: 5
+Author:
+  name: "Jon Doe"
+  email: "jondoe@example.com"
 {{< /code-toggle >}}
 
 ## Configure with Environment Variables

--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -129,6 +129,8 @@ Hugo's Open Graph template is configured using a mix of configuration variables 
   description = "Text about my cool site"
 [taxonomies]
   series = "series"
+[Social]
+  facebook = "website-facebook-profile"
 {{</ code-toggle >}}
 
 {{< code-toggle file="content/blog/my-post" >}}
@@ -151,6 +153,7 @@ Various optional metadata can also be set:
 - `audio` and `videos` are URL arrays like `images` for the audio and video metadata tags, respectively.
 - The first 6 `tags` on the page are used for the tags metadata.
 - The `series` taxonomy is used to specify related "see also" pages by placing them in the same series.
+- `publisher` is set to the `.Site.Social.facebook` value, and could correspond to a Facebook page for your website.
 
 If using YouTube this will produce a og:video tag like `<meta property="og:video" content="url">`. If using a YouTube link make sure this is in **https://www.youtube.com/v/NlXVWtgLNjY** not __https://www.youtube.com/watch?v=NlXVWtgLNjY__
 

--- a/content/en/templates/rss.md
+++ b/content/en/templates/rss.md
@@ -49,9 +49,12 @@ The following values will also be included in the RSS output if specified in you
 languageCode = "en-us"
 copyright = "This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License."
 
-[author]
+[Author]
     name = "My Name Here"
+    email = "myemailaddress@example.com"
 ```
+
+To include an author's name in RSS output, you must have the `email` key set.
 
 ## The Embedded rss.xml
 

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -110,7 +110,7 @@ baseURL = "https://yoursite.example.com/"
 
 [params]
   description = "Tesla's Awesome Hugo Site"
-  author = "Nikola Tesla"
+  famousPerson = "Nikola Tesla"
 {{</ code-toggle >}}
 
 You can use `.Site.Params` in a [partial template](/templates/partials/) to call the default site description:


### PR DESCRIPTION
RSS template specifies that it needs the author name and email as keys, so this updates other relevant docs to reflect that.

This leaves out the "Authors" stuff I did in my other push to hugo base...

Additionally, one demo suggested users should put their "author" line under params, but that fails to make it show up via the site variable ".Site.Author" - which, incidentally, is described on the same page.