### PR TITLE
markdownify: add note about render-hooks and .RenderString

### DIFF
--- a/content/en/functions/markdownify.md
+++ b/content/en/functions/markdownify.md
@@ -23,3 +23,8 @@ aliases: []
 ```
 {{ .Title | markdownify }}
 ```
+
+*Note*: if you need [Render Hooks][], which `markdownify` doesn't currently
+support, use [.RenderString](/functions/renderstring/) instead.
+
+[Render Hooks]: /getting-started/configuration-markup/#markdown-render-hooks


### PR DESCRIPTION
Motivation: I still have a hard time remembering the name of `.RenderString`. Ideally, `.RenderString` would appear in the "See Also" section, but that section seems limited to 5 entries. This note at least also mentions why one might consider `.RenderString` as an alternative.

Preview: https://deploy-preview-1281--gohugoio.netlify.app/functions/markdownify/