### PR TITLE
Handle corner case with rendering text as code in URL

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -134,7 +134,7 @@ PlainText
 Here is a code example for how the render-link.html template could look:
 
 {{< code file="layouts/_default/_markup/render-link.html" >}}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>
 {{< /code >}}
 
 #### Image Markdown example:


### PR DESCRIPTION
Without `| safeHTML` for `[`hrefTargetBlank`](http://example.com/hugo-docs) doesn't work`
links text it is rendered verbatimly as `<code>hrefTargetBlank</code>`. After my change it
would use default styling for code.

Btw, I'm new to Hugo, so please let me know if it brings any negative implications or is broken in some other cases for some reason.