### PR TITLE
docs: add a link to the mailmap documentation

### DIFF
--- a/content/en/variables/git.md
+++ b/content/en/variables/git.md
@@ -37,10 +37,10 @@ The `GitInfo` object contains the following fields:
 : the abbreviated commit hash (e.g., `866cbcc`)
 
 .AuthorName
-: the author's name, respecting `.mailmap`
+: the author's name, respecting [`.mailmap`](https://git-scm.com/docs/gitmailmap)
 
 .AuthorEmail
-: the author's email address, respecting `.mailmap`
+: the author's email address, respecting [`.mailmap`](https://git-scm.com/docs/gitmailmap)
 
 .AuthorDate
 : the author date


### PR DESCRIPTION
I find that Hugo should contain more links to relevant documentation of features in other tools/documentations. Please let me know if we don't want that and I'll stop. In this specific case I read about `.mailmap` in the Hugo docs and as a developer knew what was meant, but I think less dev-y users might not understand this. Instead of starting to add paragraphs about the format maybe it's ok to link to the features docs? As I said, let me know if that is overkill/bloat. It would make my life easier than seeing a word and googling it :)

(for instance, if we link to git in this case we don't need to add extra-documentation about what the mailmap file should look like and what should be in there)