### PR TITLE
Change anchor reference to use relref function calls

### DIFF
--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -111,7 +111,7 @@ When taxonomies are used---and [taxonomy templates][] are provided---Hugo will a
 
 ## Configure Taxonomies
 
-Custom taxonomies other than the [defaults](#default-taxonomies) must be defined in your [site config][config] before they can be used throughout the site. You need to provide both the plural and singular labels for each taxonomy. For example, `singular key = "plural value"` for TOML and `singular key: "plural value"` for YAML.
+Custom taxonomies other than the [defaults]({{< relref "taxonomies.md#default-taxonomies" >}}) must be defined in your [site config][config] before they can be used throughout the site. You need to provide both the plural and singular labels for each taxonomy. For example, `singular key = "plural value"` for TOML and `singular key: "plural value"` for YAML.
 
 ### Example: Adding a custom taxonomy named "series"
 
@@ -135,7 +135,7 @@ If you want to have just the default `tags` taxonomy, and remove the `categories
   tag = "tags"
 {{</ code-toggle >}}
 
-If you want to disable all taxonomies altogether, see the use of `disableKinds` in [Hugo Taxonomy Defaults](#default-taxonomies).
+If you want to disable all taxonomies altogether, see the use of `disableKinds` in [Hugo Taxonomy Defaults]({{< relref "taxonomies.md#default-taxonomies" >}}).
 
 {{% note %}}
 You can add content and front matter to your taxonomy list and taxonomy terms pages. See [Content Organization](/content-management/organization/) for more information on how to add an `_index.md` for this purpose.

--- a/content/en/functions/where.md
+++ b/content/en/functions/where.md
@@ -115,7 +115,7 @@ You can also put the returned value of the `where` clauses into a variable:
 
 Using `first` and `where` together can be very
 powerful. Below snippet gets a list of posts only from [**main
-sections**](#mainsections), sorts it using the [default
+sections**]({{< relref "where.md#mainsections" >}}), sorts it using the [default
 ordering](/templates/lists/) for lists (i.e., `weight => date`), and
 then ranges through only the first 5 posts in that list:
 

--- a/content/en/templates/introduction.md
+++ b/content/en/templates/introduction.md
@@ -496,7 +496,7 @@ Will render `Bonsoir, Eliott.`, and not care about the syntax error (`add 0 + 2`
 
 ### HTML comments
 
-If you need to produce HTML comments from your templates, take a look at the [Internet Explorer conditional comments](#ie-conditional-comments) example. If you need variables to construct such HTML comments, just pipe `printf` to `safeHTML`. For example:
+If you need to produce HTML comments from your templates, take a look at the [Internet Explorer conditional comments]({{< relref "introduction.md#ie-conditional-comments" >}}) example. If you need variables to construct such HTML comments, just pipe `printf` to `safeHTML`. For example:
 
 ```go-html-template
 {{ printf "<!-- Our website is named: %s -->" .Site.Title | safeHTML }}

--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -105,7 +105,7 @@ See also `.ExpiryDate`, `.Date`, `.PublishDate`, and [`.GitInfo`][gitinfo].
 
 .Pages
 : a collection of associated pages. This value will be `nil` within
-  the context of regular content pages. See [`.Pages`](#pages).
+  the context of regular content pages. See [`.Pages`]({{< relref "page.md#pages" >}}).
 
 .Permalink
 : the Permanent link for this page; see [Permalinks](/content-management/urls/)

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -87,10 +87,10 @@ All the methods below, e.g. `.Site.RegularPages` can also be reached via the glo
 : all of the menus in the site.
 
 .Site.Pages
-: array of all content ordered by Date with the newest first. This array contains only the pages in the current language. See [`.Site.Pages`](#site-pages).
+: array of all content ordered by Date with the newest first. This array contains only the pages in the current language. See [`.Site.Pages`]({{< relref "site.md#site-pages" >}}).
 
 .Site.RegularPages
-: a shortcut to the *regular* page collection. `.Site.RegularPages` is equivalent to `where .Site.Pages "Kind" "page"`. See [`.Site.Pages`](#site-pages).
+: a shortcut to the *regular* page collection. `.Site.RegularPages` is equivalent to `where .Site.Pages "Kind" "page"`. See [`.Site.Pages`]({{< relref "site.md#site-pages" >}}).
 
 .Site.Sections
 : top-level directories of the site.


### PR DESCRIPTION
The [MD051](https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md#md051) warnings are because of the use of custom heading IDs. This change updates the link references to use the [relref](https://gohugo.io/content-management/cross-references/#heading-ids) function to reference the custom heading IDs without triggering markdownlint's warnings on MD051 

Fixes #1849