### PR TITLE
Update starter-kits.md

### DIFF
--- a/content/en/tools/starter-kits.md
+++ b/content/en/tools/starter-kits.md
@@ -24,22 +24,14 @@ The following starter kits are developed by active members of the Hugo community
 {{% /note %}}
 
 * [Hugo Wrapper][hugow]. Hugo Wrapper is a POSIX-style shell script which acts as a wrapper to download and run Hugo binary for your platform. It can be executed in variety of [Operating Systems][hugow-test] and [Command Shells][hugow-test].
-* [Victor Hugo][]. Victor Hugo is a Hugo boilerplate for creating truly epic websites using Webpack as an asset pipeline. Victor Hugo uses post-css and Babel for CSS and JavaScript, respectively, and is actively maintained.
 * [GOHUGO AMP][]. GoHugo AMP is a starter theme that aims to make it easy to adopt [Google's AMP Project][amp]. The starter kit comes with 40+ shortcodes and partials plus automatic structured data. The project also includes a [separate site with extensive documentation][gohugodocs].
-* [Blaupause][]. Blaupause is a developer-friendly Hugo starter kit based on Gulp tasks. It comes ES6-ready with several helpers for SVG and fonts and basic structure for HTML, SCSS, and JavaScript.
-* [hugulp][]. hugulp is a tool to optimize the assets of a Hugo website. The main idea is to recreate the famous Ruby on Rails Asset Pipeline, which minifies, concatenates and fingerprints the assets used in your website.
-* [Atlas][]. Atlas is a Hugo boilerplate designed to speed up development with support for Netlify, Hugo Pipes, SCSS & more. It's actively maintained and contributions are always welcome.
 * [Hyas][]. Hyas is a Hugo starter helping you build modern websites that are secure, fast, and SEO-ready — by default. It is Netlify-ready (functions, redirects, headers) and comes with [documentation](https://gethyas.com/) to easily make it your own.
 
 
 [addkit]: https://github.com/gohugoio/hugo/edit/master/docs/content/en/tools/starter-kits.md
 [amp]: https://amp.dev
-[Blaupause]: https://github.com/fspoettel/blaupause
 [GOHUGO AMP]: https://github.com/wildhaber/gohugo-amp
 [gohugodocs]: https://gohugo-amp.gohugohq.com/
 [hugow]: https://github.com/khos2ow/hugo-wrapper
 [hugow-test]: https://github.com/khos2ow/hugo-wrapper#tested-on
-[hugulp]: https://github.com/jbrodriguez/hugulp
-[Victor Hugo]: https://github.com/netlify/victor-hugo
-[Atlas]: https://github.com/indigotree/atlas
 [Hyas]: https://github.com/h-enk/hyas


### PR DESCRIPTION
Blaupause, victor-hugo, hugulp, and atlas are all either deprecated, archived, or abandoned.