### PR TITLE
Fix broken anchor links

### DIFF
--- a/content/en/about/features.md
+++ b/content/en/about/features.md
@@ -60,7 +60,7 @@ toc: true
 [content summaries]: /content-management/summaries/
 [content types]: /content-management/types/
 [Disqus]: https://disqus.com/
-[Dynamic menu]: /templates/menus/
+[Dynamic menu]: /templates/menu-templates/
 [Extremely fast]: https://github.com/bep/hugo-benchmark
 [front matter]: /content-management/front-matter/
 [functions]: /functions/
@@ -73,13 +73,13 @@ toc: true
 [organization for your projects]: /getting-started/directory-structure/
 [pagevars]: /variables/page/
 [Permalink]: /content-management/urls/#permalinks
-[Powerful theming]: /themes/
+[Powerful theming]: /hugo-modules/theme-components/
 [Pretty URLs]: /content-management/urls/
 [RSS]: /templates/rss/
 [Shortcodes]: /content-management/shortcodes/
 [sort content]: /templates/
 [supported formats]: /content-management/formats/
-[Syntax highlighting]: /tools/syntax-highlighting/
+[Syntax highlighting]: /content-management/syntax-highlighting/
 [table of contents]: /content-management/toc/
 [taxonomies]: /content-management/taxonomies/
 [URLs]: /content-management/urls/

--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -64,7 +64,7 @@ These are some alternatives to Disqus:
 * [Utterances](https://utteranc.es/) (Open source, GitHub comments widget built on GitHub issues)
 
 [configuration]: /getting-started/configuration/
-[disquspartial]: /templates/partials/#disqus
+[disquspartial]: /templates/internal/#disqus
 [disqussetup]: https://disqus.com/profile/signup/
 [forum]: https://discourse.gohugo.io
 [front matter]: /content-management/front-matter/

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -92,7 +92,7 @@ keywords
 : the meta keywords for the content.
 
 layout
-: the layout Hugo should select from the [lookup order][lookup] when rendering the content. If a `type` is not specified in the front matter, Hugo will look for the layout of the same name in the layout directory that corresponds with a content's section. See ["Content Types"][content type]
+: the layout Hugo should select from the [lookup order][lookup] when rendering the content. If a `type` is not specified in the front matter, Hugo will look for the layout of the same name in the layout directory that corresponds with a content's section. See [Content Types][content type].
 
 lastmod
 : the datetime at which the content was last modified.

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -92,7 +92,7 @@ keywords
 : the meta keywords for the content.
 
 layout
-: the layout Hugo should select from the [lookup order][lookup] when rendering the content. If a `type` is not specified in the front matter, Hugo will look for the layout of the same name in the layout directory that corresponds with a content's section. See ["Defining a Content Type"][definetype]
+: the layout Hugo should select from the [lookup order][lookup] when rendering the content. If a `type` is not specified in the front matter, Hugo will look for the layout of the same name in the layout directory that corresponds with a content's section. See ["Content Types"][content type]
 
 lastmod
 : the datetime at which the content was last modified.
@@ -229,10 +229,9 @@ It's possible to set some options for Markdown rendering in a content's front ma
 [config]: /getting-started/configuration/ "Hugo documentation for site configuration"
 [content type]: /content-management/types/
 [contentorg]: /content-management/organization/
-[definetype]: /content-management/types/#defining-a-content-type "Learn how to specify a type and a layout in a content's front matter"
 [headless-bundle]: /content-management/page-bundles/#headless-bundle
 [json]: https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf "Specification for JSON, JavaScript Object Notation"
-[lists]: /templates/lists/#ordering-content "See how to order content in list pages; for example, templates that look to specific _index.md for content and front matter."
+[lists]: /templates/lists/#order-content "See how to order content in list pages; for example, templates that look to specific _index.md for content and front matter."
 [lookup]: /templates/lookup-order/ "Hugo traverses your templates in a specific order when rendering content to allow for DRYer templating."
 [ordering]: /templates/lists/ "Hugo provides multiple ways to sort and order your content in list templates"
 [outputs]: /templates/output-formats/ "With the release of v22, you can output your content to any text format using Hugo's familiar templating"

--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -571,7 +571,7 @@ If there is more than one language defined, the `LanguagePrefix` variable will e
 [lang.FormatAccounting]: /functions/lang/#langformataccounting
 [lang.FormatCurrency]: /functions/lang/#langformatcurrency
 [lang.FormatNumber]: /functions/lang/#langformatnumber
-[lang.FormatNumberCustom]: functions/lang/#langformatnumbercustom
+[lang.FormatNumberCustom]: /functions/lang/#langformatnumbercustom
 [lang.FormatPercent]: /functions/lang/#langformatpercent
 [lang.Merge]: /functions/lang.merge/
 [menus]: /content-management/menus/

--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -183,7 +183,7 @@ To demonstrate the remarkably efficiency of Hugo's shortcode feature, we have em
 
 ### `highlight`
 
-This shortcode will convert the source code provided into syntax-highlighted HTML. Read more on [highlighting](/tools/syntax-highlighting/). `highlight` takes exactly one required `language` parameter and requires a closing shortcode.
+This shortcode will convert the source code provided into syntax-highlighted HTML. Read more on [highlighting](/content-management/syntax-highlighting/). `highlight` takes exactly one required `language` parameter and requires a closing shortcode.
 
 #### Example `highlight` Input
 

--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -84,7 +84,7 @@ Moonrise Kingdom            <- Value
 
 Hugo natively supports taxonomies.
 
-Without adding a single line to your [site config][config] file, Hugo will automatically create taxonomies for `tags` and `categories`. That would be the same as manually [configuring your taxonomies](#configuring-taxonomies) as below:
+Without adding a single line to your [site config][config] file, Hugo will automatically create taxonomies for `tags` and `categories`. That would be the same as manually [configuring your taxonomies](#configure-taxonomies) as below:
 
 {{< code-toggle copy="false" >}}
 [taxonomies]
@@ -189,7 +189,7 @@ categories_weight = 44
 By using taxonomic weight, the same piece of content can appear in different positions in different taxonomies.
 
 {{% note "Limits to Ordering Taxonomies" %}}
-Currently taxonomies only support the [default `weight => date` ordering of list content](/templates/lists/#default-weight-date). For more information, see the documentation on [taxonomy templates](/templates/taxonomy-templates/).
+Currently taxonomies only support the [default `weight => date` ordering of list content](/templates/lists/#default-weight--date--linktitle--filepath). For more information, see the documentation on [taxonomy templates](/templates/taxonomy-templates/).
 {{% /note %}}
 
 ## Add custom metadata to a Taxonomy or Term
@@ -209,7 +209,7 @@ wikipedia: "https://en.wikipedia.org/wiki/Bruce_Willis"
 [content type]: /content-management/types/
 [documentation on archetypes]: /content-management/archetypes/
 [front matter]: /content-management/front-matter/
-[taxonomy list templates]: /templates/taxonomy-templates/#taxonomy-page-templates
+[taxonomy list templates]: /templates/taxonomy-templates/#taxonomy-list-templates
 [taxonomy templates]: /templates/taxonomy-templates/
 [terms within the taxonomy]: /templates/taxonomy-templates/#taxonomy-terms-templates "See how to order terms associated with a taxonomy"
 [config]: /getting-started/configuration/

--- a/content/en/content-management/toc.md
+++ b/content/en/content-management/toc.md
@@ -50,7 +50,7 @@ Hugo will take this Markdown and create a table of contents from `## Introductio
 The built-in `.TableOfContents` variables outputs a `<nav id="TableOfContents">` element with a child `<ul>`, whose child `<li>` elements begin with appropriate HTML headings. See [the available settings](/getting-started/configuration-markup/#table-of-contents) to configure what heading levels you want to include in TOC.
 
 {{% note "Table of contents not available for MMark" %}}
-Hugo documents created in the [MMark](/content-management/formats/#mmark) Markdown dialect do not currently display TOCs. TOCs are, however, compatible with all other supported Markdown formats.
+Hugo documents created in the [MMark](/content-management/formats/#list-of-content-formats) Markdown dialect do not currently display TOCs. TOCs are, however, compatible with all other supported Markdown formats.
 {{% /note %}}
 
 ## Template Example: Basic TOC

--- a/content/en/contribute/documentation.md
+++ b/content/en/contribute/documentation.md
@@ -86,7 +86,7 @@ Here is a review of the front matter fields automatically generated for you usin
 `{{.Content}}`
 : an extended description of the new function; examples are not only welcomed but encouraged.
 
-In the body of your function, expand the short description used in the front matter. Include as many examples as possible, and leverage the Hugo docs [`code` shortcode](#adding-code-blocks). If you are unable to add examples but would like to solicit help from the Hugo community, add `needsexample: true` to your front matter.
+In the body of your function, expand the short description used in the front matter. Include as many examples as possible, and leverage the Hugo docs [`code` shortcode](#add-code-blocks). If you are unable to add examples but would like to solicit help from the Hugo community, add `needsexample: true` to your front matter.
 
 ## Add Code Blocks
 

--- a/content/en/functions/relLangURL.md
+++ b/content/en/functions/relLangURL.md
@@ -17,7 +17,7 @@ deprecated: false
 aliases: []
 ---
 
-`absLangURL` and `relLangURL` functions are similar to their [`absURL`](/functions/absurl/) and [`relURL`](/functions/relurl/) relatives but will add the correct language prefix when the site is configured with more than one language. (See [Configuring Multilingual][multiliconfig].)
+`absLangURL` and `relLangURL` functions are similar to their [`absURL`](/functions/absurl/) and [`relURL`](/functions/relurl/) relatives but will add the correct language prefix when the site is configured with more than one language. (See [Configure Languages][multiliconfig].)
 
 So for a site  `baseURL` set to `https://example.com/hugo/` and the current language is `en`:
 
@@ -26,4 +26,4 @@ So for a site  `baseURL` set to `https://example.com/hugo/` and the current lang
 {{ "blog/" | relLangURL }} → "/hugo/en/blog/"
 ```
 
-[multiliconfig]: /content-management/multilingual/#configuring-multilingual-mode
+[multiliconfig]: /content-management/multilingual/#configure-languages

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -268,7 +268,7 @@ If true, auto-detect Chinese/Japanese/Korean Languages in the content. This will
 
 ### imaging
 
-See [Image Processing Config](/content-management/image-processing/#image-processing-config).
+See [Image Processing Config](/content-management/image-processing/#imaging-configuration).
 
 ### languageCode
 
@@ -390,13 +390,13 @@ See ["Section Menu for Lazy Bloggers"](/templates/menu-templates/#section-menu-f
 See [Security Policy](/about/security-model/#security-policy)
 
 ### sitemap
-Default [sitemap configuration](/templates/sitemap-template/#configure-sitemapxml).
+Default [sitemap configuration](/templates/sitemap-template/#configuration).
 
 ### summaryLength
 
 **Default value:** 70
 
-The length of text in words to show in a [`.Summary`](/content-management/summaries/#hugo-defined-automatic-summary-splitting).
+The length of text in words to show in a [`.Summary`](/content-management/summaries/#automatic-summary-splitting).
 
 ### taxonomies
 See [Configure Taxonomies](/content-management/taxonomies#configure-taxonomies).

--- a/content/en/getting-started/directory-structure.md
+++ b/content/en/getting-started/directory-structure.md
@@ -48,7 +48,7 @@ By default, Hugo will create new content files with at least `date`, `title` (in
 : Stores all the files which need be processed by [Hugo Pipes]({{< ref "/hugo-pipes" >}}). Only the files whose `.Permalink` or `.RelPermalink` are used will be published to the `public` directory. Note: assets directory is not created by default.
 
 [`config`](/getting-started/configuration/)
-: Hugo ships with a large number of [configuration directives](https://gohugo.io/getting-started/configuration/#all-variables-yaml).
+: Hugo ships with a large number of [configuration directives][].
 The [config directory](/getting-started/configuration/#configuration-directory) is where those directives are stored as JSON, YAML, or TOML files. Every root setting object can stand as its own file and structured by environments.
 Projects with minimal settings and no need for environment awareness can use a single `config.toml` file at its root.
 
@@ -76,7 +76,7 @@ resources
 
 
 [archetypes]: /content-management/archetypes/
-[configuration directives]: /getting-started/configuration/#all-variables-yaml
+[configuration directives]: /getting-started/configuration/#all-configuration-settings
 [`content`]: /content-management/organization/
 [content section]: /content-management/sections/
 [content types]: /content-management/types/

--- a/content/en/news/0.12-relnotes/index.md
+++ b/content/en/news/0.12-relnotes/index.md
@@ -18,7 +18,7 @@ This release represents over 90 code commits from 28 different contributors.
 - [views](/templates/views/) support in themes
 - inner [shortcode](/extras/shortcodes/) content now treated as markdown
 - support for header ids in markdown (# header {#myid})
-- [where](/templates/lists/#where) template function to filter lists of content, taxonomies, etc
+- [where](/functions/where/) template function to filter lists of content, taxonomies, etc.
 - [groupby](/templates/list) & [groupbydate](/templates/list) methods to group pages
 - taxonomy [pages list](/taxonomies/methods/) now sortable, filterable, limitable & groupable
 - general cleanup to taxonomies & documentation to make it more clear and consistent

--- a/content/en/templates/render-hooks.md
+++ b/content/en/templates/render-hooks.md
@@ -13,7 +13,7 @@ menu:
     weight: 20
 ---
 
-{{< new-in "0.62.0" >}} Note that this is only supported with the [Goldmark](#goldmark) renderer.
+{{< new-in "0.62.0" >}} Note that this is only supported with the [Goldmark](/getting-started/configuration-markup#goldmark) renderer.
 
 
 You can override certain parts of the default Markdown rendering to HTML by creating templates with base names `render-{kind}` in `layouts/_default/_markup`.

--- a/content/en/templates/single-page-templates.md
+++ b/content/en/templates/single-page-templates.md
@@ -83,7 +83,7 @@ To easily generate new instances of a content type (e.g., new `.md` files in a s
 [dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 [`.Format` function]: /functions/format/
 [front matter]: /content-management/front-matter/
-[pagetaxonomy]: /templates/taxonomy-templates/#displaying-a-single-piece-of-content-s-taxonomies
+[pagetaxonomy]: /templates/taxonomy-templates/#display-a-single-piece-of-contents-taxonomies
 [pagevars]: /variables/page/
 [partials]: /templates/partials/
 [section]: /content-management/sections/

--- a/content/en/templates/taxonomy-templates.md
+++ b/content/en/templates/taxonomy-templates.md
@@ -25,8 +25,8 @@ Hugo includes support for user-defined groupings of content called **taxonomies*
 
 Hugo provides multiple ways to use taxonomies throughout your project templates:
 
-* Order the way content associated with a taxonomy term is displayed in a [taxonomy list template](#taxonomy-list-template)
-* Order the way the terms for a taxonomy are displayed in a [taxonomy terms template](#taxonomy-terms-template)
+* Order the way content associated with a taxonomy term is displayed in a [taxonomy list template](#taxonomy-list-templates)
+* Order the way the terms for a taxonomy are displayed in a [taxonomy terms template](#taxonomy-terms-templates)
 * List a single content's taxonomy terms within a [single page template][]
 
 ## Taxonomy List Templates
@@ -37,7 +37,7 @@ Taxonomy list page templates are lists and therefore have all the variables and 
 
 See [Template Lookup](/templates/lookup-order/).
 
-## Taxonomy Terms Template
+## Taxonomy Terms Templates
 
 ### Taxonomy Terms Templates Lookup Order
 
@@ -103,7 +103,7 @@ type WeightedPages []WeightedPage
 
 ## Displaying custom metadata in Taxonomy Terms Templates
 
-If you need to display custom metadata for each taxonomy term, you will need to create a page for that term at `/content/<TAXONOMY>/<TERM>/_index.md` and add your metadata in its front matter, [as explained in the taxonomies documentation](/content-management/taxonomies/#add-custom-meta-data-to-a-taxonomy-term). Based on the Actors taxonomy example shown there, within your taxonomy terms template, you may access your custom fields by iterating through the variable `.Pages` as such:
+If you need to display custom metadata for each taxonomy term, you will need to create a page for that term at `/content/<TAXONOMY>/<TERM>/_index.md` and add your metadata in its front matter, [as explained in the taxonomies documentation](/content-management/taxonomies/#add-custom-metadata-to-a-taxonomy-or-term). Based on the Actors taxonomy example shown there, within your taxonomy terms template, you may access your custom fields by iterating through the variable `.Pages` as such:
 
 ```go-html-template
 <ul>

--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -96,10 +96,10 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 : access when creating links to the content. If set, Hugo will use the `linktitle` from the front matter before `title`.
 
 .Next
-: Points up to the next [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath)). Example: `{{with .Next}}{{.Permalink}}{{end}}`. Calling `.Next` from the first page returns `nil`.
+: Points up to the next [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight--date--linktitle--filepath)). Example: `{{with .Next}}{{.Permalink}}{{end}}`. Calling `.Next` from the first page returns `nil`.
 
 .NextInSection
-: Points up to the next [regular page](/variables/site/#site-pages) below the same top level section (e.g. in `/blog`)). Pages are sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath). Example: `{{with .NextInSection}}{{.Permalink}}{{end}}`. Calling `.NextInSection` from the first page returns `nil`.
+: Points up to the next [regular page](/variables/site/#site-pages) below the same top level section (e.g. in `/blog`)). Pages are sorted by Hugo's [default sort](/templates/lists#default-weight--date--linktitle--filepath). Example: `{{with .NextInSection}}{{.Permalink}}{{end}}`. Calling `.NextInSection` from the first page returns `nil`.
 
 .OutputFormats
 : contains all formats, including the current format, for a given page. Can be combined the with [`.Get` function](/functions/get/) to grab a specific format. (See [Output Formats](/templates/output-formats/).)
@@ -118,10 +118,10 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 : the slice of strings that results from splitting .Plain into words, as defined in Go's [strings.Fields](https://golang.org/pkg/strings/#Fields).
 
 .Prev
-: Points down to the previous [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath)). Example: `{{if .Prev}}{{.Prev.Permalink}}{{end}}`.  Calling `.Prev` from the last page returns `nil`.
+: Points down to the previous [regular page](/variables/site/#site-pages) (sorted by Hugo's [default sort](/templates/lists#default-weight--date--linktitle--filepath)). Example: `{{if .Prev}}{{.Prev.Permalink}}{{end}}`.  Calling `.Prev` from the last page returns `nil`.
 
 .PrevInSection
-: Points down to the previous [regular page](/variables/site/#site-pages) below the same top level section (e.g. `/blog`). Pages are sorted by Hugo's [default sort](/templates/lists#default-weight-date-linktitle-filepath). Example: `{{if .PrevInSection}}{{.PrevInSection.Permalink}}{{end}}`.  Calling `.PrevInSection` from the last page returns `nil`.
+: Points down to the previous [regular page](/variables/site/#site-pages) below the same top level section (e.g. `/blog`). Pages are sorted by Hugo's [default sort](/templates/lists#default-weight--date--linktitle--filepath). Example: `{{if .PrevInSection}}{{.PrevInSection.Permalink}}{{end}}`.  Calling `.PrevInSection` from the last page returns `nil`.
 
 .PublishDate
 : the date on which the content was or will be published; `.Publishdate` pulls from the `publishdate` field in a content's front matter. See also `.ExpiryDate`, `.Date`, and `.Lastmod`.


### PR DESCRIPTION
This PR fixes more than 20 broken anchor links in the hugo docs. These broken links where detected using the great [hyperlink](https://github.com/untitaker/hyperlink) tool. With current HEAD of repo, this tool reports:

```
$ hyperlink.exe public/ --check-anchors --sources content/en/
Reading files
Checking 100383 links from 1308 files (540 documents)
Found some broken links, reading source files
...
Found 233 bad links
Found 25 bad anchors
```
With this PR applied, this comes down to:

```
Found 228 bad links
Found 0 bad anchors
```

Please note that not all of these 228 bad links are actually bad links, a lot of them are covered by aliases, `hyperlink` produces false alerts for this kind of links.

**Idea:** What about integrating link checking as a part of the build process when committing of receiving PR (e.g. via GitHub actions)?