### PR TITLE
Update en/templates/404.md with Firebase Hosting

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -54,6 +54,7 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 * Netlify. Add `/* /404.html 404` to `content/_redirects`. [Details Here](https://www.netlify.com/docs/redirects/#custom-404)
 * Azure Static website. You can specify the `Error document path` in the Static website configuration page of the Azure portal. [More details are available in the Static website documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website).
 * DigitalOcean App Platform. You can specify `error_document` in your app specification file or use control panel to set up error document. [Details here](https://docs.digitalocean.com/products/app-platform/how-to/manage-static-sites/#configure-a-static-site).
+* [Firebase Hosting](https://firebase.google.com/docs/hosting/full-config#404): `/404.html` automatically gets used as the 404 page.
 
 {{% note %}}
 `hugo server` will not automatically load your custom `404.html` file, but you


### PR DESCRIPTION
The Documentation already includes a guide on deploying to Firebase. But, Firebase is still missing from the Page explaining how to create 404 templates. On that page, there is a list of explanations on how to set up a 404 page on various hosting providers. This PR adds an explanation of Firebase Hosting's behavior to that list.