### PR TITLE
Update name of command that enables printing i18n warnings

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -544,10 +544,10 @@ Hugo will generate your website with these missing translation placeholders. It 
 
 For merging of content from other languages (i.e. missing content translations), see [lang.Merge].
 
-To track down missing translation strings, run Hugo with the `--i18n-warnings` flag:
+To track down missing translation strings, run Hugo with the `--printI18nWarnings` flag:
 
 ```bash
-hugo --i18n-warnings | grep i18n
+hugo --printI18nWarnings | grep i18n
 i18n|MISSING_TRANSLATION|en|wordCount
 ```
 


### PR DESCRIPTION
This was changed in commit 837fdfdf45014e3d5ef3b00b01548b68a4489c5f of
the hugo repository.

Note: The same command that was renamed is referenced in an example of the `hugo help` command to verify that hugo was installed correctly, but I saw that the output is not only outdated for this command but there are new ones that also do not appear there so I left it the way it is. 