### PR TITLE
Fix a minor typo

### DIFF
--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -88,7 +88,7 @@ And it will resolve to the top-most `index.{js,ts,tsx,jsx}` inside `assets/my/mo
 import { hello3 } from 'my/module/hello3';
 ```
 
-Wil resolve to `hello3.{js,ts,tsx,jsx}` inside `assets/my/module`.
+Will resolve to `hello3.{js,ts,tsx,jsx}` inside `assets/my/module`.
 
 Any imports starting with `.` is resolved relative to the current file:
 


### PR DESCRIPTION
Just a tiny typo fix in the documentation for _JavaScript Building_.