### PR TITLE
Update the 'Customize Dates' example to not error

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -421,12 +421,13 @@ At the time of this writing, Go does not yet have support for internationalized 
 ...then index the non-English date names in your templates like so:
 
 ~~~html
-<time class="post-date" datetime="{{ .Date.Format '2006-01-02T15:04:05Z07:00' | safeHTML }}">
+<time class="post-date" datetime="{{ .Date.Format `2006-01-02T15:04:05Z07:00` | safeHTML }}">
   Article publié le {{ .Date.Day }} {{ index $.Site.Data.mois (printf "%d" .Date.Month) }} {{ .Date.Year }} (dernière modification le {{ .Lastmod.Day }} {{ index $.Site.Data.mois (printf "%d" .Lastmod.Month) }} {{ .Lastmod.Year }})
 </time>
 ~~~
 
 This technique extracts the day, month and year by specifying ``.Date.Day``, ``.Date.Month``, and ``.Date.Year``, and uses the month number as a key, when indexing the month name data file.
+
 
 ## Menus
 


### PR DESCRIPTION
Part of the work to improve the docs for users who are less familiar with GoLang by removing an error that would cause the template parser to throw with a `malformed character constant` Error as detailed in this issue https://github.com/gohugoio/hugo/issues/8322