### PR TITLE
update GitHub 404 docs URL to prevent redirect

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -17,7 +17,7 @@ aliases: []
 toc: false
 ---
 
-When using Hugo with [GitHub Pages](https://pages.github.com/), you can provide your own template for a [custom 404 error page](https://help.github.com/articles/custom-404-pages/) by creating a 404.html template file in your `/layouts` folder. When Hugo generates your site, the `404.html` file will be placed in the root.
+When using Hugo with [GitHub Pages](https://pages.github.com/), you can provide your own template for a [custom 404 error page](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) by creating a 404.html template file in your `/layouts` folder. When Hugo generates your site, the `404.html` file will be placed in the root.
 
 404 pages will have all the regular [page variables][pagevars] available to use in the templates.
 


### PR DESCRIPTION
This link was redirecting so this PR updates the URL to the final destination.