### PR TITLE
docs: Link data templates to index function

### DIFF
--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -114,12 +114,21 @@ You can use the following code to render the `Short Description` in your layout:
 
 Note the use of the [`markdownify` template function][markdownify]. This will send the description through the Markdown rendering engine.
 
-## Use data in front matter
+## Keys as variables
 
-You might want to access different properties of your data in front matter.
-For example, you want to specify a `location` for a page with specific information about that location.
+You might want to access a key name as a variable.
+To do so, use the [`index` function][index] with the variable as the second parameter.
+```plaintext
+{{ $keyName := "Name" }}
+{{ index .Site.Data.User0123 $keyName }}
+```
 
-To do so, use the [`index` function][index].
+If the `Name` key is an object, you can also access its properties:
+
+```plaintext
+{{ $keyName := "Name" }}
+{{ (index .Site.Data.User0123 $keyName).propertyName }}
+```
 
 ## Get Remote Data
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -114,6 +114,12 @@ You can use the following code to render the `Short Description` in your layout:
 
 Note the use of the [`markdownify` template function][markdownify]. This will send the description through the Markdown rendering engine.
 
+## Use data in front matter
+
+You might want to access different properties of your data in front matter.
+For example, you want to specify a `location` for a page with specific information about that location.
+
+To do so, use the [`index` function][index].
 
 ## Get Remote Data
 


### PR DESCRIPTION
Someone was having difficulty accessing their data in their front matter. They were looking at the [data templates page](https://gohugo.io/templates/data-templates) and not seeing any relevant help. When I linked to the [index function](https://gohugo.io/functions/index-function/) it was clear for them.

This PR is to try to help anyone else who might have the same issue.