### PR TITLE
Remove references to outdated Blackfriday markdown processor

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -217,7 +217,7 @@ You can assign content-specific `weight` in the front matter of your content. Th
 
 ## Override Global Markdown Configuration
 
-It's possible to set some options for Markdown rendering in a content's front matter as an override to the [BlackFriday rendering options set in your project configuration][config].
+It's possible to set some options for Markdown rendering in a content's front matter as an override to the [Rendering options set in your project configuration][config].
 
 ## Front Matter Format Specs
 

--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -24,7 +24,7 @@ Below are all markup related configuration in Hugo with their default settings:
 
 ### Goldmark
 
-[Goldmark](https://github.com/yuin/goldmark/) is from Hugo 0.60 the default library used for Markdown. It's fast, it's [CommonMark](https://spec.commonmark.org/0.29/) compliant and it's very flexible. Note that the feature set of Goldmark vs Blackfriday isn't the same; you gain a lot but also lose some, but we will work to bridge any gap in the upcoming Hugo versions.
+[Goldmark](https://github.com/yuin/goldmark/) is from Hugo 0.60 the default library used for Markdown. It's fast, it's [CommonMark](https://spec.commonmark.org/0.29/) compliant and it's very flexible.
 
 This is the default configuration:
 
@@ -77,7 +77,7 @@ Note that attributes in [code fences](/content-management/syntax-highlighting/#h
 ````
 
 autoHeadingIDType ("github") {{< new-in "0.62.2" >}}
-: The strategy used for creating auto IDs (anchor names). Available types are `github`, `github-ascii` and `blackfriday`. `github` produces GitHub-compatible IDs, `github-ascii` will drop any non-Ascii characters after accent normalization, and `blackfriday` will make the IDs comptible with [Blackfriday](#blackfriday), the default Markdown engine before Hugo 0.60. Note that if Goldmark is your default Markdown engine, this is also the strategy used in the [anchorize](/functions/anchorize/) template func.
+: The strategy used for creating auto IDs (anchor names). Available types are `github`, `github-ascii` and `blackfriday`. `github` produces GitHub-compatible IDs, `github-ascii` will drop any non-Ascii characters after accent normalization, and `blackfriday` will make the IDs compatible with [Blackfriday](#blackfriday), the default Markdown engine before Hugo 0.60. Note that if Goldmark is your default Markdown engine, this is also the strategy used in the [anchorize](/functions/anchorize/) template func.
 
 
 ### Highlight

--- a/content/en/showcase/tomango/index.md
+++ b/content/en/showcase/tomango/index.md
@@ -10,7 +10,7 @@ siteURL: https://www.tomango.co.uk
 
 siteSource: https://github.com/trys/tomango-2018
 
-byline: "[Trys Mudford](http://www.trysmudford.com), Lead Developer, Tomango"
+byline: "[Trys Mudford](https://www.trysmudford.com), Lead Developer, Tomango"
 
 ---
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -112,7 +112,7 @@ You can use the following code to render the `Short Description` in your layout:
 <div>Short Description of {{.Site.Data.User0123.Name}}: <p>{{ index .Site.Data.User0123 "Short Description" | markdownify }}</p></div>
 ```
 
-Note the use of the [`markdownify` template function][markdownify]. This will send the description through the Blackfriday Markdown rendering engine.
+Note the use of the [`markdownify` template function][markdownify]. This will send the description through the Markdown rendering engine.
 
 
 ## Get Remote Data

--- a/content/en/templates/files.md
+++ b/content/en/templates/files.md
@@ -43,7 +43,7 @@ To use the `readFile` function in your templates, make sure the path is relative
 
 ### `readFile` Example: Add a Project File to Content
 
-As `readFile` is a function, it is only available to you in your templates and not your content. However, we can create a simple [shortcode template][sct] that calls `readFile`, passes the first argument through the function, and then allows an optional second argument to send the file through the Blackfriday markdown processor. The pattern for adding this shortcode to your content will be as follows:
+As `readFile` is a function, it is only available to you in your templates and not your content. However, we can create a simple [shortcode template][sct] that calls `readFile`, passes the first argument through the function, and then allows an optional second argument to send the file through the markdown processor. The pattern for adding this shortcode to your content will be as follows:
 
 ```
 {{</* readfile file="/path/to/local/file.txt" markdown="true" */>}}


### PR DESCRIPTION
This PR remove references to outdated Blackfriday markdown processor. It also changes some links from http to https and fixes a typo.