### PR TITLE
Add link to safeHTML function

### DIFF
--- a/content/en/templates/introduction.md
+++ b/content/en/templates/introduction.md
@@ -389,6 +389,8 @@ By default, Go Templates remove HTML comments from output. This has the unfortun
 {{ "<![endif]-->" | safeHTML }}
 ```
 
+This example uses the [`safeHTML` function][safehtml].
+
 Alternatively, you can use the backtick (`` ` ``) to quote the IE conditional comments, avoiding the tedious task of escaping every double quotes (`"`) inside, as demonstrated in the [examples](https://golang.org/pkg/text/template/#hdr-Examples) in the Go text/template documentation:
 
 ```go-html-template


### PR DESCRIPTION
Section #ie-conditional-comments is the first one on this page to mention the safeHTML function.

However, it doesn't explain what the safeHTML function actually does.

Therefore I think it should have a link to the safeHTML page.

The much later section #use-site-configuration-parameters already contains a link to the safeHTML page, but I think having that link on the first occurrence is more useful.