### PR TITLE
Don't set GOPATH when building from source

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -305,9 +305,6 @@ Make the directory containing the source your working directory and then fetch H
 mkdir -p src/github.com/gohugoio
 ln -sf $(pwd) src/github.com/gohugoio/hugo
 
-# set the build path for Go
-export GOPATH=$(pwd)
-
 go get
 ```
 


### PR DESCRIPTION
Now that go.mod exists, setting GOPATH to the root of the Hugo source results in commands like "go get" giving the error "$GOPATH/go.mod exists but should not". Hugo should now be built outside the GOPATH.