### PR TITLE
Breadcrumb example: add basic accessibility

### DIFF
--- a/content/en/content-management/sections.md
+++ b/content/en/content-management/sections.md
@@ -73,7 +73,7 @@ With the available [section variables and methods](#section-page-variables-and-m
 {{ else if not .p1.IsHome }}
 {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
 {{ end }}
-<li{{ if eq .p1 .p2 }} class="active"{{ end }}>
+<li{{ if eq .p1 .p2 }} class="active" aria-current="page" {{ end }}>
   <a href="{{ .p1.Permalink }}">{{ .p1.Title }}</a>
 </li>
 {{ end }}


### PR DESCRIPTION
Add `aria-current="page"` for screen readers for the bredcrumb example.