### PR TITLE
Add id attribute to h2 elements

### DIFF
--- a/layouts/template-func/page.html
+++ b/layouts/template-func/page.html
@@ -4,8 +4,9 @@
 {{  range $k, $v := $funcs }}
   {{ if $v.Description }}
     {{ $func := printf "%s.%s" $pkg $k }}
-    <h2>
-      <a class="header-link" href="#{{ $func | anchorize | safeURL }}">
+    {{ $id := $func | anchorize | safeURL }}
+    <h2 id="{{ $id }}">
+      <a class="header-link" href="#{{ $id }}">
         <svg class="fill-current o-60 hover-accent-color-light" height="22px" viewBox="0 0 24 24" width="22px" xmlns="http://www.w3.org/2000/svg">
           <path d="M0 0h24v24H0z" fill="none"/>
           <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>


### PR DESCRIPTION
Prior to this change, it was not possible to link to headings. For
example, this link wasn't functional:

functions/lang/#langformatnumber