### PR TITLE
repair menu position on mobile devices

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-docs-mobile.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-docs-mobile.html
@@ -1,6 +1,6 @@
 {{ $currentPage := . }}
 {{ $menu := .Site.Menus.docs.ByWeight }}
-<ul class="list dib ph0 ma0 scrolling-touch tc">
+<ul class="list dib ph0 scrolling-touch tc">
   {{ range $menu }}{{ $post := printf "%s" .Post }}
     <li  class="tl dib ma0 hover-bg-black w-100{{ if eq $post "break" }} mb2 bb b--mid-gray{{ end }}">
         <a href="{{.URL}}" class="ttu f6 link primary-color-light  hover-white db brand-font mb1  ma0 w-100 pv2 ph4{{if $currentPage.IsMenuCurrent "main" . }} bg-primary-color{{end}}">

--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-global-mobile.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-links-global-mobile.html
@@ -1,6 +1,6 @@
 {{ $currentPage := . }}
 {{ $menu := .Site.Menus.global }}
-<ul class="list hidden dib ph0 ma0 scrolling-touch tc">
+<ul class="list hidden dib ph0 scrolling-touch tc">
   {{ range $menu }}
     <li  class="tl dib ma0 hover-bg-black w-100">
         <a href="{{.URL}}" class="ttu f6 link primary-color-light overflow hover-white db brand-font  ma0 w-100 pv3 ph4{{if $currentPage.IsMenuCurrent "main" . }} bg-primary-color{{end}}">

--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-mobile.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/nav-mobile.html
@@ -1,12 +1,12 @@
-<div  class="globalmenu mobilemenu pb3 dn">
+<div  class="globalmenu mobilemenu pb1 dn">
     {{ partial "nav-links-global-mobile.html" . }}
 </div>
-<div  class="docsmenu mobilemenu pb3 dn">
+<div  class="docsmenu mobilemenu pb1 dn">
     {{ partial "nav-links-docs-mobile.html" . }}
 </div>
 
 <div class="flex dn-l justify-between">
-  <button class="js-toggle flex-auto dib dn-l f6 tc db mt4-ns ph3 pv2 link mr2 white bg-primary-color-dark hover-bg-primary-color ba b--white-40 w-auto" data-target=".globalmenu">Menu</button>
+  <button class="js-toggle flex-auto dib dn-l f6 tc db ph3 pv2 link mr2 white bg-primary-color-dark hover-bg-primary-color ba b--white-40 w-auto" data-target=".globalmenu">Menu</button>
 
-  <button class="js-toggle flex-auto dib dn-l f6 tc db mt4-ns ph3 pv2 link white bg-primary-color-dark hover-bg-primary-color ba b--white-40 w-auto" data-target=".docsmenu">Docs Menu</button>
+  <button class="js-toggle flex-auto dib dn-l f6 tc db ph3 pv2 link white bg-primary-color-dark hover-bg-primary-color ba b--white-40 w-auto" data-target=".docsmenu">Docs Menu</button>
 </div>

--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-footer.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-footer.html
@@ -41,7 +41,7 @@
 
     <img src="/images/gopher-side_color.svg" alt="" class="absolute-l bottom-0 dn db-l h4 right-0 z-999"/>
 
-    <div class="bg-primary-color-dark bottom-0 left-0 right-0 dn-l fixed pb3 ph3 w-100">
+    <div class="bg-primary-color-dark bottom-0 left-0 right-0 dn-l fixed pb3 ph3 pt3 w-100">
       {{- partial "nav-mobile.html" . -}}
     </div>
 


### PR DESCRIPTION
When media screen is under 30rem, the menu and menu docs doesn't have padding on top and the top item from menu docs isn't visible