### PR TITLE
Clarify the distinction between resources and .Resources

### DIFF
--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -13,10 +13,7 @@ menu:
     parent: "content-management"
     weight: 31
 ---
-Page resources are only accessible from [page bundles]({{< relref
-"/content-management/page-bundles" >}}), those directories with `index.md` or
-`_index.md` files at their root. Page resources are only available to the
-page with which they are bundled.
+Page resources are only accessible from [page bundles]({{< relref "/content-management/page-bundles" >}}), those directories with `index.md` or `_index.md` files at their root. Page resources are accessible through `.Resources`, but only on the page with which they are bundled. Page resources are separate from [global assets]({{< relref "/hugo-pipes/introduction" >}}) which are accessible through `resources`.
 
 In this example, `first-post` is a page bundle with access to 10 page resources including audio, data, documents, images, and video. Although `second-post` is also a page bundle, it has no page resources and is unable to directly access the page resources associated with `first-post`.
 
@@ -75,6 +72,7 @@ MediaType.Suffixes
 : A slice of possible suffixes for the resource's MIME type.
 
 ## Methods
+
 ByType
 : Returns the page resources of the given type.
 
@@ -90,6 +88,8 @@ Match
 
 GetMatch
 : Same as `Match` but will return the first match.
+
+Note that unlike [global assets]({{< relref "/hugo-pipes/introduction" >}}) which support a `resources.Get` method, there is no `.Resources.Get` method for page resources. `.Resources.GetMatch` should be used for this purpose.
 
 ### Pattern Matching
 ```go

--- a/content/en/hugo-pipes/introduction.md
+++ b/content/en/hugo-pipes/introduction.md
@@ -28,6 +28,8 @@ In order to process an asset with Hugo Pipes, it must be retrieved as a resource
 {{ $style := resources.Get "sass/main.scss" }}
 ```
 
+Note that `resources` is separate from `.Resources`, which is used for [page resources]({{< relref "/content-management/page-resources" >}}).
+
 ### Asset publishing
 
 Assets will only be published (to `/public`) if `.Permalink` or `.RelPermalink` is used.


### PR DESCRIPTION
I've seen a number of references/comments that mix up resources.Get and .Resources.GetMatch (for example: https://discourse.gohugo.io/t/data-files-in-the-page-bundle/19284/2).  This leads to confusion (for example: https://discourse.gohugo.io/t/what-am-i-not-getting-about-resources-get/33517).

Ideally, `resources` would have a different name (like `assets`) to eliminate some of the ambiguity with `.Resources`.  However, since it is probably too late to change the name now, the next best thing would be to have the docs more explicitly distinguish between these.

This PR attempts to clarify the distinction between these in the documentation.