### PR TITLE
Fix incorrect directory name in quick-start

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -58,7 +58,7 @@ The above will create a new Hugo site in a folder named `quickstart`.
 
 See [themes.gohugo.io](https://themes.gohugo.io/) for a list of themes to consider. This quickstart uses the beautiful [Ananke theme](https://themes.gohugo.io/gohugo-theme-ananke/).
 
-First, download the theme from GitHub and add it to your site's `theme` directory:
+First, download the theme from GitHub and add it to your site's `themes` directory:
 
 ```bash
 cd quickstart


### PR DESCRIPTION
Fixed a minor typo in quick-start guide. The name of the theme directory should be `themes` not `theme`.

Moved from https://github.com/gohugoio/hugo/pull/7399