### PR TITLE
Format dates with "th", "nd", and "rd".

### DIFF
--- a/content/en/functions/format.md
+++ b/content/en/functions/format.md
@@ -108,7 +108,6 @@ This will output:
 5th of March 2017
 ```
 
-<!-- Content idea: see https://discourse.gohugo.io/t/formatting-a-date-with-suffix-2nd/5701 -->
 
 ### Use `.Local` and `.UTC`
 

--- a/content/en/functions/format.md
+++ b/content/en/functions/format.md
@@ -94,16 +94,18 @@ More examples can be found in Go's [documentation for the time package][timecons
 
 ### Cardinal Numbers and Ordinal Abbreviations
 
-Spelled-out cardinal numbers (e.g. "one", "two", and "three") and ordinal abbreviations (i.e., with shorted suffixes like "1st", "2nd", and "3rd") are not currently supported:
+Spelled-out cardinal numbers (e.g. "one", "two", and "three") are not currently supported. 
+
+Ordinal abbreviations (i.e., with shorted suffixes like "1st", "2nd", and "3rd") are not currently directly supported. By using `{{.Date.Format "Jan 2nd 2006"}}`, Hugo assumes you want to append `nd` as a string to the day of the month. However, you can chain functions together to create something like this:
 
 ```
-{{.Date.Format "Jan 2nd 2006"}}
+{{ .Date.Format "2" }}{{ if in (slice 1 21 31) .Date.Day}}st{{ else if in (slice 2 22) .Date.Day}}nd{{ else if in (slice 3 23) .Date.Day}}rd{{ else }}th{{ end }} of {{ .Date.Format "January 2006" }}
 ```
 
-Hugo assumes you want to append `nd` as a string to the day of the month and outputs the following:
+This will output:
 
 ```
-Mar 3nd 2017
+5th of March 2017
 ```
 
 <!-- Content idea: see https://discourse.gohugo.io/t/formatting-a-date-with-suffix-2nd/5701 -->


### PR DESCRIPTION
[This post by ssddanbrown](https://discourse.gohugo.io/t/formatting-a-date-with-suffix-2nd/5701) suggested a nice little snippet that allows Hugo to format dates into something like `posted on 5th of March 2017`.

Sorry if this PR isn't following certain formatting constraints. I couldn't find anything regarding formatting in this repo. Feel free to tweak things and merge when ready :)