### PR TITLE
Update slice.md

### DIFF
--- a/content/en/functions/slice.md
+++ b/content/en/functions/slice.md
@@ -23,7 +23,9 @@ toc: false
 One use case is the concatenation of elements in combination with the [`delimit` function][]:
 
 {{< code file="slice.html" >}}
-{{ delimit (slice "foo" "bar" "buzz") ", " }}
+{{ $sliceOfStrings := slice "foo" "bar" "buzz" }}
+<!-- returns the slice [ "foo", "bar", "buzz"] -->
+{{ delimit ($sliceOfStrings) ", " }}
 <!-- returns the string "foo, bar, buzz" -->
 {{< /code >}}
 


### PR DESCRIPTION
Should include simple case.  By combining in to a single step with the delimit function it confuses that this is the reference for the slice function.  My solution is just to add an interim step illustrating the simple case and feeding that back into the delimit function.