### PR TITLE
Updates Hugo Pipes (JS building sourcemaps) documentation

### DIFF
--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -93,7 +93,7 @@ format [string] {{< new-in "0.74.3" >}}
   Default is `iife`, a self-executing function, suitable for inclusion as a <script> tag.
 
 sourceMap
-: Whether to generate source maps. Enum, currently only `inline` (we will improve that).
+: Whether to generate source maps. Enum, currently only `inline` or `external` (we will improve that).
 
 ### Import JS code from /assets
 


### PR DESCRIPTION
Based on [this commit](https://github.com/gohugoio/hugo/commit/2c8b5d9165011c4b24b494e661ae60dfc7bb7d1b) it looks like `external` is an option for JS building with Hugo Pipes.   Just adding this to the documentation.   Not sure if there are plans to add other options - if not i'm happy to remove the "(we will improve that)" part.   Thanks!