### PR TITLE
Improves formatting of resources, assets sections

### DIFF
--- a/content/en/getting-started/directory-structure.md
+++ b/content/en/getting-started/directory-structure.md
@@ -31,6 +31,7 @@ Running the `hugo new site` generator from the command line will create a direct
 ├── content
 ├── data
 ├── layouts
+├── public
 ├── static
 └── themes
 ```
@@ -45,7 +46,7 @@ The following is a high-level overview of each of the directories with links to 
 By default, Hugo will create new content files with at least `date`, `title` (inferred from the file name), and `draft = true`. This saves time and promotes consistency for sites using multiple content types. You can create your own [archetypes][] with custom preconfigured front matter fields as well.
 
 [`assets`][]
-: Stores all the files which need be processed by [Hugo Pipes]({{< ref "/hugo-pipes" >}}). Only the files whose `.Permalink` or `.RelPermalink` are used will be published to the `public` directory. Note: assets directory is not created by default.
+: Stores all the files which need be processed by [Hugo Pipes](/hugo-pipes/). Only the files whose `.Permalink` or `.RelPermalink` are used will be published to the `public` directory. Note: assets directory is not created by default.
 
 [`config`](/getting-started/configuration/)
 : Hugo ships with a large number of [configuration directives][].
@@ -71,11 +72,11 @@ used by Hugo when generating your website. You can write these files in YAML, JS
 From **Hugo 0.31** you can have multiple static directories.
 {{% /note %}}
 
-resources
+[`resources`][]
 : Caches some files to speed up generation. Can be also used by template authors to distribute built SASS files, so you don't have to have the preprocessor installed. Note: resources directory is not created by default.
 
-
 [archetypes]: /content-management/archetypes/
+[`assets`]: /hugo-pipes/introduction#asset-directory/
 [configuration directives]: /getting-started/configuration/#all-configuration-settings
 [`content`]: /content-management/organization/
 [content section]: /content-management/sections/
@@ -84,6 +85,7 @@ resources
 [homepage]: /templates/homepage/
 [`layouts`]: /templates/
 [`static`]: /content-management/static-files/
+[`resources`]: /getting-started/configuration/#configure-file-caches
 [lists]: /templates/list/
 [pagevars]: /variables/page/
 [partials]: /templates/partials/
@@ -93,4 +95,3 @@ resources
 [taxonomies]: /content-management/taxonomies/
 [taxonomy templates]: /templates/taxonomy-templates/
 [types]: /content-management/types/
-[`assets`]: {{< ref "/hugo-pipes/introduction#asset-directory" >}}


### PR DESCRIPTION
This PR fixes a few formatting issues in the [Directory Structure](https://gohugo.io/getting-started/directory-structure/) page. Here are the changes made:

1. Updated the tree structure section to add `public` folder (created by the generator command `hugo new site`)
2. `assets` section: replaced usages of Hugo shortcodes with regular links so that markdown preview looks good in github and docs website.
3. `resources` section: fixed the formatting to show it as link instead of plain text
