### PR TITLE
Remove broken link on "where" page

### DIFF
--- a/content/en/functions/where.md
+++ b/content/en/functions/where.md
@@ -114,7 +114,7 @@ You can also put the returned value of the `where` clauses into a variable:
 
 ## Use `where` with `first`
 
-Using `first` and [`where`][wherefunction] together can be very
+Using `first` and `where` together can be very
 powerful. Below snippet gets a list of posts only from [**main
 sections**](#mainsections), sorts it using the [default
 ordering](/templates/lists/) for lists (i.e., `weight => date`), and


### PR DESCRIPTION
The link "[wherefunction]" was not defined, so the square brackets where visible on the rendered page.
![image](https://user-images.githubusercontent.com/10100202/76793390-40b45600-67c5-11ea-847f-86a9746e144c.png)

It seems that this link would have just gone back to the top of the page, so I removed it instead of fixing it.