### PR TITLE
fix new post command directory

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -86,7 +86,7 @@ echo 'theme = "ananke"' >> config.toml
 You can manually create content files (for example as `content/<CATEGORY>/<FILE>.<FORMAT>`) and provide metadata in them, however you can use the `new` command to do few things for you (like add title and date):
 
 ```
-hugo new posts/my-first-post.md
+hugo new content/posts/my-first-post.md
 ```
 
 {{< asciicast eUojYCfRTZvkEiqc52fUsJRBR >}}


### PR DESCRIPTION
The quickstart says that hugo new posts/my-first-post.md is the command to create new posts but it wasn't working. I could see another person with the same problem here: https://stackoverflow.com/questions/51974423/hugo-posts-not-displaying. It seems that by default hugo is looking for posts in content/posts/ not posts/