### PR TITLE
No need for type="text/javascript"

### DIFF
--- a/content/en/hugo-pipes/fingerprint.md
+++ b/content/en/hugo-pipes/fingerprint.md
@@ -25,5 +25,5 @@ Any so processed asset will bear a `.Data.Integrity` property containing an inte
 ```go-html-template
 {{ $js := resources.Get "js/global.js" }}
 {{ $secureJS := $js | resources.Fingerprint "sha512" }}
-<script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+<script src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
 ```


### PR DESCRIPTION
This is a small change to the script tag in the example. There is no longer a need to include the `type` attribute on the `script` tag. Saves a couple of bytes and is generally good practice these days.