### PR TITLE
add rel="noopener noreferrer" to insecure links

### DIFF
--- a/data/homepagetweets.toml
+++ b/data/homepagetweets.toml
@@ -8,7 +8,7 @@ date = 2019-11-12T00:00:00Z
 [[tweet]]
 name = "Joshua Steven‏‏"
 twitter_handle = "@jscarto"
-quote = "Can't overstate how much I enjoy <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a>. My site is relatively small, but *18 ms* to build the whole thing made template development and proofing a breeze."
+quote = "Can't overstate how much I enjoy <a href='https://twitter.com/gohugoio' target='_blank' rel='noopener noreferrer'>@GoHugoIO</a>. My site is relatively small, but *18 ms* to build the whole thing made template development and proofing a breeze."
 link = "https://twitter.com/jscarto/status/1039648827815485440"
 date = 2018-09-12T00:00:00Z
 
@@ -22,21 +22,21 @@ date = 2018-01-03T04:00:00Z
 [[tweet]]
 name = "STOQE"
 twitter_handle = "@STOQE"
-quote = "I fear <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a> v0.22 might be so fast it creates a code vortex that time-warps me back to a time I used Wordpress. <a href='https://twitter.com/hashtag/gasp?src=hash'>#gasp</a>"
+quote = "I fear <a href='https://twitter.com/gohugoio' target='_blank' rel='noopener noreferrer'>@GoHugoIO</a> v0.22 might be so fast it creates a code vortex that time-warps me back to a time I used Wordpress. <a href='https://twitter.com/hashtag/gasp?src=hash'>#gasp</a>"
 link = "https://twitter.com/STOQE/status/874184881701494784"
 date = 2017-06-12T00:00:00Z
 
 [[tweet]]
 name = "Christophe Diericx"
 twitter_handle = "@spcrngr_"
-quote = "The more I use <a href='https://gohugo.io' target='_blank'>gohugo.io</a>, the more I really like it. Super intuitive/powerful static site generator...great job <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a>"
+quote = "The more I use <a href='https://gohugo.io' target='_blank'>gohugo.io</a>, the more I really like it. Super intuitive/powerful static site generator...great job <a href='https://twitter.com/gohugoio' target='_blank' rel='noopener noreferrer'>@GoHugoIO</a>"
 link = "https://twitter.com/spcrngr_/status/870863020905435136"
 date = 2017-06-03T00:00:00Z
 
 [[tweet]]
 name = "marcoscan"
 twitter_handle = "@marcoscan"
-quote = "Blog migrated from <a href='https://twitter.com/WordPress' target='_blank'>@WordPress</a> to <a href='https://twitter.com/GoHugoIO' target='_blank'>@GoHugoIO</a>, with a little refresh of my theme, Vim shortcuts and a full featured deploy script <a href='https://twitter.com/hashtag/gohugo?src=hash' target='_blank'>#gohugo</a>"
+quote = "Blog migrated from <a href='https://twitter.com/WordPress' target='_blank' rel='noopener noreferrer'>@WordPress</a> to <a href='https://twitter.com/GoHugoIO' target='_blank' rel='noopener noreferrer'>@GoHugoIO</a>, with a little refresh of my theme, Vim shortcuts and a full featured deploy script <a href='https://twitter.com/hashtag/gohugo?src=hash' target='_blank' rel='noopener noreferrer'>#gohugo</a>"
 link = "https://twitter.com/marcoscan/status/869661175960752129"
 date = 2017-05-30T00:00:00Z
 
@@ -57,14 +57,14 @@ date = 2017-05-26T00:00:00Z
 [[tweet]]
 name = "Phil Hawksworth"
 twitter_handle = "@philhawksworth"
-quote = "I've been keen on <a href='https://twitter.com/hashtag/JAMStack?src=hash' target='_blank'>#JAMStack</a> for some time, but <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a> is wooing me all over again. Great fun to build with. And speeeeedy."
+quote = "I've been keen on <a href='https://twitter.com/hashtag/JAMStack?src=hash' target='_blank' rel='noopener noreferrer'>#JAMStack</a> for some time, but <a href='https://twitter.com/gohugoio' target='_blank' rel='noopener noreferrer'>@GoHugoIO</a> is wooing me all over again. Great fun to build with. And speeeeedy."
 link = "https://twitter.com/philhawksworth/status/866684170512326657"
 date = 2017-05-22T00:00:00Z
 
 [[tweet]]
 name = "Aras Pranckevicius"
 twitter_handle = "@aras_p"
-quote = "I've probably said it before...but having Hugo rebuild the whole website in 300ms is amazing. <a href='https://gohugo.io' target='_blank'>gohugo.io</a>, <a href='https://twitter.com/hashtag/gohugo' target='_blank'>#gohugo</a>"
+quote = "I've probably said it before...but having Hugo rebuild the whole website in 300ms is amazing. <a href='https://gohugo.io' target='_blank'>gohugo.io</a>, <a href='https://twitter.com/hashtag/gohugo' target='_blank' rel='noopener noreferrer'>#gohugo</a>"
 link = "https://twitter.com/aras_p/status/861157286823288832"
 date = 2017-05-07T00:00:00Z
 


### PR DESCRIPTION
links to external domains using target="_blank" are vulnerable to clickjacking, and `noopener` addresses this. Using `noreferrer` is an addition to address older browsers that don't support `noopener`.