### PR TITLE
docs: Add direct link to internal template code

### DIFF
--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -208,6 +208,8 @@ To add Twitter card metadata, include the following line between the `<head>` ta
 
 ## The Internal Templates
 
+The code for these templates and more can be found here at the [internal templates](https://github.com/gohugoio/hugo/tree/master/tpl/tplimpl/embedded/templates):
+
 * `_internal/disqus.html`
 * `_internal/google_analytics.html`
 * `_internal/google_analytics_async.html`


### PR DESCRIPTION
It is difficult to find the internal template code in Github and impossible apart from it. Having a direct link allows the user to easily see the code used.