### PR TITLE
Removed extra quotation strings that prevents hugo server from launching

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -78,7 +78,7 @@ git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/anan
 Then, add the theme to the site configuration:
 
 ```bash
-echo 'theme = "ananke"' >> config.toml
+echo theme = "ananke" >> config.toml
 ```
 
 {{< asciicast 7naKerRYUGVPj8kiDmdh5k5h9 >}}


### PR DESCRIPTION
Error code:
Error: "C:\Hugo\academic\config.toml:4:1": unmarshal failed: Near line 4 (last key parsed 'theme = "academic"'): expected key separator '=', but got '\r' instead