### PR TITLE
Update syntax-highlighting.md: add link of Chroma

### DIFF
--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -125,7 +125,7 @@ The options are the same as in the [highlighting shortcode](/content-management/
 
 ## List of Chroma Highlighting Languages
 
-The full list of Chroma lexers and their aliases (which is the identifier used in the `highlight` template func or when doing highlighting in code fences):
+The full list of [Chroma](https://github.com/alecthomas/chroma) lexers and their aliases (which is the identifier used in the `highlight` template func or when doing highlighting in code fences):
 
 {{< chroma-lexers >}}
 


### PR DESCRIPTION
Added a link to [Chroma](https://github.com/alecthomas/chroma) to help more people realize this is a go development project  [#8326](https://github.com/gohugoio/hugo/issues/8326#issuecomment-798516268)