### PR TITLE
Added where .RegularPagesRecursive was added

### DIFF
--- a/content/en/readfiles/pages-vs-site-pages.md
+++ b/content/en/readfiles/pages-vs-site-pages.md
@@ -26,8 +26,10 @@ the current _list_ page:
 : Collection of only _regular_ pages under the
     current _list_ page. This **excludes** regular pages in nested sections/_list_ pages (those are subdirectories with an `_index.md` file.
 
-`.RegularPagesRecursive`{{< new-in "0.68.0" >}}
+`.RegularPagesRecursive`
 : Collection of **all** _regular_ pages under a _list_ page. This **includes** regular pages in nested sections/_list_ pages.
+
+This feature was added in Hugo version 0.68.0
 
 Note
 : From the scope of _regular_ pages, `.Pages` and


### PR DESCRIPTION
Seems like there isn't a way to render shortcodes in a readfile.