### PR TITLE
add Azure Static Web App config to 404 template

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -53,7 +53,8 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 * Amazon CloudFront. You can specify the page in the Error Pages section in the CloudFront Console. [Details here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html)
 * Caddy Server. Using `errors { 404 /404.html }`. [Details here](https://caddyserver.com/docs/errors)
 * Netlify. Add `/* /404.html 404` to `content/_redirects`. [Details Here](https://www.netlify.com/docs/redirects/#custom-404)
-* Azure Static website. You can specify the `Error document path` in the Static website configuration page of the Azure portal. [More details are available in the Static website documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website).
+* Azure Static Web App. set `responseOverrides.404.rewrite` and `responseOverrides.404.statusCode` in configfile `staticwebapp.config.json`. [Details here](https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#response-overrides)
+* Azure Storage as Static Web Site Hosting. You can specify the `Error document path` in the Static website configuration page of the Azure portal. [Details here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website).
 
 {{% note %}}
 `hugo server` will not automatically load your custom `404.html` file, but you


### PR DESCRIPTION
add Azure Static Web App specification to Automatic loading spec

Reword Azure Storage option to further differentiate between hosting in Azure Storage and using Azure Static Web Apps

closes #1464 