### PR TITLE
Add len function to navigation side menu

### DIFF
--- a/content/en/functions/len.md
+++ b/content/en/functions/len.md
@@ -7,6 +7,9 @@ date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-04-18
 categories: [functions]
+menu:
+  docs:
+    parent: "functions"
 keywords: []
 signature: ["len INPUT"]
 workson: [lists,taxonomies,terms]


### PR DESCRIPTION
Just a quick PR that fixes the front matter for the `len` function which was previously not appearing in the documentation side navigation menu.
This PR closes #1110 