### PR TITLE
Add git required FAQ & remove ZIP from Quick Start

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -21,7 +21,7 @@ toc: true
 {{% note %}}
 This quick start uses `macOS` in the examples. For instructions about how to install Hugo on other operating systems, see [install](/getting-started/installing).
 
-It is recommended to have [Git installed](https://git-scm.com/downloads) to run this tutorial.
+It is required to have [Git installed](https://git-scm.com/downloads) to run this tutorial.
 
 For other approaches to learning Hugo (like books or video tutorials), refer to the [external learning resources](/getting-started/external-learning-resources/) page.
 {{% /note %}}
@@ -67,13 +67,6 @@ cd quickstart
 git init
 git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke
 ```
-
-*Note for non-git users:*
-   - If you do not have git installed, you can download the archive of the latest
-     version of this theme from:
-       https://github.com/theNewDynamic/gohugo-theme-ananke/archive/master.zip
-   - Extract that .zip file to get a "gohugo-theme-ananke-master" directory.
-   - Rename that directory to "ananke", and move it into the "themes/" directory.
 
 Then, add the theme to the site configuration:
 

--- a/content/en/troubleshooting/faq.md
+++ b/content/en/troubleshooting/faq.md
@@ -56,3 +56,14 @@ error: failed to transform resource: TOCSS: failed to transform "scss/main.scss"
 We release two set of binaries for technical reasons. The extended version is not what you get by default for some installation methods. On the [release page](https://github.com/gohugoio/hugo/releases), look for archives with `extended` in the name. To build `hugo-extended`, use `go install --tags extended`
 
 To confirm, run `hugo version` and look for the word `extended`.
+
+## Do I need to install Git to create, deploy, and maintain a website with Hugo?
+
+>Technically, no.
+>
+>Practically, yes.
+
+* The primary installation method documented by most (perhaps all) themes is via Git or the Hugo Modules feature.
+* The Hugo Modules feature requires Go, and Go “gets” with Git.
+* A Git repository is required by CI/CD hosting (Bitbucket, Cloudflare, GitHub Pages, GitLab Pages, Netlify, et. al.).
+* The canonical “last modified” date for content is its Git committer date; using anything else is error-prone.


### PR DESCRIPTION
Closes #1712

See discussion in <https://discourse.gohugo.io/t/hugodocs-quick-start-should-we-move-the-zip-info-to-a-separate-page/38062>