### PR TITLE
Fix `ref` shortcode example output

### DIFF
--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -302,7 +302,7 @@ Read a more extensive description of `ref` and `relref` in the [cross references
 Assuming that standard Hugo pretty URLs are turned on.
 
 ```
-<a href="/blog/neat">Neat</a>
+<a href="https://example.com/blog/neat">Neat</a>
 <a href="/about/#who:c28654c202e73453784cfd2c5ab356c0">Who</a>
 ```
 

--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -303,7 +303,7 @@ Assuming that standard Hugo pretty URLs are turned on.
 
 ```
 <a href="https://example.com/blog/neat">Neat</a>
-<a href="/about/#who:c28654c202e73453784cfd2c5ab356c0">Who</a>
+<a href="/about/#who">Who</a>
 ```
 
 ### `tweet`


### PR DESCRIPTION
In contrast to `relref`, the `ref` shortcode returns the _absolute_ permalink.

In the absence of further knowledge, I simply used `https://example.com/` as the base URL.