### PR TITLE
js.Build: Add SourceMap flag into js.Build opts which can turn on sou…

### DIFF
--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -26,6 +26,11 @@ Note that the target path's extension may change if the target MIME type is diff
 minify [bool]
 : Let `js.Build` handle the minification.
 
+sourceMap [string, bool] {{< new-in "0.75-DEV" >}}
+: Let `js.Build` output sourceMap. Current only inline is supported. true defaults to inline.
+  One of: true, false, `inline`, `external`
+  Default is false
+
 target [string]
 : The language target.
   One of: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020` or `esnext`.

--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -26,10 +26,10 @@ Note that the target path's extension may change if the target MIME type is diff
 minify [bool]
 : Let `js.Build` handle the minification.
 
-sourceMap [string, bool] {{< new-in "0.75-DEV" >}}
-: Let `js.Build` output sourceMap. Current only inline is supported. true defaults to inline.
-  One of: true, false, `inline`, `external`
-  Default is false
+sourceMap [string] {{< new-in "0.75-DEV" >}}
+: Let `js.Build` output sourceMap. Current only inline is supported.
+  One of: "", `inline`, `external`
+  Default is ""
 
 target [string]
 : The language target.


### PR DESCRIPTION
Add documentation for sourceMap opt in js.Build. Comment on future external support.
Temporarily tagged with 0.75-DEV