### PR TITLE
Update quick-start.md

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -78,7 +78,7 @@ git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/anan
 Then, add the theme to the site configuration:
 
 ```bash
-echo theme = "ananke" >> config.toml
+echo theme = \"ananke\" >> config.toml
 ```
 
 {{< asciicast 7naKerRYUGVPj8kiDmdh5k5h9 >}}


### PR DESCRIPTION
```
❯ hugo new posts/welcome.md
Error: "/Users/dominik/abb/abb-nds-hf-swe-swdt/docs/config.toml:4:1": unmarshal failed: Near line 4 (last key parsed 'theme'): expected value but found "ananke" instead
```

If you do not escape the quotes, subsequent hugo commands run into an error because the config becomes invalid.