### PR TITLE
Dynamic menu localisation with menu Identifier attribute

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -427,7 +427,7 @@ The rendering of the main navigation works as usual. `.Site.Menus` will just con
 ### Dynamically localizing menus with i18n
 While customizing menus per language is useful, your config file can become hard to maintain if you have a lot of languages
 
-If your menus are the same in all languages, and the only thing that changes is the actual translation, you can use the menu `.Identifier` as a translation key for the name of the the menu:
+If your menus are the same in all languages (ie. if the only thing that changes is the translated name) you can use the `.Identifier` as a translation key for the menu name:
 
 {{< code-toggle file="config" >}}
 [[menu.main]]

--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -425,7 +425,7 @@ The rendering of the main navigation works as usual. `.Site.Menus` will just con
 ```
 
 ### Dynamically localizing menus with i18n
-While customizing menus per language is useful, if you have a log of languages your config file can become hard to maintain. 
+While customizing menus per language is useful, your config file can become hard to maintain if you have a lot of languages
 
 If your menus are the same in all languages, and the only thing that changes is the actual translation, you can use the menu `.Identifier` as a translation key for the name of the the menu:
 

--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -424,6 +424,40 @@ The rendering of the main navigation works as usual. `.Site.Menus` will just con
 
 ```
 
+### Dynamically localizing menus with i18n
+While customizing menus per language is useful, if you have a log of languages your config file can become hard to maintain. 
+
+If your menus are the same in all languages, and the only thing that changes is the actual translation, you can use the menu `.Identifier` as a translation key for the name of the the menu:
+
+{{< code-toggle file="config" >}}
+[[menu.main]]
+name = "About me"
+url = "about"
+weight = 1
+identifier = "about"
+{{< /code-toggle >}}
+
+You now need to specify the translations for the menu keys in the i18n files:
+
+{{< code file="i18n/pt.toml" >}}
+[about]
+other="Sobre mim"
+{{< /code >}}
+
+And do the appropriate changes in the menu code to use the `i18n` tag with the `.Identifier` as a key. You will also note that here we are using a `default` to fall back to `.Name`, in case the `.Identifier` key is also not present in the language specified in the `defaultContentLanguage` configuration.
+
+{{< code file="layouts/partials/menu.html" >}}
+<ul>
+    {{- $currentPage := . -}}
+    {{ range .Site.Menus.main -}}
+    <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
+        <a href="{{ .URL | absLangURL }}">{{ i18n .Identifier | default .Name}}</a>
+    </li>
+    {{- end }}
+</ul>
+{{< /code >}}
+                
+
 ## Missing Translations
 
 If a string does not have a translation for the current language, Hugo will use the value from the default language. If no default value is set, an empty string will be shown.


### PR DESCRIPTION
I have struggled with menu localisation a bit. I don't want to configure the menu per language due to large number of languages. Also I want the translations of the menu to be in the `i18n` folder so it can be translated using common translation management tools.

Therefore I added this documentation that explains how to make a simple dynamic localisation using menu `identifiers` and `i18n`. 

PS: Sorry my english. Not my native language.

<img width="300" alt="Screenshot 2020-06-06 at 20 49 52" src="https://user-images.githubusercontent.com/5014629/83950985-4f942d00-a837-11ea-976d-990e7732a32d.png">
