### PR TITLE
 Typo fix: requires -> require

### DIFF
--- a/layouts/shortcodes/gomodules-info.html
+++ b/layouts/shortcodes/gomodules-info.html
@@ -1,5 +1,5 @@
 {{ $text := `
-Most of the commands for **Hugo Modules** requires a newer version of Go installed (see https://golang.org/dl/) and the relevant VCS client (e.g. Git, see https://git-scm.com/downloads/ ). If you have an "older" site running on Netlify, you may have to set GO_VERSION to 1.12 in your Environment settings.
+Most of the commands for **Hugo Modules** require a newer version of Go installed (see https://golang.org/dl/) and the relevant VCS client (e.g. Git, see https://git-scm.com/downloads/ ). If you have an "older" site running on Netlify, you may have to set GO_VERSION to 1.12 in your Environment settings.
 
 For more information about Go Modules, see:
 


### PR DESCRIPTION
A minor spelling mistake noticed when browsing through the documentation. 
The sentence:
> ... commands for Hugo Modules **requires** a newer version... 

Should be:
> ... commands for Hugo Modules **require** a newer version...

