### PR TITLE
Fix shortcode in hugo-pipes/introduction

### DIFF
--- a/content/en/hugo-pipes/introduction.md
+++ b/content/en/hugo-pipes/introduction.md
@@ -29,7 +29,7 @@ In order to process an asset with Hugo Pipes, it must be retrieved as a `Resourc
 
 ### Error Handling
 
-{{ new-in "0.90.1" }}
+{{< new-in "0.90.1" >}}
 
 The return value from `resources.Get` includes an `.Err` method that will be set if the call failed. If you want to just log any error as a `WARNING` you can use a construct similar to the one below.
 


### PR DESCRIPTION
Fix the `new-in` shortcode in https://gohugo.io/hugo-pipes/introduction/#error-handling