### PR TITLE
docs: Escaping Hugo/GO template code

### DIFF
--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -79,6 +79,20 @@ func GetTitleFunc(style string) func(s string) string {
 }
 {{< / highlight >}}
 
+## Highlight Hugo/GO Template Code
+
+For highlighting Hugo/GO template code on your page, add `/*` after the opening double curly braces and `*/` before closing curly braces.
+
+``` go
+{{</*/* myshortcode */*/>}}
+```
+
+Gives this:
+
+``` go
+{{</* myshortcode */>}}
+```
+
 ## Highlight Template Func
 
 See [Highlight](/functions/highlight/).


### PR DESCRIPTION
Short example how to escape Hugo/GO template code used in a highlight shortcode.

Fixes: #1442