### PR TITLE
explaination that `weight` key is used for sorting

### DIFF
--- a/content/en/variables/menus.md
+++ b/content/en/variables/menus.md
@@ -64,9 +64,10 @@ a string representing HTML.
 
 .Weight
 : _int_ <br />
-Value of the `weight` key if set for the menu entry. If that key is not set,
-and if the menu entry is set in a page front-matter, this value defaults to the
-page's `.Weight`.
+Value of the `weight` key if set for the menu entry. By default the entries in 
+a menu are sorted ascending by their `weight`. If that key is not set, and if 
+the menu entry is set in a page front-matter, this value defaults to the page's 
+`.Weight`.
 
 .Parent
 : _string_ <br />


### PR DESCRIPTION
added a sentence to explain that by default menu entries are sorted ascending by their weight. As a new user you otherwise might not be familiar with it.