### PR TITLE
📄 Add more clarity on merging of config files 

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -78,7 +78,7 @@ foo = "bar"
 
 Considering the structure above, when running `hugo --environment staging`, Hugo will use every settings from `config/_default` and merge `staging`'s on top of those.
 
-Let's take an example to understand this better. Let's say you are using Google analytics for your website. This requires you to specify `googleAnalytics = "UA-XXXXXXXX"` in `config.toml`. Now consider the following scenario:
+Let's take an example to understand this better. Let's say you are using Google Analytics for your website. This requires you to specify `googleAnalytics = "UA-XXXXXXXX"` in `config.toml`. Now consider the following scenario:
 - You don't want the Analytics code to be loaded in development i.e. in your `localhost`
 - You want to use separate googleAnalytics IDs for your production & staging environments (say):
   - `UA-PPPPPPPP` for production

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -4,7 +4,6 @@ linktitle: Configuration
 description: How to configure your Hugo site.
 date: 2013-07-01
 publishdate: 2017-01-02
-lastmod: 2017-03-05
 categories: [getting started,fundamentals]
 keywords: [configuration,toml,yaml,json]
 menu:
@@ -17,7 +16,6 @@ draft: false
 aliases: [/overview/source-directory/,/overview/configuration/]
 toc: true
 ---
-
 
 ## Configuration File
 
@@ -78,24 +76,24 @@ foo = "bar"
 
 Considering the structure above, when running `hugo --environment staging`, Hugo will use every settings from `config/_default` and merge `staging`'s on top of those.
 
-Let's take an example to understand this better. Let's say you are using Google Analytics for your website. This requires you to specify `googleAnalytics = "UA-XXXXXXXX"` in `config.toml`. Now consider the following scenario:
+Let's take an example to understand this better. Let's say you are using Google Analytics for your website. This requires you to specify `googleAnalytics = "G-XXXXXXXX"` in `config.toml`. Now consider the following scenario:
 - You don't want the Analytics code to be loaded in development i.e. in your `localhost`
 - You want to use separate googleAnalytics IDs for your production & staging environments (say):
-  - `UA-PPPPPPPP` for production
-  - `UA-SSSSSSSS` for staging
+  - `G-PPPPPPPP` for production
+  - `G-SSSSSSSS` for staging
 
 This is how you need to configure your `config.toml` files considering the above scenario:
 1. In `_default/config.toml` you don't need to mention `googleAnalytics` parameter at all. This ensures that no Google Analytics code is loaded in your development server i.e. when you run `hugo serve`. This works since, by default Hugo sets `Environment=development` when you run `hugo serve` which uses the config files from `_default` folder
 2. In `production/config.toml` you just need to have one line:
 
-    ```googleAnalytics = "UA-PPPPPPPP"```
+    ```googleAnalytics = "G-PPPPPPPP"```
 
-    You don't need to mention all other parameters like `title`, `baseURL`, `theme` etc. again in this config file. You need to mention only those parameters which are different or new for the production environment. This is due to the fact that Hugo is going to __merge__ this on top of `_default/config.toml`. Now when you run `hugo` (build command), by default hugo sets `Environment=production`, so the `UA-PPPPPPPP` analytics code will be there in your production website
+    You don't need to mention all other parameters like `title`, `baseURL`, `theme` etc. again in this config file. You need to mention only those parameters which are different or new for the production environment. This is due to the fact that Hugo is going to __merge__ this on top of `_default/config.toml`. Now when you run `hugo` (build command), by default hugo sets `Environment=production`, so the `G-PPPPPPPP` analytics code will be there in your production website
 3. Similarly in `staging/config.toml` you just need to have one line:
 
-    ```googleAnalytics = "UA-SSSSSSSS"```
+    ```googleAnalytics = "G-SSSSSSSS"```
     
-    Now you need to tell Hugo that you are using the staging environment. So your build command should be `hugo --environment staging` which will load the `UA-SSSSSSSS` analytics code in your staging website
+    Now you need to tell Hugo that you are using the staging environment. So your build command should be `hugo --environment staging` which will load the `G-SSSSSSSS` analytics code in your staging website
 
 
 {{% note %}}

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -90,7 +90,7 @@ This is how you need to configure your `config.toml` files considering the above
 
     ```googleAnalytics = "UA-PPPPPPPP"```
 
-    You don't need to mention all other parameters like `title`, `baseURL`, `theme` etc. againg in this config file. You need to mention only those parameters which are different or new for the production environment. This is due to the fact that Hugo is going to __merge__ this on top of `_default/config.toml`. Now when you run `hugo` (build command), by default hugo sets `Environment=production`, so the `UA-PPPPPPPP` analytics code will be there in your production website
+    You don't need to mention all other parameters like `title`, `baseURL`, `theme` etc. again in this config file. You need to mention only those parameters which are different or new for the production environment. This is due to the fact that Hugo is going to __merge__ this on top of `_default/config.toml`. Now when you run `hugo` (build command), by default hugo sets `Environment=production`, so the `UA-PPPPPPPP` analytics code will be there in your production website
 3. Similarly in `staging/config.toml` you just need to have one line:
 
     ```googleAnalytics = "UA-SSSSSSSS"```

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -84,7 +84,7 @@ Let's take an example to understand this better. Let's say you are using Google 
   - `UA-PPPPPPPP` for production
   - `UA-SSSSSSSS` for staging
 
-This is how you need to configure tour `config.toml` files considering the above scenario:
+This is how you need to configure your `config.toml` files considering the above scenario:
 1. In `_default/config.toml` you don't need to mention `googleAnalytics` parameter at all. This ensures that no Google Analytics code is loaded in your development server i.e. when you run `hugo serve`. This works since, by default Hugo sets `Environment=development` when you run `hugo serve` which uses the config files from `_default` folder
 2. In `production/config.toml` you just need to have one line:
 

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -85,7 +85,7 @@ Let's take an example to understand this better. Let's say you are using Google 
   - `UA-SSSSSSSS` for staging
 
 This is how you need to configure tour `config.toml` files considering the above scenario:
-1. In `_default/config.toml` you don't need to mention the `googleAnalytics` parameter at all. This ensures that no Google Analytics code is not loaded in your development server i.e. when you run hugo serve. This works since, by default Hugo sets `Environment=development` when you run `hugo serve` which uses the config files from `_default` folder
+1. In `_default/config.toml` you don't need to mention `googleAnalytics` parameter at all. This ensures that no Google Analytics code is loaded in your development server i.e. when you run `hugo serve`. This works since, by default Hugo sets `Environment=development` when you run `hugo serve` which uses the config files from `_default` folder
 2. In `production/config.toml` you just need to have one line:
 
     ```googleAnalytics = "UA-PPPPPPPP"```
@@ -95,7 +95,7 @@ This is how you need to configure tour `config.toml` files considering the above
 
     ```googleAnalytics = "UA-SSSSSSSS"```
     
-    Now you got to tell Hugo that you are using the staging environment. So your build command should be `hugo --environment staging` which will load the `UA-SSSSSSSS` analytics code in your staging website
+    Now you need to tell Hugo that you are using the staging environment. So your build command should be `hugo --environment staging` which will load the `UA-SSSSSSSS` analytics code in your staging website
 
 
 {{% note %}}

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -77,6 +77,27 @@ foo = "bar"
 ```
 
 Considering the structure above, when running `hugo --environment staging`, Hugo will use every settings from `config/_default` and merge `staging`'s on top of those.
+
+Let's take an example to understand this better. Let's say you are using Google analytics for your website. This requires you to specify `googleAnalytics = "UA-XXXXXXXX"` in `config.toml`. Now consider the following scenario:
+- You don't want the Analytics code to be loaded in development i.e. in your `localhost`
+- You want to use separate googleAnalytics IDs for your production & staging environments (say):
+  - `UA-PPPPPPPP` for production
+  - `UA-SSSSSSSS` for staging
+
+This is how you need to configure tour `config.toml` files considering the above scenario:
+1. In `_default/config.toml` you don't need to mention the `googleAnalytics` parameter at all. This ensures that no Google Analytics code is not loaded in your development server i.e. when you run hugo serve. This works since, by default Hugo sets `Environment=development` when you run `hugo serve` which uses the config files from `_default` folder
+2. In `production/config.toml` you just need to have one line:
+
+    ```googleAnalytics = "UA-PPPPPPPP"```
+
+    You don't need to mention all other parameters like `title`, `baseURL`, `theme` etc. againg in this config file. You need to mention only those parameters which are different or new for the production environment. This is due to the fact that Hugo is going to __merge__ this on top of `_default/config.toml`. Now when you run `hugo` (build command), by default hugo sets `Environment=production`, so the `UA-PPPPPPPP` analytics code will be there in your production website
+3. Similarly in `staging/config.toml` you just need to have one line:
+
+    ```googleAnalytics = "UA-SSSSSSSS"```
+    
+    Now you got to tell Hugo that you are using the staging environment. So your build command should be `hugo --environment staging` which will load the `UA-SSSSSSSS` analytics code in your staging website
+
+
 {{% note %}}
 Default environments are __development__ with `hugo server` and __production__ with `hugo`.
 {{%/ note %}}


### PR DESCRIPTION
## 🤔 What does this PR do ?
It adds more clarity on merging of config files when different config files for different environments are present in a Hugo site.

## 📄 Which files does this PR modify ?
File `configuration.md` located at `content/en/getting-started/configuration.md`

## 🖼️ Screenshots

#### Before this PR
![image](https://user-images.githubusercontent.com/68782815/125898742-4cb93d93-f5ec-4133-9749-fa38be98ad12.png)

#### After this PR
![image](https://user-images.githubusercontent.com/68782815/125921204-fcc96b46-35f0-4a09-b47f-20d22e1a19fa.png)

