### PR TITLE
Clean documentation summary on CLI commands page

### DIFF
--- a/content/en/content-management/page-bundles.md
+++ b/content/en/content-management/page-bundles.md
@@ -64,26 +64,27 @@ content/
 In the above example `content/` directory, there are four leaf
 bundles:
 
-about
+`about`
 : This leaf bundle is at the root level (directly under
     `content` directory) and has only the `index.md`.
 
-my-post
+`my-post`
 : This leaf bundle has the `index.md`, two other content
     Markdown files and two image files.
 
-image1
-: This image is a page resource of `my-post`
+- image1, image2: 
+These images are page resources of `my-post`
     and only available in `my-post/index.md` resources.
 
-image2
-: This image is a page resource of `my-post`
-    and only available in `my-post/index.md` resources.
+- content1, content2: 
+These content files are page resources of `my-post`
+    and only available in `my-post/index.md` resources. 
+    They will **not** be rendered as individual pages.
 
-my-other-post
+`my-other-post`
 : This leaf bundle has only the `index.md`.
 
-another-leaf-bundle
+`another-leaf-bundle`
 : This leaf bundle is nested under couple of
     directories. This bundle also has only the `index.md`.
 

--- a/content/en/troubleshooting/faq.md
+++ b/content/en/troubleshooting/faq.md
@@ -21,6 +21,8 @@ aliases: [/faq/]
 
 Is your markdown file [in draft mode](https://gohugo.io/content-management/front-matter/#front-matter-variables)? When testing, run `hugo server` with the `-D` or `--buildDrafts` [switch](https://gohugo.io/getting-started/usage/#draft-future-and-expired-content).
 
+Is your markdown file part of a [leaf bundle](/content-management/page-bundles/)? If there is an `index.md` file in the same or any parent directory then other markdown files will not be rendered as individual pages.
+
 ## Can I set configuration variables via OS environment?
 
 Yes you can! See [Configure with Environment Variables](/getting-started/configuration/#configure-with-environment-variables).


### PR DESCRIPTION
Fixes https://github.com/gohugoio/hugo/issues/7608

Note that I recommend closing the issue without applying 
this patch as per argument in the issue.

Lack of 'description' frontmatter generated by spf13/cobra
resulted in ugly summary pages. This patch fixes that by
inserting itself before the default summary use with a
custom code snippet extracting the synopsis as summary.

There is no direct access to the content DOM so
string matching is used to identify the start and end
of the synopsis section.

This commit overrides a partial in the gohugoioTheme to 
achieve the intended outcome. As it solves a non-theme  
issue I felt this is the better place.
