### PR TITLE
Fix typo on "where" page

### DIFF
--- a/content/en/functions/where.md
+++ b/content/en/functions/where.md
@@ -138,7 +138,7 @@ You can also nest `where` clauses to drill down on lists of content by more than
 
 Filtering only works for set fields. To check whether a field is set or exists, you can use the operand `nil`.
 
-This can be useful to filter a small amount of pages from a large pool. Instead of set field on all pages, you can set field on required pages only.
+This can be useful to filter a small amount of pages from a large pool. Instead of setting a field on all pages, you can set that field on required pages only.
 
 Only the following operators are available for `nil`
 


### PR DESCRIPTION
The phrase "Instead of set field on all pages, you can set field on required pages only." seems to be grammatically incorrect.

I have changed it to: "Instead of setting a field on all pages, you can set that field on required pages only."