### PR TITLE
Update 404 docs: GitLab auto-detects 404.html

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -46,7 +46,7 @@ This is a basic example of a 404.html template:
 
 Your 404.html file can be set to load automatically when a visitor enters a mistaken URL path, dependent upon the web serving environment you are using. For example:
 
-* [GitHub Pages](/hosting-and-deployment/hosting-on-github/). The 404 page is automatic.
+* [GitHub Pages](/hosting-and-deployment/hosting-on-github/) and [GitLab Pages](/hosting-and-deployment/hosting-on-gitlab/). The 404 page is automatic.
 * Apache. You can specify `ErrorDocument 404 /404.html` in an `.htaccess` file in the root of your site.
 * Nginx. You might specify `error_page 404 /404.html;` in your `nginx.conf` file.
 * Amazon AWS S3. When setting a bucket up for static web serving, you can specify the error file from within the S3 GUI.


### PR DESCRIPTION
Add information for deploying on GitLab Pages: GitLab also automatically serves 404.html when a 404 code is to be returned.