### PR TITLE
Update configuration-markup.md (security) 

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -134,7 +134,7 @@ PlainText
 Here is a code example for how the render-link.html template could look:
 
 {{< code file="layouts/_default/_markup/render-link.html" >}}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>
 {{< /code >}}
 
 #### Image Markdown example:


### PR DESCRIPTION
Links with `target="_blank"` should also have `rel="noopener noreferrer"` attribute to keep users safe. I think it's good to include this because it seems like there are many Hugo sites who use this code snippet and they don't seem to be aware of this vulnerability.

More info: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/