### PR TITLE
Update use-modules.md

### DIFF
--- a/content/en/hugo-modules/use-modules.md
+++ b/content/en/hugo-modules/use-modules.md
@@ -136,7 +136,7 @@ Also see the [CLI Doc](/commands/hugo_mod_clean/).
 
 Run `hugo mod clean` to delete the entire modules cache.
 
-Note that you can also configure the `modules` cache with a `maxAge`, see [File Caches](/hugo-modules/configuration/#configure-file-caches).
+Note that you can also configure the `modules` cache with a `maxAge`, see [File Caches](/getting-started/configuration/#configure-file-caches).
 
 
 


### PR DESCRIPTION
Fixes a broken link to the "configure file caches" content. This PR updates the link to point to the GSG configuration page instead of the hugo modules configuration page. 