### PR TITLE
Deploy Github Project Pages added section Setup Hugos Configuration D…

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -106,27 +106,27 @@ That's it! Your personal page should be up and running at `https://<USERNAME>.gi
 
 If you are using a custom domain you will not need to setup Hugo's Configuration Directory.  For a custom domain `baseURL = "/"`.
 
-Github Project Pages appends the project's repository name to the URL.  The URL format is: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
+GitHub Project Pages appends the project's repository name to the URL.  The URL format is: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
 
-Because of the addition of `<REPOSITORY-NAME>` to the http path, a different `baseURL` must set for Github Project Pages to render html correctly.  However `hugo serve` still needs the default `baseURL = "/"` in order to render local builds.
+Because of the addition of `<REPOSITORY-NAME>` to the http path, a different `baseURL` must be set for GitHub Project Pages to render html correctly.  However `hugo serve` still needs the default `baseURL = "/"` in order to render local builds.
 
-The easiest way to solve these two conditions is to setup [Hugo's Configuration Directory](https://gohugo.io/getting-started/configuration/#configuration-directory) to handle builds for the different environments: local vs Github Project Pages.  
+The easiest way to solve these two conditions is to setup [Hugo's Configuration Directory](https://gohugo.io/getting-started/configuration/#configuration-directory) to handle builds for the different environments: local vs GitHub Project Pages.  
 
 1. Create the directory `config/_default`
 1. Move config.toml from Hugo's root directory into  `config/_default`  
-1. Create the directory `config/GithubProjectPage`
-1. Create the file `config/GithubProjectPage/config.toml` which only requires one line of text:  `baseuURL =  "/<REPOSITORY-NAME>"`
+1. Create the directory `config/GitHubProjectPage`
+1. Create the file `config/GitHubProjectPage/config.toml` which only requires one line of text:  `baseuURL =  "/<REPOSITORY-NAME>"`
 
 ```unix
 config
-├── GithubProjectPage
+├── GitHubProjectPage
 │   └── config.toml  #baseURL = "/REPOSITORY-NAME"
 └── _default
     └── config.toml  #baseURL = "/"
 ```
 
 5. To test the Configuration Directory is setup correctly, build your local environment by running `hugo serve` and verify the html renders ok.
-6. To test the GithubProjectPage configuration run `hugo --environment GithubProjectPage`, push the build to Github, and view the Github Project Page at: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
+6. To test the GitHubProjectPage configuration run `hugo --environment GitHubProjectPage`, push the build to GitHub, and view the GitHub Project Page at: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
 
 ### Deployment of Project Pages from `/docs` folder on `master` branch
 

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -104,7 +104,9 @@ That's it! Your personal page should be up and running at `https://<USERNAME>.gi
 
 ### Setup Hugo's Configuration Directory
 
-Github Project Pages appends the project's repository name to the URL.  The format is: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
+If you are using a custom domain you will not need to setup Hugo's Configuration Directory.  For a custom domain `baseURL = "/"`.
+
+Github Project Pages appends the project's repository name to the URL.  The URL format is: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
 
 Because of the addition of `<REPOSITORY-NAME>` to the http path, a different `baseURL` must set for Github Project Pages to render html correctly.  However `hugo serve` still needs the default `baseURL = "/"` in order to render local builds.
 

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -102,9 +102,29 @@ That's it! Your personal page should be up and running at `https://<USERNAME>.gi
 
 ## GitHub Project Pages
 
-{{% note %}}
-Make sure your `baseURL` key-value in your [site configuration](/getting-started/configuration/) reflects the full URL of your GitHub pages repository if you're using the default GH Pages URL (e.g., `<USERNAME>.github.io/<PROJECT>/`) and not a custom domain.
-{{% /note %}}
+### Setup Hugo's Configuration Directory
+
+Github Project Pages appends the project's repository name to the URL.  The format is: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
+
+Because of the addition of `<REPOSITORY-NAME>` to the http path, a different `baseURL` must set for Github Project Pages to render html correctly.  However `hugo serve` still needs the default `baseURL = "/"` in order to render local builds.
+
+The easiest way to solve these two conditions is to setup [Hugo's Configuration Directory](https://gohugo.io/getting-started/configuration/#configuration-directory) to handle builds for the different environments: local vs Github Project Pages.  
+
+1. Create the directory `config/_default`
+1. Move config.toml from Hugo's root directory into  `config/_default`  
+1. Create the directory `config/GithubProjectPage`
+1. Create the file `config/GithubProjectPage/config.toml` which only requires one line of text:  `baseuURL =  "/<REPOSITORY-NAME>"`
+
+```unix
+config
+├── GithubProjectPage
+│   └── config.toml  #baseURL = "/REPOSITORY-NAME"
+└── _default
+    └── config.toml  #baseURL = "/"
+```
+
+5. To test the Configuration Directory is setup correctly, build your local environment by running `hugo serve` and verify the html renders ok.
+6. To test the GithubProjectPage configuration run `hugo --environment GithubProjectPage`, push the build to Github, and view the Github Project Page at: `<USERNAME>.github.io/<REPOSITORY-NAME>/`
 
 ### Deployment of Project Pages from `/docs` folder on `master` branch
 


### PR DESCRIPTION
Deploying through Github Project Pages had me stumped for two days.   

I finally asked for help on [Hugo's Discourse Board](https://discourse.gohugo.io/t/docsy-theme-not-rendering-using-github-pages/28109) and created a [Github Issue in the Doscy theme repo](https://github.com/google/docsy/issues/336)

This captures the solution in Hugo's Documentation.