### PR TITLE
Add `getcontent` shortcode

### DIFF
--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -204,7 +204,7 @@ aliased form `.Pages`.
 
 ### `.Pages` compared to `.Site.Pages`
 
-{{< readfile file="/content/en/readfiles/pages-vs-site-pages.md" markdown="true" >}}
+{{< insertpages path="readfiles/pages-vs-site-pages.md" >}}
 
 ## Page-level Params
 

--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -204,7 +204,7 @@ aliased form `.Pages`.
 
 ### `.Pages` compared to `.Site.Pages`
 
-{{< insertpages path="readfiles/pages-vs-site-pages.md" >}}
+{{< getcontent path="readfiles/pages-vs-site-pages.md" >}}
 
 ## Page-level Params
 

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -127,7 +127,7 @@ You can use `.Site.Params` in a [partial template](/templates/partials/) to call
 
 ### `.Site.Pages` compared to `.Pages`
 
-{{< insertpages path="readfiles/pages-vs-site-pages.md" >}}
+{{< getcontent path="readfiles/pages-vs-site-pages.md" >}}
 
 
 

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -127,7 +127,7 @@ You can use `.Site.Params` in a [partial template](/templates/partials/) to call
 
 ### `.Site.Pages` compared to `.Pages`
 
-{{< readfile file="/content/en/readfiles/pages-vs-site-pages.md" markdown="true" >}}
+{{< insertpages path="readfiles/pages-vs-site-pages.md" >}}
 
 
 

--- a/layouts/shortcodes/getcontent.html
+++ b/layouts/shortcodes/getcontent.html
@@ -10,12 +10,12 @@ Usage: {{< getcontent path="PATH/TO/FILE" >}}
 {{ $scratch := newScratch -}}
 {{ with $glob -}}
   {{ $bundle := site.GetPage $path -}}
-  {{ $scratch.Set "pages" ($bundle.Resources.Match $glob) -}}
+  {{ $scratch.Set "resources" ($bundle.Resources.Match $glob) -}}
 {{ else -}}
   {{ $bundle := site.GetPage (path.Dir $path) -}}
-  {{ $scratch.Set "pages" ($bundle.Resources.Match (path.Base $path)) -}}
+  {{ $scratch.Set "resources" ($bundle.Resources.Match (path.Base $path)) -}}
 {{ end -}}
 
-{{ range ($scratch.Get "pages") -}}
+{{ range ($scratch.Get "resources") -}}
   {{ .Content }}
 {{ end -}}

--- a/layouts/shortcodes/getcontent.html
+++ b/layouts/shortcodes/getcontent.html
@@ -1,18 +1,18 @@
 <!-- {{/*
 Insert page `.Content` from a (headless) bundle; you can insert `.Content` from multiple page resources of the same bundle by specifying `glob`
 
-Usage: {{< insertpages path="PATH/TO/MD_FILE" >}}
-       {{< insertpages path="PATH/TO/BUNDLE" glob="*_PATTERN.md" >}}
+Usage: {{< insertpages path="PATH/TO/FILE" >}}
+       {{< insertpages path="PATH/TO/BUNDLE/" glob="*_PATTERN.md" >}}
 */}} -->
 {{- $path := .Get "path" -}}
 {{ $glob := .Get "glob" -}}
 
 {{ $scratch := newScratch -}}
 {{ with $glob -}}
-  {{ $bundle := site.GetPage (path.Join $path "index.md") -}}
+  {{ $bundle := site.GetPage $path -}}
   {{ $scratch.Set "pages" ($bundle.Resources.Match $glob) -}}
 {{ else -}}
-  {{ $bundle := site.GetPage (path.Join (path.Dir $path) "index.md") -}}
+  {{ $bundle := site.GetPage (path.Dir $path) -}}
   {{ $scratch.Set "pages" ($bundle.Resources.Match (path.Base $path)) -}}
 {{ end -}}
 

--- a/layouts/shortcodes/getcontent.html
+++ b/layouts/shortcodes/getcontent.html
@@ -1,5 +1,5 @@
 <!-- {{/*
-Insert `.Content` from a (headless) bundle; you can insert `.Content` from multiple page resources of the same bundle by specifying `glob`
+Insert `.Content` from a (headless) bundle. You can insert `.Content` from multiple page resources of the same bundle by specifying `glob`.
 
 Usage: {{< getcontent path="PATH/TO/FILE" >}}
        {{< getcontent path="PATH/TO/BUNDLE/" glob="*_PATTERN.md" >}}
@@ -7,15 +7,15 @@ Usage: {{< getcontent path="PATH/TO/FILE" >}}
 {{- $path := .Get "path" -}}
 {{ $glob := .Get "glob" -}}
 
-{{ $scratch := newScratch -}}
+{{ $resources := slice -}}
 {{ with $glob -}}
   {{ $bundle := site.GetPage $path -}}
-  {{ $scratch.Set "resources" ($bundle.Resources.Match $glob) -}}
+  {{ $resources = $bundle.Resources.Match $glob -}}
 {{ else -}}
   {{ $bundle := site.GetPage (path.Dir $path) -}}
-  {{ $scratch.Set "resources" ($bundle.Resources.Match (path.Base $path)) -}}
+  {{ $resources = $bundle.Resources.Match (path.Base $path) -}}
 {{ end -}}
 
-{{ range ($scratch.Get "resources") -}}
+{{ range $resources -}}
   {{ .Content }}
 {{ end -}}

--- a/layouts/shortcodes/getcontent.html
+++ b/layouts/shortcodes/getcontent.html
@@ -1,8 +1,8 @@
 <!-- {{/*
-Insert page `.Content` from a (headless) bundle; you can insert `.Content` from multiple page resources of the same bundle by specifying `glob`
+Insert `.Content` from a (headless) bundle; you can insert `.Content` from multiple page resources of the same bundle by specifying `glob`
 
-Usage: {{< insertpages path="PATH/TO/FILE" >}}
-       {{< insertpages path="PATH/TO/BUNDLE/" glob="*_PATTERN.md" >}}
+Usage: {{< getcontent path="PATH/TO/FILE" >}}
+       {{< getcontent path="PATH/TO/BUNDLE/" glob="*_PATTERN.md" >}}
 */}} -->
 {{- $path := .Get "path" -}}
 {{ $glob := .Get "glob" -}}

--- a/layouts/shortcodes/insertpages.html
+++ b/layouts/shortcodes/insertpages.html
@@ -4,7 +4,7 @@ Insert page `.Content` from a (headless) bundle; you can insert `.Content` from 
 Usage: {{< insertpages path="PATH/TO/MD_FILE" >}}
        {{< insertpages path="PATH/TO/BUNDLE" glob="*_PATTERN.md" >}}
 */}} -->
-{{ $path := .Get "path" -}}
+{{- $path := .Get "path" -}}
 {{ $glob := .Get "glob" -}}
 
 {{ $scratch := newScratch -}}

--- a/layouts/shortcodes/insertpages.html
+++ b/layouts/shortcodes/insertpages.html
@@ -1,0 +1,21 @@
+<!-- {{/*
+Insert page `.Content` from a (headless) bundle; you can insert `.Content` from multiple page resources of the same bundle by specifying `glob`
+
+Usage: {{< insertpages path="PATH/TO/MD_FILE" >}}
+       {{< insertpages path="PATH/TO/BUNDLE" glob="*_PATTERN.md" >}}
+*/}} -->
+{{ $path := .Get "path" -}}
+{{ $glob := .Get "glob" -}}
+
+{{ $scratch := newScratch -}}
+{{ with $glob -}}
+  {{ $bundle := site.GetPage (path.Join $path "index.md") -}}
+  {{ $scratch.Set "pages" ($bundle.Resources.Match $glob) -}}
+{{ else -}}
+  {{ $bundle := site.GetPage (path.Join (path.Dir $path) "index.md") -}}
+  {{ $scratch.Set "pages" ($bundle.Resources.Match (path.Base $path)) -}}
+{{ end -}}
+
+{{ range ($scratch.Get "pages") -}}
+  {{ .Content }}
+{{ end -}}


### PR DESCRIPTION
This is an alternative to the [`readfiles`](https://github.com/gohugoio/hugoDocs/blob/master/layouts/shortcodes/readfile.html) shortcode that is better suited to insert [headless](https://gohugo.io/content-management/page-bundles/#headless-bundle) page content since the inserted content can contain shortcodes itself. It's inspired by [this answer on Discourse](https://discourse.gohugo.io/t/using-hugo-shortcodes-in-readfile/20161/4).

This new shortcode is used to fix a regression introduced in https://github.com/gohugoio/hugoDocs/pull/1442 (`new-in` shortcode was not rendered as I intended).

If you agree, I can also update all other occurences of Markdown file snippet inclusion to use `getcontent` instead of `readfile`.