### PR TITLE
Mentioning a range is equivalent to foreach

### DIFF
--- a/content/en/functions/range.md
+++ b/content/en/functions/range.md
@@ -20,6 +20,6 @@ draft: false
 aliases: []
 ---
 
-Just like in the Go programming language, Go and Hugo templates make heavy use of `range` to iterate over a map, array or slice.
+Just like in the Go programming language, Go and Hugo templates make heavy use of `range` to iterate over a map, array or slice. Other templating languages use a foreach for the equivelant functionality.
 
 `range` is fundamental to templating in Hugo. (See the [Introduction to Hugo Templates](/templates/introduction/) for more examples.)

--- a/content/en/functions/range.md
+++ b/content/en/functions/range.md
@@ -20,6 +20,6 @@ draft: false
 aliases: []
 ---
 
-Just like in the Go programming language, Go and Hugo templates make heavy use of `range` to iterate over a map, array or slice. Other templating languages use a foreach for the equivelant functionality.
+Just like in the Go programming language, Go and Hugo templates make heavy use of `range` to iterate over a map, array or slice. Other templating languages use a foreach for the equivalent functionality.
 
 `range` is fundamental to templating in Hugo. (See the [Introduction to Hugo Templates](/templates/introduction/) for more examples.)


### PR DESCRIPTION
I’m new to Go and really struggled to find this. I added this sentence so it would be searchable for other people to find. At the moment, searching for a foreach doesn’t return range and IMHO it should.

I suspect there are other places that could benefit from this.

Another idea, further down the line would be a table showing the equivalents in other templating languages such as liquid. This would make transition from Jekyll much simpler for me.