### PR TITLE
docs(content-management): display page bundles image

### DIFF
--- a/content/en/content-management/organization/index.md
+++ b/content/en/content-management/organization/index.md
@@ -23,9 +23,9 @@ Hugo `0.32` announced page-relative images and other resources packaged into `Pa
 
 These terms are connected, and you also need to read about [Page Resources]({{< relref "/content-management/page-resources" >}}) and [Image Processing]({{< relref "/content-management/image-processing" >}}) to get the full picture.
 
-{{% imgproc 1-featured Resize "300x" %}}
+{{< imgproc 1-featured Resize "300x" >}}
 The illustration shows 3 bundles. Note that the home page bundle cannot contain other content pages, but other files (images etc.) are fine.
-{{% /imgproc %}}
+{{< /imgproc >}}
 
 
 {{% note %}}


### PR DESCRIPTION
I'm new to Hugo and going through the docs I found the image was missing:
<img width="566" alt="Screenshot 2020-04-23 at 11 19 30" src="https://user-images.githubusercontent.com/866808/80082525-cb226f00-8554-11ea-9fd5-e56435b9d456.png">

So I think this is the right fix:
<img width="560" alt="Screenshot 2020-04-23 at 11 20 06" src="https://user-images.githubusercontent.com/866808/80082517-c8277e80-8554-11ea-879b-9d06c8718429.png">

Fixes #1010
