### PR TITLE
Remove `#+KEY: VALUE` to avoid deprecated warning

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -36,7 +36,7 @@ JSON
 
 ORG
 : a group of Org mode keywords in the format '`#+KEY: VALUE`'. Any line that does not start with `#+` ends the front matter section.
-  Keyword values can be either strings (`#+KEY: VALUE`) or a whitespace separated list of strings (`#+KEY[]: VALUE_1 VALUE_2`).
+  Keyword values can be a whitespace separated list of strings (`#+KEY[]: VALUE_1 VALUE_2`).
 
 ### Example
 


### PR DESCRIPTION
If you use sth. like this in your org posts file:

```org
#+TITLE: ...
#+DATE: ...
#+TAGS: CSS
```

WARNING you may get:

```shell
Please use '#+tags[]:' notation, automatic conversion is deprecated.
```
