### PR TITLE
more loving into last commit -> css fix of expanding code box in docs

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/assets/output/css/app.css
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/assets/output/css/app.css
@@ -4828,7 +4828,7 @@ pre {
   right: 50%;*/
   /*margin-left: -30vw;*/
   margin-right: -30vw;
-  max-width: 50vw;
+  max-width: 48vw;
   }
 }
 .code-block .line-numbers-rows {


### PR DESCRIPTION
on previous commit the max-width was set to 50vw, as a fix. With some viewport width this is not the perfect solution.
so I'm fixing this, so that in all viewport width the code box that expands on hover (.expand class) never overlaps the right-side navigation column.
my solution is this commit; setting `.expand` max-width to 48vw