### PR TITLE
Change link of repojacking vulnerable link - JekyllToHugo

### DIFF
--- a/content/en/tools/migrations.md
+++ b/content/en/tools/migrations.md
@@ -29,7 +29,7 @@ Take a look at this list of migration tools if you currently use other blogging 
 
 Alternatively, you can use the new [Jekyll import command](/commands/hugo_import_jekyll/).
 
-- [JekyllToHugo](https://github.com/SenjinDarashiva/JekyllToHugo) - A Small script for converting Jekyll blog posts to a Hugo site.
+- [JekyllToHugo](https://github.com/fredrikloch/JekyllToHugo) - A Small script for converting Jekyll blog posts to a Hugo site.
 - [ConvertToHugo](https://github.com/coderzh/ConvertToHugo) - Convert your blog from Jekyll to Hugo.
 
 ## Ghost


### PR DESCRIPTION
Hello from Hacktoberfest :)
The link to - https://github.com/SenjinDarashiva/JekyllToHugo is vulnerable to RepoJacking (it redirects to the original project that changed name), you should change the link to the current name of the project. if you won't change the link, an attacker can open the linked repository and attacks users that trust your links/tool.
The new repository name is: https://github.com/fredrikloch/JekyllToHugo