### PR TITLE
Add link for ''Hugo Shortcode Syntax Highlighting' VS Code extension

### DIFF
--- a/content/en/tools/editors.md
+++ b/content/en/tools/editors.md
@@ -31,6 +31,7 @@ The Hugo community uses a wide range of preferred tools and has developed plug-i
 * [Hugo Language and Syntax Support](https://marketplace.visualstudio.com/items?itemName=budparr.language-hugo-vscode). Hugo Language and Syntax Support is a Visual Studio Code plugin for Hugo syntax highlighting and snippets. The source code can be found [here](https://github.com/budparr/language-hugo-vscode).
 * [Hugo Themer](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-hugo-themer). Hugo Themer is an extension to help you while developing themes. It allows you to easily navigate through your theme files.
 * [Front Matter](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter). Once you go for a static site, you need to think about how you are going to manage your articles. Front matter is a tool that helps you maintaining the metadata/front matter of your articles like: creation date, modified date, slug, tile, SEO check, and many more...
+* [Syntax Highlighting for Hugo Shortcodes](https://github.com/kael-larkin/hugo-vscode-shortcode-syntax-highlighting). This extension add some syntax highlighting for Shortcodes, making visual identification of individual pieces easier.
 
 ## Emacs
 


### PR DESCRIPTION
Add a VS code Extension to highlight shortcodes.