### PR TITLE
Fixed a broken link on github instructions.

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -50,7 +50,7 @@ This is a much simpler setup as your Hugo files and generated content are publis
 
 GitHub execute your software development workflows. Everytime you push your code on the Github repository, Github Action will build the site automatically.
 
-Create a file in `.github/workflows/gh-pages.yml` containing the following content (based on https://github.com/marketplace/actions/hugo-setup):
+Create a file in `.github/workflows/gh-pages.yml` containing the following content (based on [https://github.com/marketplace/actions/hugo-setup](https://github.com/marketplace/actions/hugo-setup)):
 
  `
 name: github pages


### PR DESCRIPTION
Inside https://gohugo.io/hosting-and-deployment/hosting-on-github/#build-hugo-with-github-action the link to the hugo action setup is broken. It mistakenly includes the right ) in it so when it is clicked it does not work.

This is how it was rendering on the website:
(based on [https://github.com/marketplace/actions/hugo-setup):](https://github.com/marketplace/actions/hugo-setup\):)

This is how it should render:
(based on [https://github.com/marketplace/actions/hugo-setup](https://github.com/marketplace/actions/hugo-setup)):