### PR TITLE
Code block render hooks are introduced in v0.93.0

### DIFF
--- a/content/en/templates/render-hooks.md
+++ b/content/en/templates/render-hooks.md
@@ -25,7 +25,7 @@ The hook kinds currently supported are:
 * `image`
 * `link`
 * `heading` {{< new-in "0.71.0" >}}
-* `codeblock`{{< new-in "0.83.0" >}}
+* `codeblock`{{< new-in "0.93.0" >}}
 
 You can define [Output-Format-](/templates/output-formats) and [language-](/content-management/multilingual/)specific templates if needed. Your `layouts` folder may look like this:
 


### PR DESCRIPTION
The docs incorrectly stated that code block render hooks were introduced in version 0.83.0, so I corrected it to version 0.93.0 (changelog here: https://github.com/gohugoio/hugo/releases/tag/v0.93.0).