### PR TITLE
fix: Use `=` instead of `:=` for variable reassignments

### DIFF
--- a/content/en/functions/union.md
+++ b/content/en/functions/union.md
@@ -40,8 +40,8 @@ This is also very useful to use as `OR` filters when combined with where:
 
 ```
 {{ $pages := where .Site.RegularPages "Type" "not in" (slice "page" "about") }}
-{{ $pages := $pages | union (where .Site.RegularPages "Params.pinned" true) }}
-{{ $pages := $pages | intersect (where .Site.RegularPages "Params.images" "!=" nil) }}
+{{ $pages = $pages | union (where .Site.RegularPages "Params.pinned" true) }}
+{{ $pages = $pages | intersect (where .Site.RegularPages "Params.images" "!=" nil) }}
 ```
 
 The above fetches regular pages not of `page` or `about` type unless they are pinned. And finally, we exclude all pages with no `images` set in Page params.


### PR DESCRIPTION
Ref: https://discourse.gohugo.io/t/join-two-variables-together/39402/6