### PR TITLE
live reload: add section about `--navigateToChanged`

### DIFF
--- a/content/en/getting-started/usage.md
+++ b/content/en/getting-started/usage.md
@@ -167,6 +167,11 @@ Most Hugo builds are so fast that you may not notice the change unless looking d
 Hugo injects the LiveReload `<script>` before the closing `</body>` in your templates and will therefore not work if this tag is not present..
 {{% /note %}}
 
+### Redirect automatically to the page you just saved
+
+When you are working with more than one document and want to see the markup as real-time as possible it's not ideal to keep jumping between them. 
+Fortunately Hugo has an easy, embedded and simple solution for this. It's the flag `--navigateToChanged`.
+
 ### Disable LiveReload
 
 LiveReload works by injecting JavaScript into the pages Hugo generates. The script creates a connection from the browser's web socket client to the Hugo web socket server.


### PR DESCRIPTION
After some hours of hacking I've discovered that Hugo do this with just one extra flag.

I think it should be more explicit, probably saving some hours of someone else xD.

Related: https://discourse.gohugo.io/t/how-to-get-the-changed-file-route-on-the-frontend-part/33260