### PR TITLE
Correct possible typos re: Alias robots usage

### DIFF
--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -175,7 +175,7 @@ Assuming a `baseURL` of `example.com`, the contents of the auto-generated alias 
 </html>
 ```
 
-The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case. If an end user of your website goes to `https://example.com/posts/my-old-url`, they will now be automatically redirected to the newer, correct URL. The addition of `<meta name="robots" content="noindex">` lets search engine bots know that they should not index your old alias page, `https://example.com/posts/my-old-url/`.
+The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case. If an end user of your website goes to `https://example.com/posts/my-old-url`, they will now be automatically redirected to the newer, correct URL. The addition of `<meta name="robots" content="noindex">` lets search engine bots know that they should not index your alias page (`https://example.com/posts/my-old-url/`).
 
 ### Customize
 You may customize this alias page by creating an `alias.html` template in the

--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -175,7 +175,7 @@ Assuming a `baseURL` of `example.com`, the contents of the auto-generated alias 
 </html>
 ```
 
-The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case. If an end user of your website goes to `https://example.com/posts/my-old-url`, they will now be automatically redirected to the newer, correct URL. The addition of `<meta name="robots" content="noindex">` lets search engine bots know that they should not crawl and index your new alias page.
+The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case. If an end user of your website goes to `https://example.com/posts/my-old-url`, they will now be automatically redirected to the newer, correct URL. The addition of `<meta name="robots" content="noindex">` lets search engine bots know that they should not index your old alias page, `https://example.com/posts/my-old-url/`.
 
 ### Customize
 You may customize this alias page by creating an `alias.html` template in the


### PR DESCRIPTION
If the `<meta name="robots" content="noindex">` is on the old alias page, `https://example.com/posts/my-old-url/`, then the directive is informing the robot to not index the old page. I've updated this to clarify.

I also removed "crawl" as it implies using "no-index" tells a search engine bot crawl the page for additional links. Unless the `nofollow` directive is included search engine bots should still look through the page for links.

[Google's clarification on `robots` directives:](https://developers.google.com/search/reference/robots_meta_tag)
`noindex` = "Do not show this page in search results." 
`nofollow` = "Do not follow the links on this page."