### PR TITLE
Add `.html` suffix to partial usage and references

### DIFF
--- a/content/en/functions/apply.md
+++ b/content/en/functions/apply.md
@@ -64,13 +64,13 @@ If you have `post-tag-list.html` and `post-tag-link.html` as [partials][], you *
   Tags:
   {{ $len := len . }}
   {{ if eq $len 1 }}
-    {{ partial "post-tag-link" (index . 0) }}
+    {{ partial "post-tag-link.html" (index . 0) }}
   {{ else }}
     {{ $last := sub $len 1 }}
     {{ range first $last . }}
-      {{ partial "post-tag-link" . }},
+      {{ partial "post-tag-link.html" . }},
     {{ end }}
-    {{ partial "post-tag-link" (index . $last) }}
+    {{ partial "post-tag-link.html" (index . $last) }}
   {{ end }}
 </div>
 {{ end }}
@@ -89,7 +89,7 @@ This first version of `layouts/partials/post-tag-list.html` separates all of the
     <div class="tags-list">
       Tags:
       {{ $sort := sort . }}
-      {{ $links := apply $sort "partial" "post-tag-link" "." }}
+      {{ $links := apply $sort "partial" "post-tag-link.html" "." }}
       {{ $clean := apply $links "chomp" "." }}
       {{ delimit $clean ", " }}
     </div>
@@ -102,7 +102,7 @@ Now in the completed version, you can sort the tags, convert the tags to links w
     {{ with .Params.tags }}
     <div class="tags-list">
       Tags:
-      {{ delimit (apply (apply (sort .) "partial" "post-tag-link" ".") "chomp" ".") ", " }}
+      {{ delimit (apply (apply (sort .) "partial" "post-tag-link.html" ".") "chomp" ".") ", " }}
     </div>
     {{ end }}
 {{< /code >}}

--- a/content/en/templates/partials.md
+++ b/content/en/templates/partials.md
@@ -126,9 +126,9 @@ Only one `return` statement is allowed per partial file.
 You can also define partials inline in the template. But remember that template namespace is global, so you need to make sure that the names are unique to avoid conflicts.
 
 ```go-html-template
-Value: {{ partial "my-inline-partial" . }}
+Value: {{ partial "my-inline-partial.html" . }}
 
-{{ define "partials/my-inline-partial" }}
+{{ define "partials/my-inline-partial.html" }}
 {{ $value := 32 }}
 {{ return $value }}
 {{ end }}

--- a/content/en/templates/template-debugging.md
+++ b/content/en/templates/template-debugging.md
@@ -61,13 +61,13 @@ When developing a [homepage][], what does one of the pages you're looping throug
 Check that you are passing variables in the `partial` function:
 
 ```
-{{ partial "header" }}
+{{ partial "header.html" }}
 ```
 
 This example will render the header partial, but the header partial will not have access to any contextual variables. You need to pass variables explicitly. For example, note the addition of ["the dot"][tempintro].
 
 ```
-{{ partial "header" . }}
+{{ partial "header.html" . }}
 ```
 
 The dot (`.`) is considered fundamental to understanding Hugo templating. For more information, see [Introduction to Hugo Templating][tempintro].

--- a/layouts/maintenance/list.html
+++ b/layouts/maintenance/list.html
@@ -17,9 +17,9 @@
             {{ $recent := ($byLastMod | last 30).Reverse }}
             {{ $leastRecent := $byLastMod | first 10 }}            
             <h2 id="last-updated">Last Updated</h2>
-            {{ partial "maintenance-pages-table" $recent }}
+            {{ partial "maintenance-pages-table.html" $recent }}
             <h2 id="least-recently-updated">Least Recently Updated</h2>
-            {{ partial "maintenance-pages-table" $leastRecent }}
+            {{ partial "maintenance-pages-table.html" $leastRecent }}
 
             {{/* Don't think this is possible with where directly. Should investigate. */}}
             {{ .Scratch.Set "todos" slice }}
@@ -29,7 +29,7 @@
                  {{ end }}
             {{ end }}
             <h2 id="todos">Pages marked with TODO</h2>
-            {{ partial "maintenance-pages-table" (.Scratch.Get "todos") }}
+            {{ partial "maintenance-pages-table.html" (.Scratch.Get "todos") }}
 
             <h2 id="dependencies">Dependencies</h2>
             <table class="collapse ba br2 b--black-10 pv2 ph3">


### PR DESCRIPTION
## Summary
Per the discussions below, it's now clear to me that all partial usage should include the file name extension as a suffix. This PR intends to fix all remaining references in the documentation and the layouts to help future Hugo users understand this best practice.

## Sources
- https://github.com/gohugoio/hugo/issues/9603
- https://discourse.gohugo.io/t/duplicate-entries-in-templatemetrics/37459/10
- https://discourse.gohugo.io/t/duplicate-entries-in-templatemetrics/37459/10

## Additional notes
- https://github.com/gohugoio/gohugoioTheme will require a separate effort