### PR TITLE
fix disqus example name

### DIFF
--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -69,7 +69,7 @@ Hugo also ships with an internal template for [Disqus comments][disqus], a popul
 To use Hugo's Disqus template, you first need to set a single configuration value:
 
 {{< code-toggle file="config" >}}
-disqusShortname = "yourdiscussshortname"
+disqusShortname = "your-disqus-shortname"
 {{</ code-toggle >}}
 
 You also have the option to set the following in the front matter for a given piece of content:


### PR DESCRIPTION
changes discuss to disqus and use dashes to separate words to make it easier to read.