### PR TITLE
Add a note about default translation values

### DIFF
--- a/content/en/functions/i18n.md
+++ b/content/en/functions/i18n.md
@@ -31,4 +31,12 @@ This translates a piece of content based on your `i18n/en-US.yaml` (and similar)
 
 For more information about string translations, see [Translation of Strings in Multilingual Mode][multistrings].
 
+### Default values
+
+When developing your theme it makes sense to add a default value in your default language to the layout files without being forced to add an extra `i18n/language-code.yaml` file:
+
+```
+{{ i18n "translation_id" | default "Default Translation Text" }}
+```
+
 [multistrings]: /content-management/multilingual/#translation-of-strings


### PR DESCRIPTION
See https://discourse.gohugo.io/t/add-default-language-value-in-layouts/30477 --- I had an epiphany about this and think people should see a note about default language strings in the docs.