### PR TITLE
Fix #1275: improve hosting on Github Pages

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -247,7 +247,7 @@ Refer to the [official documentation for custom domains][domains] for further in
 [ghsignup]: https://github.com/join
 [GitHub Pages service]: https://help.github.com/articles/what-is-github-pages/
 [installgit]: https://git-scm.com/downloads
-[orphan branch]: https://git-scm.com/docs/git-checkout/#git-checkout---orphanltnewbranchgt
+[orphan branch]: https://git-scm.com/docs/git-checkout/#Documentation/git-checkout.txt---orphanltnewbranchgt
 [Quick Start]: /getting-started/quick-start/
 [submodule]: https://github.com/blog/2104-working-with-submodules
 [worktree feature]: https://git-scm.com/docs/git-worktree

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -45,7 +45,7 @@ To create a Project Pages site, choose a method from the *Project Pages* section
 As mentioned in the [GitHub Pages documentation][ghorgs], you can host a user/organization page in addition to project pages. Here are the key differences in GitHub Pages websites for Users and Organizations:
 
 1. You must use a `<USERNAME>.github.io` to host your **generated** content
-2. Content from the `master` branch will be used to publish your GitHub Pages site
+2. Content from the `main` branch will be used to publish your GitHub Pages site
 
 This is a much simpler setup as your Hugo files and generated content are published into two different repositories.
 
@@ -58,7 +58,7 @@ This is a much simpler setup as your Hugo files and generated content are publis
 5. Once you are happy with the results:
     * Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to kill the server
     * Before proceeding run `rm -rf public` to completely remove the `public` directory
-6. `git submodule add -b master https://github.com/<USERNAME>/<USERNAME>.github.io.git public`. This creates a git [submodule][]. Now when you run the `hugo` command to build your site to `public`, the created `public` directory will have a different remote origin (i.e. hosted GitHub repository).
+6. `git submodule add -b main https://github.com/<USERNAME>/<USERNAME>.github.io.git public`. This creates a git [submodule][]. Now when you run the `hugo` command to build your site to `public`, the created `public` directory will have a different remote origin (i.e. hosted GitHub repository).
 7. Make sure the `baseURL` in your config file is updated with: `<USERNAME>.github.io`
 
 ### Put it Into a Script
@@ -92,7 +92,7 @@ fi
 git commit -m "$msg"
 
 # Push source and build repos.
-git push origin master
+git push origin main
 ```
 
 
@@ -106,9 +106,9 @@ That's it! Your personal page should be up and running at `https://<USERNAME>.gi
 Make sure your `baseURL` key-value in your [site configuration](/getting-started/configuration/) reflects the full URL of your GitHub pages repository if you're using the default GH Pages URL (e.g., `<USERNAME>.github.io/<PROJECT>/`) and not a custom domain.
 {{% /note %}}
 
-### Deployment of Project Pages from `/docs` folder on `master` branch
+### Deployment of Project Pages from `/docs` folder on `main` branch
 
-[As described in the GitHub Pages documentation][ghpfromdocs], you can deploy from a folder called `docs/` on your master branch. To effectively use this feature with Hugo, you need to change the Hugo publish directory in your [site's][config] `config.toml` and `config.yaml`, respectively:
+[As described in the GitHub Pages documentation][ghpfromdocs], you can deploy from a folder called `docs/` on your main branch. To effectively use this feature with Hugo, you need to change the Hugo publish directory in your [site's][config] `config.toml` and `config.yaml`, respectively:
 
 ```
 publishDir = "docs"
@@ -117,18 +117,18 @@ publishDir = "docs"
 publishDir: docs
 ```
 
-After running `hugo`, push your master branch to the remote repository and choose the `docs/` folder as the website source of your repo. Do the following from within your GitHub project:
+After running `hugo`, push your main branch to the remote repository and choose the `docs/` folder as the website source of your repo. Do the following from within your GitHub project:
 
 1. Go to **Settings** &rarr; **GitHub Pages**
-2. From **Source**,  select "master branch /docs folder". If the option isn't enabled, you likely do not have a `docs/` folder in the root of your project.
+2. From **Source**,  select "main branch /docs folder". If the option isn't enabled, you likely do not have a `docs/` folder in the root of your project.
 
 {{% note %}}
-The `docs/` option is the simplest approach but requires you set a publish directory in your site configuration. You cannot currently configure GitHub pages to publish from another directory on master, and not everyone prefers the output site live concomitantly with source files in version control.
+The `docs/` option is the simplest approach but requires you set a publish directory in your site configuration. You cannot currently configure GitHub pages to publish from another directory on main, and not everyone prefers the output site live concomitantly with source files in version control.
 {{% /note %}}
 
 ### Deployment of Project Pages From Your `gh-pages` branch
 
-You can also tell GitHub pages to treat your `master` branch as the published site or point to a separate `gh-pages` branch. The latter approach is a bit more complex but has some advantages:
+You can also tell GitHub pages to treat your `main` branch as the published site or point to a separate `gh-pages` branch. The latter approach is a bit more complex but has some advantages:
 
 * It keeps your source and generated website in different branches and therefore maintains version control history for both.
 * Unlike the preceding `docs/` option, it uses the default `public` folder.
@@ -139,7 +139,7 @@ These steps only need to be done once. Replace `upstream` with the name of your 
 
 ##### Add the `public` Folder
 
-First, add the `public` folder to your `.gitignore` file at the project root so that the directory is ignored on the master branch:
+First, add the `public` folder to your `.gitignore` file at the project root so that the directory is ignored on the main branch:
 
 ```
 echo "public" >> .gitignore
@@ -154,7 +154,7 @@ git checkout --orphan gh-pages
 git reset --hard
 git commit --allow-empty -m "Initializing gh-pages branch"
 git push upstream gh-pages
-git checkout master
+git checkout main
 ```
 
 #### Build and Deployment
@@ -225,14 +225,14 @@ cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)
 
 This will abort if there are pending changes in the working directory and also makes sure that all previously existing output files are removed. Adjust the script to taste, e.g. to include the final push to the remote repository if you don't need to take a look at the gh-pages branch before pushing.
 
-### Deployment of Project Pages from Your `master` Branch
+### Deployment of Project Pages from Your `main` Branch
 
-To use `master` as your publishing branch, you'll need your rendered website to live at the root of the GitHub repository. Steps should be similar to that of the `gh-pages` branch, with the exception that you will create your GitHub repository with the `public` directory as the root. Note that this does not provide the same benefits of the `gh-pages` branch in keeping your source and output in separate, but version controlled, branches within the same repo.
+To use `main` as your publishing branch, you'll need your rendered website to live at the root of the GitHub repository. Steps should be similar to that of the `gh-pages` branch, with the exception that you will create your GitHub repository with the `public` directory as the root. Note that this does not provide the same benefits of the `gh-pages` branch in keeping your source and output in separate, but version controlled, branches within the same repo.
 
-You will also need to set `master` as your publishable branch from within the GitHub UI:
+You will also need to set `main` as your publishable branch from within the GitHub UI:
 
 1. Go to **Settings** &rarr; **GitHub Pages**
-2. From **Source**,  select "master branch" and then **Save**.
+2. From **Source**,  select "main branch" and then **Save**.
 
 ## Use a Custom Domain
 
@@ -243,7 +243,7 @@ Refer to the [official documentation for custom domains][domains] for further in
 [config]: /getting-started/configuration/
 [domains]: https://help.github.com/articles/using-a-custom-domain-with-github-pages/
 [ghorgs]: https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages
-[ghpfromdocs]: https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/#publishing-your-github-pages-site-from-a-docs-folder-on-your-master-branch
+[ghpfromdocs]: https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/
 [ghsignup]: https://github.com/join
 [GitHub Pages service]: https://help.github.com/articles/what-is-github-pages/
 [installgit]: https://git-scm.com/downloads

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -4,10 +4,10 @@ linktitle: Host on GitHub
 description: Deploy Hugo as a GitHub Pages project or personal/organizational site and automate the whole process with a simple shell script.
 date: 2014-03-21
 publishdate: 2014-03-21
-lastmod: 2018-09-22
+lastmod: 2020-11-12
 categories: [hosting and deployment]
 keywords: [github,git,deployment,hosting]
-authors: [Spencer Lyon, Gunnar Morling]
+authors: [Spencer Lyon, Gunnar Morling, Thomas Garlot]
 menu:
   docs:
     parent: "hosting-and-deployment"
@@ -36,11 +36,11 @@ There are 2 types of GitHub Pages:
 
 Please refer to the [GitHub Pages documentation][ghorgs] to decide which type of site you would like to create as it will determine which of the below methods to use.
 
-To create a User/Organization Pages site, follow the single method in the *GitHub User and Organization Pages* section below.
+To create a User/Organization Pages site, follow the single method in the *GitHub User or Organisation Pages* [section]({{< ref "#github-user-organisation-pages" >}}) below.
 
-To create a Project Pages site, choose a method from the *Project Pages* section below.
+To create a Project Pages site, choose a method from the *Project Pages* [section]({{< ref "#project-pages" >}}) below.
 
-## GitHub User or Organization Pages
+## GitHub User or Organization Pages {#github-user-organisation-pages}
 
 As mentioned in the [GitHub Pages documentation][ghorgs], you can host a user/organization page in addition to project pages. Here are the key differences in GitHub Pages websites for Users and Organizations:
 
@@ -54,12 +54,25 @@ This is a much simpler setup as your Hugo files and generated content are publis
 1. Create a `<YOUR-PROJECT>` (e.g. `blog`) repository on GitHub. This repository will contain Hugo's content and other source files.
 2. Create a `<USERNAME>.github.io` GitHub repository. This is the repository that will contain the fully rendered version of your Hugo website.
 3. `git clone <YOUR-PROJECT-URL> && cd <YOUR-PROJECT>`
-4. Paste your existing Hugo project into the new local `<YOUR-PROJECT>` repository. Make sure your website works locally (`hugo server` or `hugo server -t <YOURTHEME>`) and open your browser to <http://localhost:1313>.
-5. Once you are happy with the results:
+4. Paste your existing Hugo project into the new local `<YOUR-PROJECT>` repository. 
+5. Make sure your website works locally (`hugo server` or `hugo server -t <YOURTHEME>` and check via your browser at <http://localhost:1313>.
+6. Once you are happy with the results:
     * Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to kill the server
-    * Before proceeding run `rm -rf public` to completely remove the `public` directory
-6. `git submodule add -b main https://github.com/<USERNAME>/<USERNAME>.github.io.git public`. This creates a git [submodule][]. Now when you run the `hugo` command to build your site to `public`, the created `public` directory will have a different remote origin (i.e. hosted GitHub repository).
-7. Make sure the `baseURL` in your config file is updated with: `<USERNAME>.github.io`
+    * OPTIONAL - Add/commit/push your work to `<YOUR-PROJECT>` repository on GitHub.
+7. Generate the site content and initialise `<USERNAME>.github.io` GitHub repository:
+    * Run `hugo` command. It will output the HTML version in the `public` directory
+    * `cd public`
+    * `git init` then `git add .` then `git commit -m"Initial commit"` 
+    * Add the remote: `git remote add origin https://github.com/<USERNAME>/<USERNAME>.github.io.git` and push to it with `git push origin master` 
+    * then remove the `public` directory with `cd .. && rm-rf public`
+8. Add the  `<USERNAME>.github.io` GitHub repository as a git [submodule][] with `git submodule add -b master https://github.com/<USERNAME>/<USERNAME>.github.io.git public`. Now when you run the `hugo` command to build your site to `public`, the created `public` directory will have a different remote origin (i.e. hosted GitHub repository).
+
+---
+**Note**
+
+Make sure the `baseURL` in your config file is updated with: `<USERNAME>.github.io`
+
+---
 
 ### Put it Into a Script
 
@@ -95,12 +108,18 @@ git commit -m "$msg"
 git push origin main
 ```
 
+You can then run `./deploy.sh "Your optional commit message"` to send changes to `<USERNAME>.github.io`. 
 
-You can then run `./deploy.sh "Your optional commit message"` to send changes to `<USERNAME>.github.io`. Note that you likely will want to commit changes to your `<YOUR-PROJECT>` repository as well.
+---
+**Note**
+
+Note that you likely will want to commit changes to your `<YOUR-PROJECT>` repository as well as the script above only publish the changes in `<USERNAME>.github.io`. 
+
+---
 
 That's it! Your personal page should be up and running at `https://<USERNAME>.github.io` within a couple minutes.
 
-## GitHub Project Pages
+## GitHub Project Pages {#project-pages}
 
 {{% note %}}
 Make sure your `baseURL` key-value in your [site configuration](/getting-started/configuration/) reflects the full URL of your GitHub pages repository if you're using the default GH Pages URL (e.g., `<USERNAME>.github.io/<PROJECT>/`) and not a custom domain.

--- a/content/en/news/0.78.2-relnotes/index.md
+++ b/content/en/news/0.78.2-relnotes/index.md
@@ -1,0 +1,28 @@
+
+---
+date: 2020-11-13
+title: "Hugo 0.78.2: A couple of Bug Fixes"
+description: "This version fixes a couple of bugs introduced in 0.78.0."
+categories: ["Releases"]
+images:
+- images/blog/hugo-bug-poster.png
+
+---
+
+	
+
+This is a bug-fix release with a couple of important fixes.
+
+* js: Let ESBuild handle all imports from node_modules [78f227b6](https://github.com/gohugoio/hugo/commit/78f227b664d86c30fbb25f7a953b7ef8f2dacf13) [@bep](https://github.com/bep) [#7948](https://github.com/gohugoio/hugo/issues/7948)
+* build(deps): bump github.com/evanw/esbuild from 0.8.5 to 0.8.6 [5e03f644](https://github.com/gohugoio/hugo/commit/5e03f644a4507f51bdbcdb42b65ce4e99095374f) [@dependabot[bot]](https://github.com/apps/dependabot) 
+* build(deps): bump github.com/evanw/esbuild from 0.8.4 to 0.8.5 [a92ef20f](https://github.com/gohugoio/hugo/commit/a92ef20ff6e43ba05844539b60782e8190712cdc) [@dependabot[bot]](https://github.com/apps/dependabot) 
+* build(deps): bump github.com/getkin/kin-openapi from 0.22.1 to 0.26.0 [0d54a844](https://github.com/gohugoio/hugo/commit/0d54a844061e808dd5b4ff4874b2e4bd9df4d556) [@dependabot[bot]](https://github.com/apps/dependabot) 
+* Update GH docs to say "main" as default branch [943f3c93](https://github.com/gohugoio/hugo/commit/943f3c932f5f67ab52bf8e0636e57751dc9b1891) [@maco](https://github.com/maco) 
+* Updated year in header [4f20bf29](https://github.com/gohugoio/hugo/commit/4f20bf29eb246a2e65508175fdd5f25b44e98370) [@AdamKorcz](https://github.com/AdamKorcz) 
+* Added first fuzzer [4c613d5d](https://github.com/gohugoio/hugo/commit/4c613d5d5d60b80a262e968ae8a4525eba8619a2) [@AdamKorcz](https://github.com/AdamKorcz) 
+* build(deps): bump github.com/frankban/quicktest from 1.11.1 to 1.11.2 [82a182e5](https://github.com/gohugoio/hugo/commit/82a182e52c4165b4f51d0cc8ef0f21df5d628c69) [@dependabot[bot]](https://github.com/apps/dependabot) 
+* build(deps): bump golang.org/x/text from 0.3.3 to 0.3.4 [dfc662b2](https://github.com/gohugoio/hugo/commit/dfc662b2086430dde96c18ccb6b92bba4f1be428) [@dependabot[bot]](https://github.com/apps/dependabot) 
+* build(deps): bump github.com/evanw/esbuild from 0.8.3 to 0.8.4 [2f0917cc](https://github.com/gohugoio/hugo/commit/2f0917cc014557e201a9348664736d608a7fa131) [@dependabot[bot]](https://github.com/apps/dependabot) 
+
+
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.78.2"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.78.2"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.78.2"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.78.0"
+HUGO_VERSION = "0.78.2"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
- Detail the setup of GitHub page (mainly the part with the `public` directory
- Add links to sections