### PR TITLE
update GitLab CI/CD yaml syntax

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-gitlab.md
+++ b/content/en/hosting-and-deployment/hosting-on-gitlab.md
@@ -49,8 +49,8 @@ pages:
   artifacts:
     paths:
     - public
-  only:
-  - master
+  rules:
+  - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 {{< /code >}}
 
 {{% note %}}


### PR DESCRIPTION
GitLab now favors `rules` over `only` (read more about it [here](https://about.gitlab.com/releases/2020/04/22/gitlab-12-10-released/#auto-devops-and-secure-configuration-templates-are-changing-to-rules-instead-of-onlyexcept)).

The changed snippet also avoids hardcoding the master branch.