### PR TITLE
fix: pipes in sample code break table creation

### DIFF
--- a/content/en/functions/strings.Count.md
+++ b/content/en/functions/strings.Count.md
@@ -23,7 +23,7 @@ If `SUBSTR` is an empty string, this function returns 1 plus the number of Unico
 
 Example|Result
 :--|:--
-`{{ "aaabaab" | strings.Count "a" }}`|5
-`{{ "aaabaab" | strings.Count "aa" }}`|2
-`{{ "aaabaab" | strings.Count "aaa" }}`|1
-`{{ "aaabaab" | strings.Count "" }}`|8
+`{{ "aaabaab" \| strings.Count "a" }}`|5
+`{{ "aaabaab" \| strings.Count "aa" }}`|2
+`{{ "aaabaab" \| strings.Count "aaa" }}`|1
+`{{ "aaabaab" \| strings.Count "" }}`|8


### PR DESCRIPTION
The pipes in the code sample need to be masked. I also replaced the manual result with the actual code, waiting for a test rendering to see if that works as expected.