### PR TITLE
Fix several 404 errors

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/showcase/single.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/showcase/single.html
@@ -95,7 +95,7 @@ Showcase: {{ .Title }}
         </a>
       </li>
     {{end}}
-    {{if ge $number_of_entries 20}}
+    {{if gt $number_of_entries 20}}
       <li class="mt3">
         <a href="/showcase/page/2/" class="link blue">
           See More &raquo;

--- a/content/en/functions/after.md
+++ b/content/en/functions/after.md
@@ -62,5 +62,5 @@ You can use `after` in combination with the [`first` function][] and Hugo's [pow
 
 [`first` function]: /functions/first/
 [list/section page]: /templates/section-templates/
-[lists]: /lists/
+[lists]: /templates/lists/#order-content
 [slice]: /functions/slice/

--- a/content/en/hosting-and-deployment/deployment-with-wercker.md
+++ b/content/en/hosting-and-deployment/deployment-with-wercker.md
@@ -289,8 +289,6 @@ Once this workflow is established, you can update your website automatically by 
 
 [The source code for the site used in this guide is available on GitHub][guidesource], as is the [Wercker Hugo Build step][guidestep].
 
-If you want to see an example of how you can deploy to S3 instead of GitHub pages, check [Wercker's documentation][werckerdocs] for guidance on setup.
-
 [1]: /images/hosting-and-deployment/deployment-with-wercker/creating-a-basic-hugo-site.png
 [2]: /images/hosting-and-deployment/deployment-with-wercker/adding-the-project-to-github.png
 [3]: /images/hosting-and-deployment/deployment-with-wercker/wercker-sign-up.png
@@ -321,4 +319,3 @@ If you want to see an example of how you can deploy to S3 instead of GitHub page
 [hugoconfig]: /getting-started/configuration/
 [publicappurl]: https://app.wercker.com/#applications/5586dcbdaf7de9c51b02b0d5
 [quickstart]: /getting-started/quick-start/
-[werckerdocs]: http://devcenter.wercker.com/docs/deploy/s3.html

--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -152,7 +152,7 @@ Various optional metadata can also be set:
 - The first 6 `tags` on the page are used for the tags metadata.
 - The `series` taxonomy is used to specify related "see also" pages by placing them in the same series.
 
-If using YouTube this will produce a og:video tag like `<meta property="og:video" content="url">`. If using a YouTube link make sure this is in **https://www.youtube.com/v/NlXVWtgLNjY** not __https://www.youtube.com/watch?v=NlXVWtgLNjY__
+If using YouTube this will produce a og:video tag like `<meta property="og:video" content="url">`. Use the `https://youtu.be/<id>` format with YouTube videos (example: `https://youtu.be/qtIqKaDlqXo`).
 
 ### Use the Open Graph Template
 

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -22,7 +22,7 @@ The following is a list of site-level (aka "global") variables. Many of these va
 
 ## Get the Site object from a partial
 
-All the methods below, e.g. `.Site.RegularPages` can also be reached via the global `site` function, e.g. `site.RegularPages`, which can be handy in partials where the `Page` object isn't easily available. {{< new-in "0.53.0" >}}.
+All the methods below, e.g. `.Site.RegularPages` can also be reached via the global `site` function, e.g. `site.RegularPages`, which can be handy in partials where the `Page` object isn't easily available. {{< new-in "0.53" >}}.
 
 ## Site Variables List
 


### PR DESCRIPTION
Closes #1161

I removed the paragraph related to Amazon S3 deployment from Wercker;
I was unable to find any documentation on the Wercker site. This is not
surprising. Wercker was acquired by Oracle in 2017, and I suspect Oracle
has little interest in promoting any of Amazon's services.