### PR TITLE
Change shortcode delimiters around imgproc to fix page bundle image.

### DIFF
--- a/content/en/content-management/organization/index.md
+++ b/content/en/content-management/organization/index.md
@@ -23,9 +23,9 @@ Hugo `0.32` announced page-relative images and other resources packaged into `Pa
 
 These terms are connected, and you also need to read about [Page Resources]({{< relref "/content-management/page-resources" >}}) and [Image Processing]({{< relref "/content-management/image-processing" >}}) to get the full picture.
 
-{{% imgproc 1-featured Resize "300x" %}}
+{{< imgproc 1-featured Resize "300x" >}}
 The illustration shows 3 bundles. Note that the home page bundle cannot contain other content pages, but other files (images etc.) are fine.
-{{% /imgproc %}}
+{{< /imgproc >}}
 
 
 {{% note %}}


### PR DESCRIPTION
The image demonstrating the organization of page bundles under the [Page Bundles](https://gohugo.io/content-management/organization/#page-bundles) heading was displaying the caption as plain body text and missing the image itself.

It looks to me like `{{%` delimiters should be valid, but I wound up having to wrap with `{{<`.