### PR TITLE
Update quick-start.md  to add explanation for -D where it is used

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -175,5 +175,7 @@ It is simple. Just call:
 hugo -D
 ```
 
+> Note that -D will include posts marked as drafts when building and is not required to build. See: https://gohugo.io/commands/hugo/#options
+
 Output will be in `./public/` directory by default (`-d`/`--destination` flag to change it, or set `publishdir` in the config file).
 


### PR DESCRIPTION
The inclusion for -D without explanation confused me as to why drafts were still being included in public. I may be dumb, but this has probably confused others / will continue to confuse more in the future without the extra note.