### PR TITLE
Update quick-start.md: move notice about drafts up

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -102,6 +102,10 @@ draft: true
 
 ```
 
+{{% note %}}
+Drafts do not get deployed; once you finish a post, update the header of the post to say `draft: false`. More info [here](/getting-started/usage/#draft-future-and-expired-content).
+{{% /note %}}
+
 ## Step 5: Start the Hugo server
 
 Now, start the Hugo server with [drafts](/getting-started/usage/#draft-future-and-expired-content) enabled:
@@ -171,6 +175,3 @@ hugo -D
 
 Output will be in `./public/` directory by default (`-d`/`--destination` flag to change it, or set `publishdir` in the config file).
 
-{{% note %}}
-Drafts do not get deployed; once you finish a post, update the header of the post to say `draft: false`. More info [here](/getting-started/usage/#draft-future-and-expired-content).
-{{% /note %}}


### PR DESCRIPTION
If you instruct new users to create a site with a draft post and then tell them to run the server, it's confusing when they can't then see the post in question. The existing note explains why this happens, but not until the end of the quick start guide (at which point the user is expected to have run the server, customised their theme and built the site). It's unlikely that a user who's confused by the absence of the test post will progress this far.

Moving it up to the point at which users create the post and run the server means they're armed with an understanding of why they can't see their test post (rather than getting stuck before they make it to the explanation).

If you're keen to keep the existing explanation where it is, another option could be lampshade the absence of the test post in Step 5: "You may notice that the test post created in step 4. It's currently a `draft`. Let's make it visible in the test server by..."