### PR TITLE
Disambiguate global and page resources

### DIFF
--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -18,13 +18,22 @@ menu:
 
 The `image` is a [Page Resource]({{< relref "/content-management/page-resources" >}}), and the processing methods listed below does not work on images inside your `/static` folder.
 
-To get all images in a [Page Bundle]({{< relref "/content-management/organization#page-bundles" >}}):
+To print all images paths in a [Page Bundle]({{< relref "/content-management/organization#page-bundles" >}}):
 
 ```go-html-template
 {{ with .Resources.ByType "image" }}
+{{ range . }}
+{{ .RelPermalink }}
+{{ end }}
 {{ end }}
 
 ```
+
+## The Image Resource
+
+The `image` resource can also be retrieved from a [global resource]({{< relref "/hugo-pipes/introduction#from-file-to-resource" >}})
+
+{{- $image := resources.Get "images/logo.jpg" -}}
 
 ## Image Processing Methods
 

--- a/content/en/content-management/page-bundles.md
+++ b/content/en/content-management/page-bundles.md
@@ -73,6 +73,14 @@ my-post
 : This leaf bundle has the `index.md`, two other content
     Markdown files and two image files.
 
+image1
+: This image is a page resource of `my-post`
+    and only available in `my-post/index.md` resources.
+
+image2
+: This image is a page resource of `my-post`
+    and only available in `my-post/index.md` resources.
+
 my-other-post
 : This leaf bundle has only the `index.md`.
 

--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -14,6 +14,10 @@ menu:
     weight: 31
 ---
 
+Page resources are available for [page bundles]({{< relref "/content-management/page-bundles" >}}) only,
+i.e. a directory with either a `index.md`, or `_index.md` file at its root. Resources are only attached to
+the lowest page they are bundled with, and simple which names does not contain `index.md` are not attached any resource.
+
 ## Properties
 
 ResourceType


### PR DESCRIPTION
There are 2 different kind of resource, one that is attached
to the page, matching all non-rendered files, and the global
one matching all files in `/assets`. Although they have similar
behaviour, the way to access both of them are slightly different.

Explicitly express differences between both and clarify when a page
is attached resources and when not.