### PR TITLE
Display 'Configure Markup' in list of content

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -4,6 +4,10 @@ description: How to handle Markdown and other markup related configuration.
 date: 2019-11-15
 categories: [getting started,fundamentals]
 keywords: [configuration,highlighting]
+menu:
+  docs:
+    parent: "getting-started"
+    weight: 65
 weight: 65
 sections_weight: 65
 slug: configuration-markup


### PR DESCRIPTION
Related to #1473 

When on the [Configure Hugo](https://gohugo.io/getting-started/configuration/) page
- clicking the right arrow on the right sidebar 
- brings you to the [Configure Markdown](https://gohugo.io/getting-started/configuration-markup/) page
- This page doesn't show up in the list of content on the right and is a bit confusing as brought up in #1473 

![image](https://user-images.githubusercontent.com/892961/139463047-3fa131a5-6d46-4ce5-a7aa-f9279a031c28.png)

* * * 

This PR makes the page visible in the list as shown below to make it less confusing

![image](https://user-images.githubusercontent.com/892961/139463143-e7859b06-edc6-4dfe-9edc-778a4994ba9e.png)
