### PR TITLE
Warning: do not use config dir in nested modules

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -59,6 +59,9 @@ foo = "bar"
 - Each directory holds a group of files containing settings unique to an environment.
 - Files can be localized to become language specific.
 
+{{% warning %}}
+The `configDir` directory is only read for the main project. You can't use it in nested modules, where only regular config files (`config.toml`, etc.) will be read.
+{{% /warning %}}
 
 ```
 ├── config


### PR DESCRIPTION
"the config directory is only read for the main project. Themes/theme modules is config.toml etc. only."
@see https://discourse.gohugo.io/t/hugo-theme-module-with-nested-module/28199/6