### PR TITLE
Remove references to mmark

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -163,7 +163,6 @@
     "Milli",
     "Mittwoch",
     "mkdir",
-    "mmark",
     "modh",
     "monokai",
     "Morling",

--- a/.hvm
+++ b/.hvm
@@ -1,0 +1,1 @@
+hugo_extended_0.97.0_Linux-64bit

--- a/content/en/content-management/formats.md
+++ b/content/en/content-management/formats.md
@@ -5,7 +5,7 @@ description: Both HTML and Markdown are supported content formats.
 date: 2017-01-10
 publishdate: 2017-01-10
 categories: [content management]
-keywords: [markdown,asciidoc,mmark,pandoc,content format]
+keywords: [markdown,asciidoc,pandoc,content format]
 menu:
   docs:
     parent: "content-management"
@@ -30,7 +30,6 @@ The current list of content formats in Hugo:
 | ------------- | ------------- |-------------|
 | Goldmark  | md, markdown, goldmark  |Note that you can set the default handler of `md` and `markdown` to something else, see [Configure Markup](/getting-started/configuration-markup/).{{< new-in "0.60.0" >}} |
 | Blackfriday | blackfriday  |Blackfriday will eventually be deprecated.|
-|MMark|mmark|Mmark is deprecated and will be removed in a future release.|
 |Emacs Org-Mode|org|See [go-org](https://github.com/niklasfasching/go-org).|
 |AsciiDoc|asciidocext, adoc, ad|Needs [Asciidoctor][ascii] installed.|
 |RST|rst|Needs [RST](https://docutils.sourceforge.io/rst.html) installed.|
@@ -131,7 +130,6 @@ Markdown syntax is simple enough to learn in a single sitting. The following are
 [ascii]: https://asciidoctor.org/
 [bfconfig]: /getting-started/configuration/#configuring-blackfriday-rendering
 [blackfriday]: https://github.com/russross/blackfriday
-[mmark]: https://github.com/miekg/mmark
 [config]: /getting-started/configuration/
 [developer tools]: /tools/
 [emojis]: https://www.webpagefx.com/tools/emoji-cheat-sheet/
@@ -146,7 +144,6 @@ Markdown syntax is simple enough to learn in a single sitting. The following are
 [mdcheatsheet]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
 [mdguide]: https://www.markdownguide.org/
 [mdtutorial]: https://www.markdowntutorial.com/
-[Miek Gieben's website]: https://miek.nl/2016/march/05/mmark-syntax-document/
 [org]: https://orgmode.org/
 [pandoc]: https://www.pandoc.org/
 [rest]: https://docutils.sourceforge.io/rst.html

--- a/content/en/content-management/toc.md
+++ b/content/en/content-management/toc.md
@@ -49,10 +49,6 @@ Hugo will take this Markdown and create a table of contents from `## Introductio
 
 The built-in `.TableOfContents` variables outputs a `<nav id="TableOfContents">` element with a child `<ul>`, whose child `<li>` elements begin with appropriate HTML headings. See [the available settings](/getting-started/configuration-markup/#table-of-contents) to configure what heading levels you want to include in TOC.
 
-{{% note "Table of contents not available for MMark" %}}
-Hugo documents created in the [MMark](/content-management/formats/#list-of-content-formats) Markdown dialect do not currently display TOCs. TOCs are, however, compatible with all other supported Markdown formats.
-{{% /note %}}
-
 ## Template Example: Basic TOC
 
 The following is an example of a very basic [single page template][]:


### PR DESCRIPTION
Support for mmark was removed on 4 Jan 2022.
See https://github.com/gohugoio/hugo/commit/1651beb