### PR TITLE
Include flexible translation information in i18n article

### DIFF
--- a/content/en/functions/i18n.md
+++ b/content/en/functions/i18n.md
@@ -29,6 +29,27 @@ This translates a piece of content based on your `i18n/en-US.yaml` (and similar)
 `T` is an alias to `i18n`. E.g. `{{ T "translation_id" }}`.
 {{% /note %}}
 
+### Query a flexible translation with variables
+
+Often you will want to use the page variables in the translation strings. To do so, pass the `.` context when calling `i18n`:
+
+```
+{{ i18n "wordCount" . }}
+```
+
+The function will pass the `.` context to the `"wordCount"` id:
+
+{{< code-toggle file="i18n/en-US" >}}
+[wordCount]
+other = "This article has {{ .WordCount }} words."
+{{< /code-toggle >}}
+
+Assume `.WordCount` in the context has value is 101. The result will be:
+
+```
+This article has 101 words.
+```
+
 For more information about string translations, see [Translation of Strings in Multilingual Mode][multistrings].
 
 [multistrings]: /content-management/multilingual/#translation-of-strings


### PR DESCRIPTION
The flexible translation feature of the i18n function is missing from the main entry for the i18n function. While this information can be found by reading the very long article for Multilingual Mode, I think it should be included here as well as otherwise most users may not even realize it is available. 

To remedy this I simply copied the relevant section from the [Multilingual Mode](https://gohugo.io/content-management/multilingual/#translation-of-strings) article into the [i18n](https://gohugo.io/functions/i18n/) article. 

I did not include the following section about plurals, although there is certainly an argument to be made for including that as well. 