### PR TITLE
Fix data templates page

### DIFF
--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -36,7 +36,7 @@ If you wish to access the data using the `.Site.Data.filename` notation, the fil
 - `x123.json` - Valid
 - `_123.json` - Valid
 
-If you wish to access the data using the [`index`](/functions/index-function/) function, the first character of the filename is irrelevant. For example:
+If you wish to access the data using the [`index`](/functions/index-function/) function, the filename is irrelevant. For example:
 Date file|Template code
 :--|:--
 `123.json`|`{{ index .Site.Data "123" }}`

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -28,7 +28,9 @@ Hugo supports loading data from YAML, JSON, XML, and TOML files located in the `
 
 The `data` folder is where you can store additional data for Hugo to use when generating your site. Data files aren't used to generate standalone pages; rather, they're meant to be supplemental to content files. This feature can extend the content in case your front matter fields grow out of control. Or perhaps you want to show a larger dataset in a template (see example below). In both cases, it's a good idea to outsource the data in their own files.
 
-These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `.json`, `.xml`, or `.toml` extension). The data will be accessible as a `map` in the `.Site.Data` variable. Additionally, filenames must begin with an underscore or a Unicode letter, followed by zero or more underscores, Unicode letters, or Unicode digits. eg:
+These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `.json`, `.xml`, or `.toml` extension). The data will be accessible as a `map` in the `.Site.Data` variable. 
+
+If you wish to access the data using the `.Site.Data.filename` notation, the filename must begin with an underscore or a Unicode letter, followed by zero or more underscores, Unicode letters, or Unicode digits. eg:
 
 - `2022.json` - Invalid
 - `data_2022.json` - Valid

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -32,7 +32,7 @@ These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `
 
 ## Data Files in Themes
 
-Data Files can also be used in [Hugo themes][themes] but note that theme data files follow the same logic as other template files in the [Hugo lookup order][lookup] (i.e., given two files with the same name and relative path, the file in the root project `data` directory will override the file in the `themes/<THEME>/data` directory).
+Data Files can also be used in [Hugo themes][themes] but note that theme data files are merged with the project directory taking precedence (i.e., given two files with the same name and relative path, the data in the file in the root project `data` directory will override the data from the file in the `themes/<THEME>/data` directory *for keys that are duplicated*).
 
 Therefore, theme authors should take care to not include data files that could be easily overwritten by a user who decides to [customize a theme][customize]. For theme-specific data items that shouldn't be overridden, it can be wise to prefix the folder structure with a namespace; e.g. `mytheme/data/<THEME>/somekey/...`. To check if any such duplicate exists, run hugo with the `-v` flag.
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -33,7 +33,7 @@ These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `
 If you wish to access the data using the `.Site.Data.filename` notation, the filename must begin with an underscore or a Unicode letter, followed by zero or more underscores, Unicode letters, or Unicode digits. eg:
 
 - `123.json` - Invalid
-- `data_2022.json` - Valid
+- `x123.json` - Valid
 - `_2022.json` - Valid
 
 ## Data Files in Themes

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -37,7 +37,7 @@ If you wish to access the data using the `.Site.Data.filename` notation, the fil
 - `_123.json` - Valid
 
 If you wish to access the data using the [`index`](/functions/index-function/) function, the filename is irrelevant. For example:
-Date file|Template code
+Data file|Template code
 :--|:--
 `123.json`|`{{ index .Site.Data "123" }}`
 `x123.json`|`{{ index .Site.Data "x123" }}`

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -34,7 +34,14 @@ If you wish to access the data using the `.Site.Data.filename` notation, the fil
 
 - `123.json` - Invalid
 - `x123.json` - Valid
-- `_2022.json` - Valid
+- `_123.json` - Valid
+
+If you wish to access the data using the [`index`](/functions/index-function/) function, the first character of the filename is irrelevant. For example:
+Date file|Template code
+:--|:--
+`123.json`|`{{ index .Site.Data "123" }}`
+`x123.json`|`{{ index .Site.Data "x123" }}`
+`_123.json`|`{{ index .Site.Data "_123" }}`
 
 ## Data Files in Themes
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -42,6 +42,7 @@ Date file|Template code
 `123.json`|`{{ index .Site.Data "123" }}`
 `x123.json`|`{{ index .Site.Data "x123" }}`
 `_123.json`|`{{ index .Site.Data "_123" }}`
+`x-123.json`|`{{ index .Site.Data "_123" }}`
 
 ## Data Files in Themes
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -32,7 +32,7 @@ These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `
 
 If you wish to access the data using the `.Site.Data.filename` notation, the filename must begin with an underscore or a Unicode letter, followed by zero or more underscores, Unicode letters, or Unicode digits. eg:
 
-- `2022.json` - Invalid
+- `123.json` - Invalid
 - `data_2022.json` - Valid
 - `_2022.json` - Valid
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -28,7 +28,11 @@ Hugo supports loading data from YAML, JSON, XML, and TOML files located in the `
 
 The `data` folder is where you can store additional data for Hugo to use when generating your site. Data files aren't used to generate standalone pages; rather, they're meant to be supplemental to content files. This feature can extend the content in case your front matter fields grow out of control. Or perhaps you want to show a larger dataset in a template (see example below). In both cases, it's a good idea to outsource the data in their own files.
 
-These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `.json`, `.xml`, or `.toml` extension). The data will be accessible as a `map` in the `.Site.Data` variable.
+These files must be YAML, JSON, XML, or TOML files (using the `.yml`, `.yaml`, `.json`, `.xml`, or `.toml` extension). The data will be accessible as a `map` in the `.Site.Data` variable. Additionally, filenames must begin with an underscore or a Unicode letter, followed by zero or more underscores, Unicode letters, or Unicode digits. eg:
+
+- `2022.json` - Invalid
+- `data_2022.json` - Valid
+- `_2022.json` - Valid
 
 ## Data Files in Themes
 


### PR DESCRIPTION
- Updated explanation about duplicate keys in data files that are named the same in the same path
<img width="461" alt="Screen Shot 2022-10-25 at 12 11 37 AM" src="https://user-images.githubusercontent.com/612340/197696042-e14c19e8-2284-48d5-9d42-9552076e7eba.png">


- Added information about valid vs invalid filenames
<img width="453" alt="Screen Shot 2022-10-25 at 12 09 11 AM" src="https://user-images.githubusercontent.com/612340/197696023-2f894b53-c1af-4c57-a485-ea05e8fc036f.png">



Fixes #1728