### PR TITLE
PageResources: Clarifications to methods and sample layout

### DIFF
--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -25,9 +25,9 @@ content
 └── post
     ├── first-post
     │   ├── images
-    │   │   ├── morning.jpg
-    │   │   ├── sunset.jpg
-    │   │   └── moonrise.jpg
+    │   │   ├── a.jpg
+    │   │   ├── b.jpg
+    │   │   └── c.jpg
     │   ├── index.md (root of page bundle)
     │   ├── latest.html
     │   ├── manual.json
@@ -76,14 +76,11 @@ MediaType.Suffixes
 
 ## Methods
 ByType
-: Returns the page resources of the given type as a slice.
+: Returns the page resources of the given type.
 
 ```go
 {{ .Resources.ByType "image" }}
 ```
-
-returns "images/morning.jpg", "images/sunset.jpg" and "images/moonrise.jpg".
-
 Match
 : Returns all the page resources (as a slice) whose `Name` matches the given Glob pattern ([examples](https://github.com/gobwas/glob/blob/master/readme.md)). The matching is case-insensitive.
 
@@ -91,10 +88,8 @@ Match
 {{ .Resources.Match "images/*" }}
 ```
 
-returns "images/morning.jpg", "images/sunset.jpg" and "images/moonrise.jpg", same as `Resources.ByType "image"`.
-
 GetMatch
-: Same as `Match` but will return the first match as a single resource, not a slice.
+: Same as `Match` but will return the first match.
 
 ### Pattern Matching
 ```go

--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -25,9 +25,9 @@ content
 └── post
     ├── first-post
     │   ├── images
-    │   │   ├── a.jpg
-    │   │   ├── b.jpg
-    │   │   └── c.jpg
+    │   │   ├── morning.jpg
+    │   │   ├── sunset.jpg
+    │   │   └── moonrise.jpg
     │   ├── index.md (root of page bundle)
     │   ├── latest.html
     │   ├── manual.json
@@ -76,11 +76,14 @@ MediaType.Suffixes
 
 ## Methods
 ByType
-: Returns the page resources of the given type.
+: Returns the page resources of the given type as a slice.
 
 ```go
 {{ .Resources.ByType "image" }}
 ```
+
+returns "images/morning.jpg", "images/sunset.jpg" and "images/moonrise.jpg".
+
 Match
 : Returns all the page resources (as a slice) whose `Name` matches the given Glob pattern ([examples](https://github.com/gobwas/glob/blob/master/readme.md)). The matching is case-insensitive.
 
@@ -88,8 +91,10 @@ Match
 {{ .Resources.Match "images/*" }}
 ```
 
+returns "images/morning.jpg", "images/sunset.jpg" and "images/moonrise.jpg", same as `Resources.ByType "image"`.
+
 GetMatch
-: Same as `Match` but will return the first match.
+: Same as `Match` but will return the first match as a single resource, not a slice.
 
 ### Pattern Matching
 ```go


### PR DESCRIPTION
I added some clarifications to the method's descriptions (as far as I understood them). Also, I changed the sample layout to better work with the example method calls later on.

See [Issue 1487](https://github.com/gohugoio/hugoDocs/issues/1487)