### PR TITLE
Update install guide with Scoop extended

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -86,6 +86,12 @@ If you are on a Windows machine and use [Scoop][] for package management, you ca
 scoop install hugo
 ```
 
+Or install the extended version with:
+
+```bash
+scoop install hugo-extended
+```
+
 ### Source
 
 #### Prerequisite Tools


### PR DESCRIPTION
Add instructions on how to install the extended version on Windows with Scoop pkg manager.