### PR TITLE
Remove blank lines from code-toggle output

### DIFF
--- a/layouts/shortcodes/code-toggle.html
+++ b/layouts/shortcodes/code-toggle.html
@@ -29,7 +29,7 @@
   <div class="tab-content">
     {{ range $langs }}
       <div data-pane="{{ . }}" class="code-copy-content nt3 tab-pane {{ cond (eq . "yaml") "active" ""}}">
-        {{ highlight ($code | transform.Remarshal . | safeHTML) . ""}}
+        {{ highlight ($code | transform.Remarshal . | replaceRE `\n+` "\n" | safeHTML) . "" }}
       </div>
       {{ if ne ($.Get "copy") "false" }}
         <button class="needs-js copy copy-toggle bg-accent-color-dark f6 absolute top-0 right-0 lh-solid hover-bg-primary-color-dark bn white ph3 pv2" title="Copy this code to your clipboard." data-clipboard-action="copy" aria-label="copy button"></button>
@@ -37,5 +37,5 @@
       {{end}}
     {{ end }}
   </div>
-  
+
 </div>


### PR DESCRIPTION
I think the newlines were introduced with the change to go-toml.

Before this PR:

<img alt="Screen capture" width="70%" src="https://user-images.githubusercontent.com/335669/140259858-ea39da07-a044-4264-85d8-634db54e028e.png">

After this PR:
<img alt="Screen capture" width="70%" src="https://user-images.githubusercontent.com/335669/140259914-0003a63e-1a23-4610-a8ba-92fa31994200.png">
