### PR TITLE
Remove "render" keyword from Host on Render page

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-render.md
+++ b/content/en/hosting-and-deployment/hosting-on-render.md
@@ -6,7 +6,7 @@ date: 2019-06-06
 publishdate: 2019-06-06
 lastmod: 2020-01-01
 categories: [hosting and deployment]
-keywords: [render,hosting,deployment]
+keywords: [hosting,deployment]
 authors: [Anurag Goel]
 menu:
   docs:


### PR DESCRIPTION
This was causing the Host on Render page to be listed under "See Also"
on the .RenderString function page.