### PR TITLE
Clarify transform.Unmarshal when used with XML

### DIFF
--- a/content/en/functions/transform.Unmarshal.md
+++ b/content/en/functions/transform.Unmarshal.md
@@ -6,7 +6,7 @@ categories: [functions]
 menu:
   docs:
     parent: "functions"
-keywords: []
+keywords: [xml]
 signature: ["RESOURCE or STRING | transform.Unmarshal [OPTIONS]"]
 hugoversion: "0.53"
 aliases: []
@@ -48,20 +48,30 @@ Example:
 
 ## XML data
 
-As a convenience, Hugo allows you to access XML data in the same way that you access JSON, TOML, and YAML: you do not need to specify the root node when accessing the data.
+As a convenience, Hugo allows you to access XML data in the same way that you access JSON, TOML, and YAML: you do not need to specify the root node (`<root/>` in the example below) when accessing the data.
 
-To get the contents of `<title>` in the document below, you use `{{ .message.title }}`:
+Given the document below:
 
 ```
-<root>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<root xmlns:something="http://www.w3.org/something">
     <message>
         <title>Hugo rocks!</title>
-        <description>Thanks for using Hugo</description>
+        <something:id>1234</something:id>
+        <description status="verified">Thanks for using Hugo</description>
     </message>
 </root>
 ```
 
-The following example lists the items of an RSS feed:
+- Use `{{ .message.title }}` to get the contents of `<title/>` (`"Hugo rocks!"`)
+- Use `{{ index .message.description "-status" }}` to get the value of attribute `status` (`"verified"`). See [the index function](/functions/index-function/) for more information.
+- Use `{{ index .message.id }}` to get the value of namespace tag `<something:id/>`
+
+Multiple tags of the same name return a map with each instance. 
+
+### Fetching data
+
+The following example lists the items of an RSS feed, Using [resources.Get](/hugo-pipes/introduction/#get-resource-with-resourcesget-and-resourcesgetremote):
 
 ```
 {{ with resources.Get "https://example.com/rss.xml" | transform.Unmarshal }}
@@ -74,3 +84,8 @@ The following example lists the items of an RSS feed:
     {{ end }}
 {{ end }}
 ```
+
+Using 
+
+Simply storing `.xml` files in the `/data` folder works too, see [data templates](/templates/data-templates/#the-data-folder).
+

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -30,6 +30,8 @@ The `data` folder is where you can store additional data for Hugo to use when ge
 
 These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `.json`, `.xml`, or `.toml` extension). The data will be accessible as a `map` in the `.Site.Data` variable.
 
+See [transform.Unmarshal](/functions/transform.unmarshal/) for an example on how to parse XML.
+
 ## Data Files in Themes
 
 Data Files can also be used in [Hugo themes][themes] but note that theme data files follow the same logic as other template files in the [Hugo lookup order][lookup] (i.e., given two files with the same name and relative path, the file in the root project `data` directory will override the file in the `themes/<THEME>/data` directory).
@@ -146,6 +148,7 @@ This will resolve internally to the following:
 {{ $gistJ := getJSON "https://api.github.com/users/GITHUB_USERNAME/gists" }}
 ```
 
+
 ### Add HTTP headers
 
 {{< new-in "0.84.0" >}} Both `getJSON` and `getCSV` takes an optional map as the last argument, e.g.:
@@ -225,6 +228,7 @@ If you change any local file and the LiveReload is triggered, Hugo will read the
 
 - Photo gallery JSON powered: [https://github.com/pcdummy/hugo-lightslider-example](https://github.com/pcdummy/hugo-lightslider-example)
 - GitHub Starred Repositories [in a post](https://github.com/SchumacherFM/blog-cs/blob/master/content%2Fposts%2Fgithub-starred.md) using data-driven content in a [custom short code](https://github.com/SchumacherFM/blog-cs/blob/master/layouts%2Fshortcodes%2FghStarred.html).
+- Fetching JSON Webmentions to display [comments in a post](https://github.com/wgroeneveld/brainbaking/blob/master/themes/brainbaking-minimal/layouts/partials/single-webmentions.html) without resorting to JavaScript.
 
 ## Specs for Data Formats
 


### PR DESCRIPTION
See https://discourse.gohugo.io/t/parsing-xml-in-data-with-hugos-new-xml-support-attributes/36654/2 and https://github.com/gohugoio/hugoDocs/issues/1622
The new XML parsing abilities of Hugo are currently not well documented. 

I am not sure as to
1. How much I had to add, since everything is very much condensed;
2. If it deserves its own page, since it's a bit strange to put it all in transform.Unmarshall;

Since I don't frequently update the official docs, a second look is appreciated. 