### PR TITLE
Clarify leaf bundle explanation and related FAQ

### DIFF
--- a/content/en/content-management/page-bundles.md
+++ b/content/en/content-management/page-bundles.md
@@ -64,26 +64,27 @@ content/
 In the above example `content/` directory, there are four leaf
 bundles:
 
-about
+`about`
 : This leaf bundle is at the root level (directly under
     `content` directory) and has only the `index.md`.
 
-my-post
+`my-post`
 : This leaf bundle has the `index.md`, two other content
     Markdown files and two image files.
 
-image1
-: This image is a page resource of `my-post`
+- image1, image2: 
+These images are page resources of `my-post`
     and only available in `my-post/index.md` resources.
 
-image2
-: This image is a page resource of `my-post`
-    and only available in `my-post/index.md` resources.
+- content1, content2: 
+These content files are page resources of `my-post`
+    and only available in `my-post/index.md` resources. 
+    They will **not** be rendered as individual pages.
 
-my-other-post
+`my-other-post`
 : This leaf bundle has only the `index.md`.
 
-another-leaf-bundle
+`another-leaf-bundle`
 : This leaf bundle is nested under couple of
     directories. This bundle also has only the `index.md`.
 

--- a/content/en/troubleshooting/faq.md
+++ b/content/en/troubleshooting/faq.md
@@ -21,6 +21,8 @@ aliases: [/faq/]
 
 Is your markdown file [in draft mode](https://gohugo.io/content-management/front-matter/#front-matter-variables)? When testing, run `hugo server` with the `-D` or `--buildDrafts` [switch](https://gohugo.io/getting-started/usage/#draft-future-and-expired-content).
 
+Is your markdown file part of a [leaf bundle](/content-management/page-bundles/)? If there is an `index.md` file in the same or any parent directory then other markdown files will not be rendered as individual pages.
+
 ## Can I set configuration variables via OS environment?
 
 Yes you can! See [Configure with Environment Variables](/getting-started/configuration/#configure-with-environment-variables).


### PR DESCRIPTION
Organize the content of the leaf bundle such that the example with four 
leaf bundles shows four headings. Align headings with branch bundles.
Explain that the content files will not result in rendered pages.

Add a hint to check for index.md's that may inadvertently have created
a leaf bundle thus preventing a page from being rendered.