### PR TITLE
docs: Fix HTML code in .RenderString description being stripped out

### DIFF
--- a/content/en/functions/RenderString.md
+++ b/content/en/functions/RenderString.md
@@ -20,7 +20,7 @@ signature: [".RenderString MARKUP"]
 The method takes an optional map argument with these options:
 
 display ("inline")
-: `inline` or `block`. If `inline` (default), surrounding ´<p></p>` on short snippets will be trimmed.
+: `inline` or `block`. If `inline` (default), surrounding `<p></p>` on short snippets will be trimmed.
 
 markup (defaults to the Page's markup)
 : See identifiers in [List of content formats](/content-management/formats/#list-of-content-formats).


### PR DESCRIPTION
Minor typo but it causes important info to get stripped out.