### PR TITLE
Add MPR installation instructions

### DIFF
--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -494,11 +494,9 @@ This option is not recommended because the Hugo in Linux package managers for De
 
 Hugo can be installed from the [makedeb Package Repository](https://mpr.makedeb.org/packages/hugo), which provides an up-to-date version of Hugo for users on Debian and Ubuntu based systems. To install it you need to first have [makedeb](https://makedeb.org/) installed, after which it can be installed via the `makedeb` command:
 
-```sh
-git clone 'https://mpr.makedeb.org/hugo.git'
-cd hugo/
-makedeb -si
-```
+    git clone 'https://mpr.makedeb.org/hugo.git'
+    cd hugo/
+    makedeb -si
 
 ### Arch Linux
 

--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -488,7 +488,17 @@ Hugo installed via Snap can write only inside the user’s `$HOME` directory---a
 
 What this installs depends on your Debian/Ubuntu version. On Ubuntu bionic (18.04), this installs the non-extended version without Sass/SCSS support. On Ubuntu disco (19.04), this installs the extended version with Sass/SCSS support.
 
-This option is not recommended because the Hugo in Linux package managers for Debian and Ubuntu is usually a few versions behind as described [here](https://github.com/gcushen/hugo-academic/issues/703)
+This option is not recommended because the Hugo in Linux package managers for Debian and Ubuntu is usually a few versions behind as described [here](https://github.com/gcushen/hugo-academic/issues/703).
+
+### MPR Package
+
+Hugo can be installed from the [makedeb Package Repository](https://mpr.makedeb.org/packages/hugo), which provides an up-to-date version of Hugo for users on Debian and Ubuntu based systems. To install it you need to first have [makedeb](https://makedeb.org/) installed, after which it can be installed via the `makedeb` command:
+
+```sh
+git clone 'https://mpr.makedeb.org/hugo.git'
+cd hugo/
+makedeb -si
+```
 
 ### Arch Linux
 


### PR DESCRIPTION
The [MPR](https://mpr.makedeb.org/) is a project for [makedeb](https://makedeb.org/), which itself is an alternative packaging tool for Debian and Ubuntu based systems that still ultimately builds .deb packages.

I'm currently maintaining [Hugo on the MPR](https://mpr.makedeb.org/packages/hugo), as I needed some features myself that weren't present in Ubuntu 20.04.

The MPR is a platform is one I created (as well as makedeb itself), but I think the MPR package could provide a lot of benefits for users using Debian and Ubuntu based distros where they wouldn't otherwise be able to get the latest release of Hugo when sticking to just .deb packages.