### PR TITLE
Add a link to plausible-hugo module & theme component

### DIFF
--- a/content/en/tools/other.md
+++ b/content/en/tools/other.md
@@ -27,3 +27,4 @@ And for all the other small things around Hugo:
 * [Hugo SFTP Upload](https://github.com/thomasmey/HugoSftpUpload) Syncs the local build of your Hugo website with your remote webserver via SFTP.
 * [Emacs Easy Hugo](https://github.com/masasam/emacs-easy-hugo) Emacs package for writing blog posts in markdown or org-mode and building your site with Hugo.
 * [JAMStack Themes](https://jamstackthemes.dev/ssg/hugo/). JAMStack themes is a collection of site themes filterable by static site generator and supported CMS to help build CMS-connected sites using Hugo (linking to Hugo-specific themes).
+* [plausible-hugo](https://github.com/divinerites/plausible-hugo). Easy Hugo integration for Plausible Analytics, a simple, open-source, lightweight and privacy-friendly web analytics alternative to Google Analytics.


### PR DESCRIPTION
I submit a proposal following this question : https://discourse.gohugo.io/t/theme-component-for-plausible-io-integration/27345/2?u=divinerites

Feel free to discard if this theme component doesn't belongs here.