### PR TITLE
Update 404 docs: Netlify auto-detects 404.html

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -52,7 +52,7 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 * Amazon AWS S3. When setting a bucket up for static web serving, you can specify the error file from within the S3 GUI.
 * Amazon CloudFont. You can specify the page in the Error Pages section in the CloudFont Console. [Details here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html)
 * Caddy Server. Using `errors { 404 /404.html }`. [Details here](https://caddyserver.com/docs/errors)
-* Netlify. Add `/* /404.html 404` to `content/_redirects`. [Details Here](https://www.netlify.com/docs/redirects/#custom-404)
+* Netlify. The 404 page is automatic. [Details Here](https://www.netlify.com/docs/redirects/#custom-404)
 * Azure Static website. You can specify the `Error document path` in the Static website configuration page of the Azure portal. [More details are available in the Static website documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website).
 
 {{% note %}}


### PR DESCRIPTION
Added information for deploying on Netlify: "This doesn’t require any redirect rules. If you add a 404.html page to your site, it will be picked up and displayed automatically for any failed paths" info from: https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling