### PR TITLE
Add Super Linter GitHub Action

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,39 @@
+name: Super Linter
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORE_GITIGNORED_FILES: true
+          LINTER_RULES_PATH: /
+          LOG_LEVEL: NOTICE
+          MARKDOWN_CONFIG_FILE: .markdownlint.yaml
+          SUPPRESS_POSSUM: true
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_CSS: false
+          VALIDATE_EDITORCONFIG: false
+          VALIDATE_GITLEAKS: false
+          VALIDATE_HTML: false
+          VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_XML: false


### PR DESCRIPTION
This PR adds GitHub's open-source Super Linter GitHub Action.
https://github.com/github/super-linter

Many of the supported linters are disabled for now, but in the future once we have formatted all the Markdown files we can enable linting for those. For CSS we could potentially add a `.stylelintrc` config and enable that too.

For now, this is still useful to add as it validates files such as JSON, GitHub Actions, YAML etc. I have tested this running across the entire codebase and no issues are found with the current config.