### PR TITLE
Docs tidy-up

### DIFF
--- a/content/en/content-management/formats.md
+++ b/content/en/content-management/formats.md
@@ -4,7 +4,6 @@ linktitle: Content Formats
 description: Both HTML and Markdown are supported content formats.
 date: 2017-01-10
 publishdate: 2017-01-10
-lastmod: 2017-04-06
 categories: [content management]
 keywords: [markdown,asciidoc,mmark,pandoc,content format]
 menu:
@@ -27,19 +26,18 @@ You can put any file type into your `/content` directories, but Hugo uses the `m
 
 The current list of content formats in Hugo:
 
-| Name  | Markup identifiers | Comment | 
+| Name  | Markup identifiers | Comment |
 | ------------- | ------------- |-------------|
 | Goldmark  | md, markdown, goldmark  |Note that you can set the default handler of `md` and `markdown` to something else, see [Configure Markup](/getting-started/configuration-markup/).{{< new-in "0.60.0" >}} |
 | Blackfriday | blackfriday  |Blackfriday will eventually be deprecated.|
 |MMark|mmark|Mmark is deprecated and will be removed in a future release.|
 |Emacs Org-Mode|org|See [go-org](https://github.com/niklasfasching/go-org).|
 |AsciiDoc|asciidocext, adoc, ad|Needs [Asciidoctor][ascii] installed.|
-|RST|rst|Needs [RST](http://docutils.sourceforge.net/rst.html) installed.|
+|RST|rst|Needs [RST](https://docutils.sourceforge.net/rst.html) installed.|
 |Pandoc|pandoc, pdc|Needs [Pandoc](https://www.pandoc.org/) installed.|
 |HTML|html, htm|To be treated as a content file, with layout, shortcodes etc., it must have front matter. If not, it will be copied as-is.|
 
 The `markup identifier` is fetched from either the `markup` variable in front matter or from the file extension. For markup-related configuration, see [Configure Markup](/getting-started/configuration-markup/).
-
 
 ## External Helpers
 
@@ -149,7 +147,6 @@ Markdown syntax is simple enough to learn in a single sitting. The following are
 [mdguide]: https://www.markdownguide.org/
 [mdtutorial]: https://www.markdowntutorial.com/
 [Miek Gieben's website]: https://miek.nl/2016/march/05/mmark-syntax-document/
-[mmark]: https://github.com/mmarkdown/mmark
 [org]: https://orgmode.org/
 [pandoc]: https://www.pandoc.org/
 [rest]: https://docutils.sourceforge.io/rst.html

--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -178,6 +178,7 @@ Assuming a `baseURL` of `example.com`, the contents of the auto-generated alias 
 The `http-equiv="refresh"` line is what performs the redirect, in 0 seconds in this case. If an end user of your website goes to `https://example.com/posts/my-old-url`, they will now be automatically redirected to the newer, correct URL. The addition of `<meta name="robots" content="noindex">` lets search engine bots know that they should not crawl and index your new alias page.
 
 ### Customize
+
 You may customize this alias page by creating an `alias.html` template in the
 layouts folder of your site (i.e., `layouts/alias.html`). In this case, the data passed to the template is
 

--- a/content/en/contribute/development.md
+++ b/content/en/contribute/development.md
@@ -424,7 +424,7 @@ Feel free to [open an issue][newissue] if you think you found a bug or you have 
 [docscontrib]: /contribute/documentation/
 [forums]: https://discourse.gohugo.io
 [gitbook]: https://git-scm.com/
-[gobootcamp]: http://www.golangbootcamp.com/book/get_setup
+[gobootcamp]: https://www.golangbootcamp.com/book/get_setup
 [godl]: https://golang.org/dl/
 [goinstall]: https://golang.org/doc/install
 [gvm]: https://github.com/moovweb/gvm

--- a/content/en/functions/append.md
+++ b/content/en/functions/append.md
@@ -25,14 +25,9 @@ An example appending single values:
 
 The same example appending a slice to a slice:
 
-
 ```go-html-template
 {{ $s := slice "a" "b" "c" }}
 {{ $s = $s | append (slice "d" "e") }}
 ```
 
 The `append` function works for all types, including `Pages`.
-
-
-
-

--- a/content/en/functions/group.md
+++ b/content/en/functions/group.md
@@ -28,10 +28,4 @@ hugoversion: "0.49"
 {{ end }}
 {{< /code >}}
 
-
-
 The page group you get from `group` is of the same type you get from the built-in [group methods](/templates/lists#group-content) in Hugo. The above example can even be [paginated](/templates/pagination/#list-paginator-pages).
-
-
-
-

--- a/content/en/functions/hugo.md
+++ b/content/en/functions/hugo.md
@@ -4,7 +4,6 @@ linktitle: hugo
 description: The `hugo` function provides easy access to Hugo-related data.
 date: 2019-01-31
 publishdate: 2019-01-31
-lastmod: 2019-01-31
 keywords: []
 categories: [functions]
 menu:
@@ -60,17 +59,17 @@ hugo.Deps
 
 `hugo.Deps` returns a list of dependencies for a project (either Hugo Modules or local theme components).
 
-Eeach dependency contains:
+Each dependency contains:
 
 Path (string)
 : Returns the path to this module. This will either be the module path, e.g. "github.com/gohugoio/myshortcodes", or the path below your /theme folder, e.g. "mytheme".
 
 Version (string)
 :  The module version.
-	
+
 Vendor (bool)
 : Whether this dependency is vendored.
- 
+
 Time (time.Time)
 : Time version was created.
 

--- a/content/en/functions/relurl.md
+++ b/content/en/functions/relurl.md
@@ -3,7 +3,6 @@ title: relURL
 description: Creates a baseURL-relative URL.
 date: 2017-02-01
 publishdate: 2017-02-01
-lastmod: 2017-02-01
 categories: [functions]
 menu:
   docs:
@@ -31,7 +30,7 @@ The last two examples may look strange but can be very useful. For example, the 
 {{< code file="layouts/partials/schemaorg-metadata.html" download="schemaorg-metadata.html" >}}
 <script type="application/ld+json">
 {
-    "@context" : "http://schema.org",
+    "@context" : "https://schema.org",
     "@type" : "BlogPosting",
     "image" : {{ apply .Params.images "absURL" "." }}
 }
@@ -46,5 +45,5 @@ The above uses the [apply function][] and also exposes how the Go template parse
 
 [apply function]: /functions/apply/
 [configuration]: /getting-started/configuration/
-[jsonld]: https://developers.google.com/search/docs/guides/intro-structured-data
+[jsonld]: https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data
 [safejs]: /functions/safejs

--- a/content/en/getting-started/installing.md
+++ b/content/en/getting-started/installing.md
@@ -560,4 +560,4 @@ Now that you've installed Hugo, read the [Quick Start guide][quickstart] and exp
 [Scoop]: https://scoop.sh/
 [snaps]: https://snapcraft.io/docs/installing-snapd
 [windowsarch]: https://esupport.trendmicro.com/en-us/home/pages/technical-support/1038680.aspx
-[Windows Environment Variables Editor]: http://eveditor.com/
+[Windows Environment Variables Editor]: https://eveditor.com/

--- a/content/en/showcase/over/index.md
+++ b/content/en/showcase/over/index.md
@@ -10,7 +10,7 @@ At Over we're into creativity, and technology should not get in the way. We want
 
 People from all disciplines contribute to our website, be it legal documentation, layout and design, recruiting, marketing and of course… engineering. Hugo allows us to do this with as little friction as possible. A lot of this comes down to Hugo being distributed as a single static binary. Copy, paste, run... and you're up and running!
 
-We use [Wercker](https://www.wercker.com/) for continuous integration and deployments, [GitHub](https://github.com/) for contributing to and writing markdown and [Firebase](https://firebase.google.com/docs/hosting/) for hosting.
+We use Wercker for continuous integration and deployments, [GitHub](https://github.com/) for contributing to and writing markdown and [Firebase](https://firebase.google.com/docs/hosting/) for hosting.
 
 This infrastructure takes all the pressure off our engineers, anyone can contribute to our website. Anyone else can review the changes, and of course anyone with permission can deploy those approved changes as well!
 


### PR DESCRIPTION
Markdown formatting fixes, typo fixed, broken links removed, https relevant links. Remove unused lastmod dates from edited markdown pages.
Remove link to mmark GitHub repo (as its deprecated from Hugo).