### PR TITLE
Layout lookup order changed to list instead of blob

### DIFF
--- a/layouts/shortcodes/datatable-filtered.html
+++ b/layouts/shortcodes/datatable-filtered.html
@@ -18,10 +18,21 @@
 	{{ range $list }}
 	<tr>
 		{{ range $k, $v := . }}
-		{{ $.Scratch.Set $k $v }}
+		  {{ $.Scratch.Set $k $v }}
 		{{ end }}
 		{{ range $fields }}
-			<td>{{ $.Scratch.Get . }}</td>
+			{{ $cell := $.Scratch.Get . }}
+      <td>
+        {{ if eq $k "Template Lookup Order" }}
+          <ul>
+          {{ range $cell }}
+            <li>{{ . }}</li>
+          {{ end }}          
+          </ul>
+        {{ else }}
+          {{ $cell }}
+        {{ end }}
+      </td>
 		{{ end }}
 	</tr>
 	{{ end }}


### PR DESCRIPTION
In follow up to [this post](https://discourse.gohugo.io/t/improving-table-formatting-in-documentation-for-template-lookup-order/30747) this is my very first PR written in Go.

I did [a search](https://github.com/gohugoio/hugoDocs/search?q=datatable-filtered) for this shortcode and my change doesn't seem to impact any other placement of this shortcode.

Please check my syntax and logic. Feel free to correct. I tried my best.