### PR TITLE
Fix page kinds shortcode not rendering on Taxonomies page

### DIFF
--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -100,7 +100,7 @@ disableKinds = ["taxonomy","term"]
 
 {{< new-in "0.73.0" >}} We have fixed the before confusing page kinds used for taxonomies (see the listing below) to be in line with the terms used when we talk about taxonomies. We have been careful to avoid site breakage, and you should get an ERROR in the console if you need to adjust your `disableKinds` section.
 
-{{< page-kinds >}}
+{{% page-kinds %}}
 
 ### Default Destinations
 

--- a/layouts/shortcodes/page-kinds.html
+++ b/layouts/shortcodes/page-kinds.html
@@ -4,4 +4,4 @@
 | `page` | The landing page for a given page | `my-post` page (`/posts/my-post/index.html`) |
 | `section` | The landing page of a given section | `posts` section (`/posts/index.html`) |
 | `taxonomy` | The landing page for a taxonomy | `tags` taxonomy (`/tags/index.html`) |
-| `term ` | The landing page for one taxonomy's term | term `awesome` in `tags` taxonomy (`/tags/awesome/index.html`) |
+| `term` | The landing page for one taxonomy's term | term `awesome` in `tags` taxonomy (`/tags/awesome/index.html`) |


### PR DESCRIPTION
A small fix; I noticed that the table for page kinds in the taxonomies page was showing Markdown instead of rendering appropriately. I also removed a trailing space for `term` in the table.