### PR TITLE
fix link to latest release note

### DIFF
--- a/layouts/shortcodes/new-in.html
+++ b/layouts/shortcodes/new-in.html
@@ -4,5 +4,5 @@
 {{ end }}
 {{ $version = $version | strings.TrimPrefix "v" }}
 <button class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 mr2 ml2 px-4 border border-gray-400 rounded shadow">
-    <a href="{{ printf "https://github.com/gohugoio/hugo/releases/tag/v" $version }}" target="_blank">New in v{{$version}}</a>
+    <a href="{{ printf "https://github.com/gohugoio/hugo/releases/tag/v%s" $version }}" target="_blank">New in v{{$version}}</a>
 </button>

--- a/layouts/shortcodes/new-in.html
+++ b/layouts/shortcodes/new-in.html
@@ -4,5 +4,5 @@
 {{ end }}
 {{ $version = $version | strings.TrimPrefix "v" }}
 <button class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 mr2 ml2 px-4 border border-gray-400 rounded shadow">
-    <a href="{{ printf "https://gohugo.io/news/%s-relnotes/" $version }}" target="_blank">New in v{{$version}}</a>
+    <a href="{{ printf "https://github.com/gohugoio/hugo/releases/tag/v" $version }}" target="_blank">New in v{{$version}}</a>
 </button>


### PR DESCRIPTION
since the release notes were [moved to GitHub](https://gohugo.io/news/no-more-releasenotes-here/)