### PR TITLE
Fix broken links

### DIFF
--- a/content/en/functions/chomp.md
+++ b/content/en/functions/chomp.md
@@ -1,7 +1,8 @@
 ---
 title: chomp
+toc: true
 description: Removes any trailing newline characters.
-godocref: Removes any trailing newline characters.
+godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-02-01

--- a/content/en/functions/scratch.md
+++ b/content/en/functions/scratch.md
@@ -43,7 +43,7 @@ Since Hugo 0.43, there are two different ways of using Scratch:
 
 #### The local `newScratch`
 
-{{< new-in "0.43.0" >}} A Scratch instance can also be assigned to any variable using the `newScratch` function. In this case, no Page or Shortcode context is required and the scope of the scratch is only local. The methods detailed below are available from the variable the Scratch instance was assigned to.
+{{< new-in "0.43" >}} A Scratch instance can also be assigned to any variable using the `newScratch` function. In this case, no Page or Shortcode context is required and the scope of the scratch is only local. The methods detailed below are available from the variable the Scratch instance was assigned to.
 
 ```go-html-template
 {{ $data := newScratch }}
@@ -139,7 +139,7 @@ Return an array of values from `key` sorted by `mapKey`.
 
 #### .Delete
 
-{{< new-in "0.38.0" >}} Remove the given key.
+{{< new-in "0.38" >}} Remove the given key.
 
 ```go-html-template
 {{ $scratch.Set "greeting" "Hello" }}

--- a/content/en/functions/unix.md
+++ b/content/en/functions/unix.md
@@ -2,7 +2,7 @@
 title: .Unix
 draft: false
 description: .Unix returns the local Time corresponding to the given Unix time, sec seconds and nsec nanoseconds since January 1, 1970 UTC.
-godocref: https://golang.org/search?q=Unix#Functions
+godocref:
 date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-02-01

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -319,7 +319,7 @@ Default number of elements per page in [pagination](/templates/pagination/).
 
 **Default value:** "page"
 
-The path element used during pagination (https://example.com/page/2).
+The path element used during pagination (`https://example.com/page/2`).
 
 ### permalinks
 See [Content Management](/content-management/urls/#permalinks).

--- a/content/en/news/0.14-relnotes/index.md
+++ b/content/en/news/0.14-relnotes/index.md
@@ -24,7 +24,7 @@ Hugo also depends on a lot of other great projects. A big thanks to all of our d
 - Add `AsciiDoc` support using external helpers.
 - Add experimental support for [`Mmark`](https://github.com/miekg/mmark) markdown processor
 - Bash autocomplete support via `genautocomplete` command
-- Add section menu support for a [Section Menu for "the Lazy Blogger"](http://gohugo.io/extras/menus.md#section-menu-for-the-lazy-blogger")
+- Add section menu support for a [Section Menu for Lazy Bloggers](https://gohugo.io/templates/menu-templates/#section-menu-for-lazy-bloggers)
 - Add support for `Ace` base templates
 - Adding `RelativeURLs = true` to site config will now make all the relative URLs relative to the content root.
 - New template functions:

--- a/content/en/templates/shortcode-templates.md
+++ b/content/en/templates/shortcode-templates.md
@@ -369,7 +369,7 @@ More shortcode examples can be found in the [shortcodes directory for spf13.com]
 
 ## Inline Shortcodes
 
-{{< new-in "0.52.0" >}}
+{{< new-in "0.52" >}}
 
 Since Hugo 0.52, you can implement your shortcodes inline -- e.g. where you use them in the content file. This can be useful for scripting that you only need in one place.
 

--- a/data/homepagetweets.toml
+++ b/data/homepagetweets.toml
@@ -13,20 +13,6 @@ link = "https://twitter.com/jscarto/status/1039648827815485440"
 date = 2018-09-12T00:00:00Z
 
 [[tweet]]
-name = "Jens Munch"
-twitter_handle = "@jensamunch"
-quote = "Hugo is really, really incredible... Now does resizing/resampling of images as well! Crazy that something so fast can be a static site generator... Amazing open-source project."
-link = "https://twitter.com/jensamunch/status/948533063537086464"
-date = 2018-01-03T04:00:00Z
-
-[[tweet]]
-name = "STOQE"
-twitter_handle = "@STOQE"
-quote = "I fear <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a> v0.22 might be so fast it creates a code vortex that time-warps me back to a time I used Wordpress. <a href='https://twitter.com/hashtag/gasp?src=hash'>#gasp</a>"
-link = "https://twitter.com/STOQE/status/874184881701494784"
-date = 2017-06-12T00:00:00Z
-
-[[tweet]]
 name = "Christophe Diericx"
 twitter_handle = "@spcrngr_"
 quote = "The more I use <a href='https://gohugo.io' target='_blank'>gohugo.io</a>, the more I really like it. Super intuitive/powerful static site generator...great job <a href='https://twitter.com/gohugoio' target='_blank'>@GoHugoIO</a>"


### PR DESCRIPTION
There are still several broken links in old release notes, but I'm not
not going to worry about those right now...

- /news/0.7-relnotes/
- /news/0.10-relnotes/
- /news/0.11-relnotes/
- /news/0.12-relnotes/
- /news/0.13-relnotes/