### PR TITLE
Update page-bundles.md

### DIFF
--- a/content/en/content-management/page-bundles.md
+++ b/content/en/content-management/page-bundles.md
@@ -135,10 +135,6 @@ A leaf bundle can be made headless by adding below in the Front Matter
 headless = true
 ```
 
-{{% note %}}
-Only leaf bundles can be made headless.
-{{% /note %}}
-
 There are many use cases of such headless page bundles:
 
 -   Shared media galleries


### PR DESCRIPTION
Remove outdated note on only leaf bundles being able to be headless. See #1230.