### PR TITLE
Change to the actual argument order of `resources.ExecuteAsTemplate`

### DIFF
--- a/content/en/hugo-pipes/resource-from-template.md
+++ b/content/en/hugo-pipes/resource-from-template.md
@@ -18,7 +18,7 @@ draft: false
 
 In order to use Hugo Pipes function on an asset file containing Go Template magic the function `resources.ExecuteAsTemplate` must be used.
 
-The function takes three arguments, the resource object, the resource target path and the template context.
+The function takes three arguments, the resource target path, the template context and the resource object.
 
 ```go-html-template
 // assets/sass/template.scss


### PR DESCRIPTION
I thought that the same order of arguments would be a little easier to understand.