### PR TITLE
Fix mobile footer getting stacked below .tab-button elements

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-footer.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/partials/site-footer.html
@@ -41,7 +41,7 @@
 
     <img src="/images/gopher-side_color.svg" alt="" class="absolute-l bottom-0 dn db-l h4 right-0 z-999"/>
 
-    <div class="bg-primary-color-dark bottom-0 left-0 right-0 dn-l fixed pb3 ph3 w-100">
+    <div class="bg-primary-color-dark bottom-0 left-0 right-0 dn-l fixed pb3 ph3 w-100 z-2">
       {{- partial "nav-mobile.html" . -}}
     </div>
 


### PR DESCRIPTION
Mobile footer is getting stacked below the tab buttons of language-specific implementation examples.

![Screenshot 2021-09-12 at 09 00 41](https://user-images.githubusercontent.com/11093698/132971878-6e795c53-7e5c-4f87-8fbb-507db0ba6da5.png)

This PR is an attempt to change the stacking index of the footer to overcome that.
