### PR TITLE
docs: Update quick start to clarify the need of extended version

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -47,7 +47,7 @@ hugo version
 # Example output: hugo v0.104.2+extended darwin/amd64 BuildDate=unknown
 ```
 
-It should state that it is `extended`. If it does not, uninstall it and try another installation method
+It should state that it is `extended`. If it does not, uninstall it and try another installation method.
 
 {{< asciicast ItACREbFgvJ0HjnSNeTknxWy9 >}}
 

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -28,7 +28,7 @@ For other approaches to learning Hugo (like books or video tutorials), refer to 
 
 ## Step 1: Install Hugo
 
-Install the **extended version of Hugo** (this is required for the current theme used)
+Install the **extended version of Hugo** (this is required for the current theme used).
 
 {{% note %}}
 `Homebrew` and `MacPorts`, package managers for `macOS`,  can be installed from [brew.sh](https://brew.sh/) or [macports.org](https://www.macports.org/) respectively. See [install](/getting-started/installing) if you are running Windows etc.

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -28,6 +28,8 @@ For other approaches to learning Hugo (like books or video tutorials), refer to 
 
 ## Step 1: Install Hugo
 
+Install the **extended version of Hugo** (this is required for the current theme used)
+
 {{% note %}}
 `Homebrew` and `MacPorts`, package managers for `macOS`,  can be installed from [brew.sh](https://brew.sh/) or [macports.org](https://www.macports.org/) respectively. See [install](/getting-started/installing) if you are running Windows etc.
 {{% /note %}}
@@ -42,7 +44,10 @@ To verify your new install:
 
 ```bash
 hugo version
+# Example output: hugo v0.104.2+extended darwin/amd64 BuildDate=unknown
 ```
+
+It should state that it is `extended`. If it does not, uninstall it and try another installation method
 
 {{< asciicast ItACREbFgvJ0HjnSNeTknxWy9 >}}
 


### PR DESCRIPTION
The current theme requires the extended version of Hugo. Add extra mention of this requirement and how to check it

Fixes: #1549


**Preview of change**

<img width="795" alt="image" src="https://user-images.githubusercontent.com/892961/193441104-7e3c1534-bd9b-4197-accd-c8d4f568367c.png">
