### PR TITLE
Fix workspace formatting

### DIFF
--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -43,7 +43,7 @@ private
 : Comma separated glob list matching paths that should be treated as private.
 
 workspace {{< new-in "0.83.0" >}}
-The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+.
+: The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+.
 
 replacements {{< new-in "0.77.0" >}}
 : A comma separated (or a slice) list of module path to directory replacement mapping, e.g. `github.com/bep/myprettytheme -> ../..,github.com/bep/shortcodes -> /some/path`. This is mostly useful for temporary locally development of a module, and then it makes sense to set it as an OS environment variable, e.g: `env HUGO_MODULE_REPLACEMENTS="github.com/bep/myprettytheme -> ../.."`. Any relative path is relate to [themesDir](https://gohugo.io/getting-started/configuration/#all-configuration-settings), and absolute paths are allowed.


### PR DESCRIPTION
This makes sure the `workspace` configuration highlights bold
like the other configuration options and remains in its own block

Before: 

![Before](https://user-images.githubusercontent.com/5273439/161827694-6dc75baa-59d5-4a4b-b4d3-5b05a7a7e1f8.png)

After: 

![After](https://user-images.githubusercontent.com/5273439/161827723-092e22d2-8125-42b6-a230-1cb01aae136e.png)


