### PR TITLE
fixed link and code rendering on github instructions

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -50,9 +50,9 @@ This is a much simpler setup as your Hugo files and generated content are publis
 
 GitHub execute your software development workflows. Everytime you push your code on the Github repository, Github Action will build the site automatically.
 
-Create a file in `.github/workflows/gh-pages.yml` containing the following content (based on https://github.com/marketplace/actions/hugo-setup):
+Create a file in `.github/workflows/gh-pages.yml` containing the following content (based on [https://github.com/marketplace/actions/hugo-setup](https://github.com/marketplace/actions/hugo-setup)):
 
- `
+```
 name: github pages
 
 on:
@@ -83,16 +83,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
- `
+```
 
 Set hugo-version: `'latest'` to use the latest version of Hugo.
-
-`
+```
 - name: Setup Hugo
   uses: peaceiris/actions-hugo@v2
   with:
     hugo-version: 'latest'
-`
+```
 
 For more advance settings https://github.com/marketplace/actions/hugo-setup 
 


### PR DESCRIPTION
Inside https://gohugo.io/hosting-and-deployment/hosting-on-github/#build-hugo-with-github-action the link to the hugo github action setup is broken and the code blocks don't render properly. See issue #1327. 

## This is how link was rendering on the website:
(based on [https://github.com/marketplace/actions/hugo-setup):](https://github.com/marketplace/actions/hugo-setup\):)
## This is how it should render:
(based on https://github.com/marketplace/actions/hugo-setup):

## This is how the code was rendering:

 `
name: github pages

on:
  push:
    branches:
      - main  # Set a branch to deploy

jobs:
  deploy:
    runs-on: ubuntu-18.04
    steps:
      - uses: actions/checkout@v2
        with:
          submodules: true  # Fetch Hugo themes (true OR recursive)
          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

      - name: Setup Hugo
        uses: peaceiris/actions-hugo@v2
        with:
          hugo-version: '0.79.1'
          # extended: true

      - name: Build
        run: hugo --minify

      - name: Deploy
        uses: peaceiris/actions-gh-pages@v3
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./public
 `

Set hugo-version: `'latest'` to use the latest version of Hugo.

`
- name: Setup Hugo
  uses: peaceiris/actions-hugo@v2
  with:
    hugo-version: 'latest'
`

## This is how it now renders:

 ```
name: github pages

on:
  push:
    branches:
      - main  # Set a branch to deploy

jobs:
  deploy:
    runs-on: ubuntu-18.04
    steps:
      - uses: actions/checkout@v2
        with:
          submodules: true  # Fetch Hugo themes (true OR recursive)
          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

      - name: Setup Hugo
        uses: peaceiris/actions-hugo@v2
        with:
          hugo-version: '0.79.1'
          # extended: true

      - name: Build
        run: hugo --minify

      - name: Deploy
        uses: peaceiris/actions-gh-pages@v3
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./public
 ```

Set hugo-version: `'latest'` to use the latest version of Hugo.

```
- name: Setup Hugo
  uses: peaceiris/actions-hugo@v2
  with:
    hugo-version: 'latest'
```