### PR TITLE
Image filters: ensure Grayscale is a level-2 heading

### DIFF
--- a/content/en/functions/images/index.md
+++ b/content/en/functions/images/index.md
@@ -128,7 +128,7 @@ images.GaussianBlur SIGMA
 
 GaussianBlur creates a filter that applies a gaussian blur to an image.
 
-### Grayscale
+## Grayscale
 
 {{% funcsig %}}
 images.Grayscale


### PR DESCRIPTION
The `images.Grayscale` function was previously tagged as an h3, leading to its omission from the righthand navigation.