### PR TITLE
Update documentation for Ugly URLs

### DIFF
--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -202,7 +202,7 @@ content/posts/post-1.md
 
 ## Ugly URLs
 
-If you would like to have what are often referred to as "ugly URLs" (e.g., example.com/urls.html), set `uglyurls = true` or `uglyurls: true` in your site's `config.toml` or `config.yaml`, respectively. You can also use set the `HUGO_UGLYURLS` environment variable to `true` when running `hugo` or `hugo server`.
+If you would like to have what are often referred to as "ugly URLs" (e.g., example.com/urls.html), set `uglyurls = true` or `uglyurls: true` in your site's `config.toml` or `config.yaml`, respectively. You can also set the `HUGO_UGLYURLS` environment variable to `true` when running `hugo` or `hugo server`.
 
 If you want a specific piece of content to have an exact URL, you can specify this in the [front matter][] under the `url` key. The following are examples of the same content directory and what the eventual URL structure will be when Hugo runs with its default behavior.
 


### PR DESCRIPTION
Update documentation to replace the CLI-Argument with an environment variable as the CLI-argument no longer exists. 

References:
- gohugoio/hugo#4343
- https://gohugo.io/getting-started/configuration/#configure-with-environment-variables