### PR TITLE
Fix outdated i18n warnings flag mention on the multilingual page

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -544,10 +544,10 @@ Hugo will generate your website with these missing translation placeholders. It 
 
 For merging of content from other languages (i.e. missing content translations), see [lang.Merge].
 
-To track down missing translation strings, run Hugo with the `--i18n-warnings` flag:
+To track down missing translation strings, run Hugo with the `--printI18nWarnings` flag:
 
 ```bash
-hugo --i18n-warnings | grep i18n
+hugo --printI18nWarnings | grep i18n
 i18n|MISSING_TRANSLATION|en|wordCount
 ```
 


### PR DESCRIPTION
[This commit](https://github.com/gohugoio/hugo/commit/837fdfdf45014e3d5ef3b00b01548b68a4489c5f) from February 15 renamed `--i18n-warnings` to `--printI18nWarnings`.
The section on [Missing Translations on the Multilingual page](https://gohugo.io/content-management/multilingual/#missing-translations) of the Hugo docs has the old `--i18n-warnings` flag suggested.

This PR updates the flag to the current `--printI18nWarnings` usage

Also note that `hugo/docs/content/en/getting-started/usage.md` still references the outdated `--i18n-warnings` and `--path-warnings` but that file seems to be unused on the live site. 