### PR TITLE
Fix Arch Linux installation command

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -477,7 +477,7 @@ This option is not recommended because the Hugo in Linux package managers for De
 You can also install Hugo from the Arch Linux [community](https://www.archlinux.org/packages/community/x86_64/hugo/) repository. Applies also to derivatives such as Manjaro.
 
 ```
-sudo pacman -Syu hugo
+sudo pacman -S hugo
 ```
 
 ### Fedora, Red Hat and CentOS


### PR DESCRIPTION
Running `sudo pacman -Syu hugo` starts a full system upgrade which I believe is not the intention here.

```
❯ sudo pacman -Syu hugo
[sudo] password for doron: 
:: Synchronizing package databases...
 core                                                                                                                         131.8 KiB   399 KiB/s 00:00 [##############################################################################################] 100%
 extra                                                                                                                       1663.7 KiB  1095 KiB/s 00:02 [##############################################################################################] 100%
 community                                                                                                                      5.1 MiB  3.15 MiB/s 00:02 [##############################################################################################] 100%
:: Starting full system upgrade...
...
```