### PR TITLE
Adding a commercial search service

### DIFF
--- a/content/en/tools/search.md
+++ b/content/en/tools/search.md
@@ -31,3 +31,4 @@ A static website with a dynamic search function? Yes, Hugo provides an alternati
 
 * [Algolia](https://www.algolia.com/)'s Search API makes it easy to deliver a great search experience in your apps and websites. Algolia Search provides hosted full-text, numerical, faceted, and geolocalized search.
 * [Bonsai](https://www.bonsai.io) is a fully-managed hosted Elasticsearch service that is fast, reliable, and simple to set up. Easily ingest your docs from Hugo into Elasticsearch following [this guide from the docs](https://docs.bonsai.io/docs/hugo).
+* [ExpertRec](https://www.expertrec.com/) is a hosted search-as-a-service solution that is fast and scalable. Set-up and integration is extremely easy and takes only a few minutes. The search settings can be modified without coding using a dashboard.


### PR DESCRIPTION
Adding ExpertRec site searce service to the list of Commercial search services. It is an alternative to Algolia's API based solution.