### PR TITLE
Hosting on GitHub: reflect configuration of used branch

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -36,12 +36,7 @@ Please refer to the [GitHub Pages documentation][ghorgs] to decide which type of
 
 ## GitHub User or Organization Pages
 
-As mentioned in the [GitHub Pages documentation][ghorgs], you can host a user/organization page in addition to project pages. Here are the key differences in GitHub Pages websites for Users and Organizations:
-
-1. You must use a `<USERNAME>.github.io` to host your **generated** content
-2. Content from the `main` branch will be used to publish your GitHub Pages site
-
-This is a much simpler setup as your Hugo files and generated content are published into two different repositories.
+As mentioned in the [GitHub Pages documentation][ghorgs], you can host a user/organization page in addition to project pages. The key difference is that you must use a `<USERNAME>.github.io` URL to host your **generated** content.
 
 ## Build Hugo With GitHub Action
 

--- a/content/en/hosting-and-deployment/hosting-on-github.md
+++ b/content/en/hosting-and-deployment/hosting-on-github.md
@@ -84,6 +84,15 @@ jobs:
 
 For more advanced settings https://github.com/marketplace/actions/hugo-setup 
 
+## Configure the branch used by GitHub Pages
+
+The workflow above will build your site with Hugo and push the resulting `public` folder to a new branch called `gh-pages`. This is the branch, whose content you want to publish with GitHub Pages. By default, GitHub Pages publishes the content of the `main` or `master` branch.
+
+After the workflow has run successfully at least once and the branch `gh-pages` has been created, you need to change the branch used by GitHub Pages. A symptom of a wrongly configured branch can be that GitHub Pages only displays your project's `README.md`, because there's usually no `index.html` in the root folder to use instead.
+
+Go to your GitHub project settings and move to the `Pages` section or open the URL directly: `https://github.com/<USERNAME|ORGANIZATION>/<PROJECT>/settings/pages`
+In the `Source` section, change the branch to `gh-pages` and click `Save`. GitHub Pages should display the contents of this branch (your Hugo site) shortly after.
+
 ## Use a Custom Domain
 
 If you'd like to use a custom domain for your GitHub Pages site, create a file `static/CNAME`. Your custom domain name should be the only contents inside `CNAME`. Since it's inside `static`, the published site will contain the CNAME file at the root of the published site, which is a requirement of GitHub Pages.


### PR DESCRIPTION
Even though the GitHub Pages docs suggest using the `main` branch for personal or organization pages, the Hugo docs about Hosting on GitHub - correctly - suggest a GitHub workflow configuration, which pushes the site built by Hugo to a branch `gh-pages` and not the `main` branch (which makes sense because the Hugo page itself, not the built version, which you want to publish, is in `main`).
The action in question is `peaceiris/actions-gh-pages`.

At least for personal or organization pages the `gh-pages` branch needs to be explicitly set to be used by GitHub Pages  - otherwise it uses the `main` or `master` branch and the user might end up with a 404 or just the projects README (if it exists) being shown.

I stumbled upon the issue this week while migrating my own site running on GitHub Pages to Hugo and believe it stems from the GitHub Pages docs having been used when writing this document initially even though they might be specific to Jekyll, which is tightly integrated with GitHub Pages, in this particular aspect.

With the Jekyll version of my site the `main` branch was indeed the only one, which, combined with the docs, confused me.

This PR proposes adding a section about configuring the `gh-pages` branch to be the one used by GitHub Pages and modifying a section above to reflect this.

Looking forward to reading what you think about this issue.