### PR TITLE
Add transparent background in rgba for search field

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-search.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-search.html
@@ -1,6 +1,6 @@
 <form id="site-search-form" action="" role="search">
   <fieldset class="bn ma0 pa0">
     <label class="clip" for="search-input">Search</label>
-    <input type="search" id="search-input" class="needs-js bg-left bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" name="search-input" value="" style="background: transparent url('/images/icon-search.png') 5px 11px/16px 16px no-repeat;">
+    <input type="search" id="search-input" class="needs-js bg-left bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" name="search-input" value="" style="background: url('/images/icon-search.png') 5px 11px/16px 16px no-repeat; background-color: rgba(255,255,255,0);">
   </fieldset>
 </form>


### PR DESCRIPTION
Safari has a bug for not showing transparent background when isn't in rgba. For unknown reasons, using commit d28cf15e1d20470a71a45f3d2337b97519f313c5 and 'hugo server', the search field is displayed corectly, but after deployment, isn't anymore. For this reasons I've added the background-color property separately and in rgba.