### PR TITLE
Intend sub levels in table of content

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -563,6 +563,7 @@ i.freebsd-19px:before {
 #TableOfContents > ul > li > ul > li > ul li { margin-right: 8px; }
 #TableOfContents > ul > li > ul > li > a, #TableOfContents > ul > li > a   { font-weight: bold; background-color: #eeeeee; padding: 0 10px; margin: 0 2px; }
 #TableOfContents > ul > li > ul > li > a { font-style: italic; }
+#TableOfContents ul ul { margin-left:1rem; }
 .toc.compact ul > li > ul > li > ul  { display: none; }
 
 #toc {


### PR DESCRIPTION
Right now the table of contents is a list of headings each below each other without any visible structure of sub headings. This PR adds a 1rem intendation for sub lists. I am using no `>` like the lines above my change because this way every ul that is inside another ul will receive intending.