### PR TITLE
Add explicit `contentDir` to module-config-mounts

### DIFF
--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -113,7 +113,7 @@ noVendor
 ## Module Config: mounts
 
 {{% note %}}
-When the `mounts` config was introduced in Hugo 0.56.0, we were careful to preserve the existing `staticDir` and similar configuration to make sure all existing sites just continued to work. But you should not have both: if you add a `mounts` section you should remove the old `staticDir` etc. settings.
+When the `mounts` config was introduced in Hugo 0.56.0, we were careful to preserve the existing `contentDir`, `staticDir`, and similar configuration to make sure all existing sites just continued to work. But you should not have both: if you add a `mounts` section you should remove the old `contentDir`, `staticDir`, etc. settings.
 {{% /note %}}
 
 {{% warning %}}


### PR DESCRIPTION
Context: https://discourse.gohugo.io/t/content-mount-problem-for-single-language-multilingual-site/37215

/cc @jmooring 
