### PR TITLE
Mark .Page.UniqueID as deprecated and add .File.UniqueID

### DIFF
--- a/content/en/variables/files.md
+++ b/content/en/variables/files.md
@@ -39,7 +39,6 @@ The `.File` object contains the following fields:
 .File.BaseFileName
 : the filename without extension (e.g., `foo.en`)
 
-
 .File.Ext
 : the file extension of the content file (e.g., `md`); this can also be called using `.File.Extension` as well. Note that it is *only* the extension without `.`.
 
@@ -48,5 +47,8 @@ The `.File` object contains the following fields:
 
 .File.Dir
 : given the path `content/posts/dir1/dir2/`, the relative directory path of the content file will be returned (e.g., `posts/dir1/dir2/`). Note that the path separator (`\` or `/`) could be dependent on the operating system.
+
+.File.UniqueID
+: the MD5-checksum of the content file's path.
 
 [Multilingual]: /content-management/multilingual/

--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -179,8 +179,8 @@ http://remarkjs.com)
 .Type
 : the [content type](/content-management/types/) of the content (e.g., `posts`).
 
-.UniqueID
-: the MD5-checksum of the content file's path.
+.UniqueID (deprecated)
+: the MD5-checksum of the content file's path. This variable is deprecated and will be removed, use `.File.UniqueID` instead.
 
 .Weight
 : assigned weight (in the front matter) to this content, used in sorting.


### PR DESCRIPTION
Just went to the docs to discover `.Page.UniqueID` and got this warning when using it:

```
WARN 2020/04/12 10:11:37 Page.UniqueID is deprecated and will be removed in a future release. Use .File.UniqueID
```

I didn't see this reflected anywhere in the docs, so here it is. :)