### PR TITLE
Adding info about where to place the pipeline code

### DIFF
--- a/content/en/hugo-pipes/introduction.md
+++ b/content/en/hugo-pipes/introduction.md
@@ -39,6 +39,7 @@ For improved readability, the Hugo Pipes examples of this documentation will be 
 {{ $style := resources.Get "sass/main.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $style.Permalink }}">
 ```
+Place the above code within the HTML where you would normally include your CSS such as the Base template.
 
 ### Method aliases
 


### PR DESCRIPTION
People have had trouble knowing where to place the pipeline code [[ref 1](https://github.com/gohugoio/hugo/issues/5293)], [[ref 2](https://stackoverflow.com/q/54057291/5407188)]. I personally spent some time on this too until I saw the link tag.

Think it could be useful to have it in the document.