### PR TITLE
fix deploy-on-github workflows yaml

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -55,7 +55,7 @@ name: github pages
 on:
   push:
     branches:
-      - main  # Set a branch to deploy
+      - master  # Set a branch to deploy
 
 jobs:
   deploy:
@@ -76,15 +76,11 @@ jobs:
         run: hugo --minify
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@latest
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
 
-- name: Setup Hugo
-  uses: peaceiris/actions-hugo@latest
-  with:
-    hugo-version: 'latest'
 ```
 
 For more advance settings https://github.com/marketplace/actions/hugo-setup 

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@latest
+        uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: 'latest'
           # extended: true


### PR DESCRIPTION
There are always problems with the `deploy-on-github` workflow yaml, this PR will fix it.

1. github default branch name is `master` now, not `main`.
2. the `peaceiris/actions-gh-pages` workflow does not have a `latest` tag, `v3` is recommended now.
3. fix some errors on the bottom of the yaml content.

The updated yaml file is tested and works fine.