### PR TITLE
module import path remove slash at end

### DIFF
--- a/content/en/hugo-modules/use-modules.md
+++ b/content/en/hugo-modules/use-modules.md
@@ -41,7 +41,7 @@ The easiest way to use a Module for a theme is to import it in the config.
 ```toml
 [module]
   [[module.imports]]
-    path = "github.com/spf13/hyde/"
+    path = "github.com/spf13/hyde"
 ```
 
 ## Update Modules


### PR DESCRIPTION
When using import path as given in the docs
```toml
path = "github.com/spf13/hyde/"
```

Hugo fails with : "Error: module "github.com/spf13/hyde/" not found; either add it as a Hugo Module or store it in "mypathhere/themes".: module does not exist"

Remove the trailing slash /, works as expected. 

Hugo version: Hugo Static Site Generator v0.75.1/extended darwin/amd64 BuildDate: unknown