### PR TITLE
Proper description of merge order in collections.merger

### DIFF
--- a/content/en/functions/merge.md
+++ b/content/en/functions/merge.md
@@ -14,7 +14,7 @@ relatedfuncs: [dict, append, reflect.IsMap, reflect.IsSlice]
 aliases: []
 ---
 
-Merge creates a copy of the final `MAP` and merges any preceding `MAP` into it in reverse order.
+Merge creates a copy of the first `MAP` and merges any subsequent `MAP`s into it.
 Key handling is case-insensitive.
 
 An example merging two maps.


### PR DESCRIPTION
Either the sample is wrong or the explanation of the sample. I chose the latter because it does not make much sense to copy the last map and then go back to override values. That would make users very irritated.

If Hugo merges from the back to the front, please lets look into why this is the case and if we can implement merging the way all programming languages that I know do. From left to right. 