### PR TITLE
Add an example of using front-matter

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -27,12 +27,12 @@ toc: true
 If a variable is defined in front matter of `report.md`, as
 ```
 --- 
-pdf: "energy.pdf"
+energydoc: "energy.pdf"
 ---
 ```
 then it can be accessed in `single.html` template as
 ```
-<a href={{ printf "/doc/%s" $.Params.pdf  }}> Download PDF </a>
+<a href="{{ printf '/doc/%s' .Params.energydoc }}"> Download PDF </a>
 ```
 
 ## Front Matter Formats

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -21,6 +21,20 @@ toc: true
 
 {{< youtube Yh2xKRJGff4 >}}
 
+
+## Front Matter Example
+
+If a variable is defined in front matter of `report.md`, as
+```
+--- 
+pdf: "energy.pdf"
+---
+```
+then it can be accessed in `single.html` template as
+```
+<a href={{ printf "/doc/%s" $.Params.pdf  }}> Download PDF </a>
+```
+
 ## Front Matter Formats
 
 Hugo supports four formats for front matter, each with their own identifying tokens.


### PR DESCRIPTION
Example by @rindolphus from https://discourse.gohugo.io/t/how-to-display-a-custome-page-variable/1557/10

I am evaluating Hugo and don't have anything generated yet. Please check that it
1. actually works and
2. is the best way


Also, is it true that the `pdf` can not be referenced from markdown itself? I can reference the var from template only, right?
