### PR TITLE
Make render-heading example accessible by default

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -221,7 +221,7 @@ Here is a code example for how the render-image.html template could look:
 Given this template file
 
 {{< code file="layouts/_default/_markup/render-heading.html" >}}
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}">¶</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a aria-hidden="true" href="#{{ .Anchor | safeURL }}">¶</a></h{{ .Level }}>
 {{< /code >}}
 
 And this markdown

--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -221,7 +221,7 @@ Here is a code example for how the render-image.html template could look:
 Given this template file
 
 {{< code file="layouts/_default/_markup/render-heading.html" >}}
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a aria-hidden="true" href="#{{ .Anchor | safeURL }}">¶</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a aria-label="Anchor" href="#{{ .Anchor | safeURL }}">¶</a></h{{ .Level }}>
 {{< /code >}}
 
 And this markdown


### PR DESCRIPTION
Since this code will be copy-pasted on many projects, it's important to make sure it's accessible.