### PR TITLE
Remove dated new-in flags

### DIFF
--- a/content/en/about/security-model/index.md
+++ b/content/en/about/security-model/index.md
@@ -29,8 +29,6 @@ But when developing and building your site, the runtime is the `hugo` executable
 
 ## Security Policy
 
-{{< new-in "0.91.0" >}}
-
 Hugo has a built-in security policy that restricts access to [os/exec](https://pkg.go.dev/os/exec), remote communication and similar.
 
 The default configuration is listed below. Any build using features not in the allow list of the security policy will fail with a detailed message about what needs to be done. Most of these settings are allow lists (string or slice, [Regular Expressions](https://pkg.go.dev/regexp) or `none` which matches nothing).

--- a/content/en/content-management/build-options.md
+++ b/content/en/content-management/build-options.md
@@ -29,7 +29,7 @@ _build:
 
 If `always`, the page will be treated as a published page, holding its dedicated output files (`index.html`, etc...) and permalink.
 
-{{< new-in "0.76.0" >}} We extended this property from a boolean to an enum in Hugo 0.76.0. Valid values are:
+We extended this property from a boolean to an enum in Hugo 0.76.0. Valid values are:
 
 never
 : The page will not be included in any page collection.
@@ -53,7 +53,7 @@ always (default)
 : The page will be included in all page collections, e.g. `site.RegularPages`, `$page.Pages`.
 
 local
-: The page will be included in any _local_ page collection, e.g. `$page.RegularPages`, `$page.Pages`. One use case for this would be to create fully navigable, but headless content sections. {{< new-in "0.68.0" >}}
+: The page will be included in any _local_ page collection, e.g. `$page.RegularPages`, `$page.Pages`. One use case for this would be to create fully navigable, but headless content sections.
 
 If true, the page will be treated as part of the project's collections and, when appropriate, returned by Hugo's listing methods (`.Pages`, `.RegularPages` etc...).
 

--- a/content/en/content-management/formats.md
+++ b/content/en/content-management/formats.md
@@ -28,7 +28,7 @@ The current list of content formats in Hugo:
 
 | Name  | Markup identifiers | Comment |
 | ------------- | ------------- |-------------|
-| Goldmark  | md, markdown, goldmark  |Note that you can set the default handler of `md` and `markdown` to something else, see [Configure Markup](/getting-started/configuration-markup/).{{< new-in "0.60.0" >}} |
+| Goldmark  | md, markdown, goldmark  |Note that you can set the default handler of `md` and `markdown` to something else, see [Configure Markup](/getting-started/configuration-markup/).|
 |Emacs Org-Mode|org|See [go-org](https://github.com/niklasfasching/go-org).|
 |AsciiDoc|asciidocext, adoc, ad|Needs [Asciidoctor][ascii] installed.|
 |RST|rst|Needs [RST](https://docutils.sourceforge.io/rst.html) installed.|

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -160,9 +160,7 @@ Any node or section can pass down to descendants a set of Front Matter values as
 
 ### Target Specific Pages
 
-{{< new-in "0.76.0" >}}
-
-Since Hugo 0.76 the `cascade` block can be a slice with a optional `_target` keyword, allowing for multiple `cascade` values targeting different page sets.
+The `cascade` block can be a slice with a optional `_target` keyword, allowing for multiple `cascade` values targeting different page sets.
 
 {{< code-toggle copy="false" >}}
 title ="Blog"

--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -45,8 +45,6 @@ content
 ResourceType
 : The main type of the resource's [Media Type](/templates/output-formats/#media-types). For example, a file of MIME type `image/jpeg` has the ResourceType `image`. A `Page` will have `ResourceType` with value `page`.
 
-{{< new-in "0.80.0" >}} Note that we in Hugo `v0.80.0` fixed a bug where non-image resources (e.g. video) would return the MIME sub type, e.g. `json`.
-
 Name
 : Default value is the filename (relative to the owning page). Can be set in front matter.
 

--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -52,8 +52,6 @@ The examples above use two different delimiters, the difference being the `%` ch
 
 ### Shortcodes with raw string parameters
 
-{{< new-in "0.64.1" >}}
-
 You can pass multiple lines as parameters to a shortcode by using raw string literals:
 
 ```go-html-template

--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -40,7 +40,7 @@ Highlighting is carried out via the built-in [`highlight` shortcode](https://goh
 
 Options:
 
-* `linenos`: configure line numbers. Valid values are `true`, `false`, `table`, or `inline`. `false` will turn off line numbers if it's configured to be on in site config. {{< new-in "0.60.0" >}} `table` will give copy-and-paste friendly code blocks.
+* `linenos`: configure line numbers. Valid values are `true`, `false`, `table`, or `inline`. `false` will turn off line numbers if it's configured to be on in site config. `table` will give copy-and-paste friendly code blocks.
 * `hl_lines`: lists a set of line numbers or line number ranges to be highlighted.
 * `linenostart=199`: starts the line number count from 199.
 * `anchorlinenos`: Configure anchors on line numbers. Valid values are `true` or `false`;
@@ -100,7 +100,7 @@ See [Highlight](/functions/highlight/).
 
 ## Highlighting in Code Fences
 
-Highlighting in code fences is enabled by default.{{< new-in "0.60.0" >}}
+Highlighting in code fences is enabled by default.
 
 ````txt
 ```go {linenos=table,hl_lines=[8,"15-17"],linenostart=199}
@@ -134,7 +134,7 @@ func GetTitleFunc(style string) func(s string) string {
 }
 ```
 
-{{< new-in "0.60.0" >}}Note that only Goldmark supports passing attributes such as `hl_lines`, and it's important that it does not contain any spaces. See [goldmark-highlighting](https://github.com/yuin/goldmark-highlighting) for more information.
+Note that only Goldmark supports passing attributes such as `hl_lines`, and it's important that it does not contain any spaces. See [goldmark-highlighting](https://github.com/yuin/goldmark-highlighting) for more information.
 
 The options are the same as in the [highlighting shortcode](/content-management/syntax-highlighting/#highlight-shortcode),including `linenos=false`, but note the slightly different Markdown attribute syntax.
 

--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -98,8 +98,6 @@ If you do not want Hugo to create any taxonomies, set `disableKinds` in your [si
 disableKinds = ["taxonomy","term"]
 {{</ code-toggle >}}
 
-{{< new-in "0.73.0" >}} We have fixed the previously confusing page kinds used for taxonomies (see the listing below) to be in line with the terms used when we talk about taxonomies. We have been careful to avoid site breakage, and you should get an ERROR in the console if you need to adjust your `disableKinds` section.
-
 {{% page-kinds %}}
 
 ### Default Destinations

--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -81,7 +81,7 @@ The following is a list of values that can be used in a `permalink` definition i
 : the content's section
 
 `:sections`
-: the content's sections hierarchy. {{< new-in "0.83.0" >}} Since Hugo 0.83 you can use a selection of the sections using _slice syntax_: `:sections[1:]` includes all but the first, `:sections[:last]` includes all but the last, `:sections[last]` includes only the last, `:sections[1:2]` includes section 2 and 3. Note that this slice access will not throw any out-of-bounds errors, so you don't have to be exact.
+: the content's sections hierarchy. Uou can use a selection of the sections using _slice syntax_: `:sections[1:]` includes all but the first, `:sections[:last]` includes all but the last, `:sections[last]` includes only the last, `:sections[1:2]` includes section 2 and 3. Note that this slice access will not throw any out-of-bounds errors, so you don't have to be exact.
 
 `:title`
 : the content's title

--- a/content/en/functions/RenderString.md
+++ b/content/en/functions/RenderString.md
@@ -10,8 +10,6 @@ keywords: [markdown,goldmark,render]
 signature: [".RenderString MARKUP"]
 ---
 
-{{< new-in "0.62.0" >}}
-
 `.RenderString` is a method on `Page` that renders some markup to HTML using the content renderer defined for that page (if not set in the options).
 
 The method takes an optional map argument with these options:

--- a/content/en/functions/dateformat.md
+++ b/content/en/functions/dateformat.md
@@ -22,7 +22,7 @@ deprecated: false
 {{ time.Format "Monday, Jan 2, 2006" "2015-01-21" }} → "Wednesday, Jan 21, 2015"
 ```
 
-Note that since Hugo 0.87.0, `time.Format` will return a localized string for the current language. {{< new-in "0.87.0" >}}
+`time.Format` returns a localized string for the current language.
 
 The `LAYOUT` string can be either:
 
@@ -34,9 +34,7 @@ See the [`time` function](/functions/time/) to convert a timestamp string to a G
 
 ## Date/time formatting layouts
 
-{{< new-in "0.87.0" >}}
-
-Go's date layout strings can be hard to reason about, especially with multiple languages. Since Hugo 0.87.0 you can alternatively use some predefined layout identifiers that will output localized dates or times:
+Go's date layout strings can be hard to reason about, especially with multiple languages. You can alternatively use some predefined layout identifiers that will output localized dates or times:
 
 ```go-html-template
 {{ .Date | time.Format ":date_long" }}

--- a/content/en/functions/get.md
+++ b/content/en/functions/get.md
@@ -18,12 +18,11 @@ aliases: []
 needsexample: true
 ---
 
-
 `.Get` is specifically used when creating your own [shortcode template][sc], to access the [positional and named](/templates/shortcode-templates/#positional-vs-named-parameters) parameters passed to it. When used with a numeric INDEX, it queries positional parameters (starting with 0). With a string KEY, it queries named parameters.
 
-When accessing a named parameter that does not exist, `.Get` returns an empty string instead of interrupting the build. The same goes with positional parameters in hugo version 0.40 and after. This allows you to chain `.Get` with `if`, `with`, `default` or `cond` to check for parameter existence. For example, you may now use:
+When accessing named or positional parameters that do not exist, `.Get` returns an empty string instead of interrupting the build. This allows you to chain `.Get` with `if`, `with`, `default` or `cond` to check for parameter existence. For example:
 
-```
+```go-html-template
 {{ $quality := default "100" (.Get 1) }}
 ```
 

--- a/content/en/functions/hasmenucurrent.md
+++ b/content/en/functions/hasmenucurrent.md
@@ -23,6 +23,6 @@ aliases: []
 returns `true` if the PAGE is the same object as the `.Page` in one of the
 **children menu entries** under MENUENTRY in a given MENU.
 
-{{< new-in "0.86.0" >}} If MENUENTRY's `.Page` is a [section](/content-management/sections/) then, from Hugo `0.86.0`, this method also returns true for any descendant of that section..
+If MENUENTRY's `.Page` is a [section](/content-management/sections/) then, from Hugo `0.86.0`, this method also returns true for any descendant of that section..
 
 You can find its example use in [menu templates](/templates/menu-templates/).

--- a/content/en/functions/hugo.md
+++ b/content/en/functions/hugo.md
@@ -39,7 +39,7 @@ hugo.CommitHash
 hugo.BuildDate
 : the compile date of the current Hugo binary formatted with RFC 3339 e.g. `2002-10-02T10:00:00-05:00`
 
-hugo.IsExtended {{< new-in "0.83.0" >}}
+hugo.IsExtended
 : whether this is the extended Hugo binary.
 
 hugo.IsProduction

--- a/content/en/functions/images/index.md
+++ b/content/en/functions/images/index.md
@@ -15,8 +15,6 @@ See [images.Filter](#filter) for how to apply these filters to an image.
 
 ## Overlay
 
-{{< new-in "0.80.0" >}}
-
 {{% funcsig %}}
 images.Overlay SRC X Y
 {{% /funcsig %}}
@@ -38,8 +36,6 @@ A shorter version of the above, if you only need to apply the filter once:
 The above will overlay `$logo` in the upper left corner of `$img` (at position `x=50, y=50`).
 
 ## Text
-
-{{< new-in "0.90.0" >}}
 
 Using the `Text` filter, you can add text to an image.
 

--- a/content/en/functions/scratch.md
+++ b/content/en/functions/scratch.md
@@ -42,7 +42,7 @@ Since Hugo 0.43, there are two different ways of using Scratch:
 
 #### The local `newScratch`
 
-{{< new-in "0.43" >}} A Scratch instance can also be assigned to any variable using the `newScratch` function. In this case, no Page or Shortcode context is required and the scope of the scratch is only local. The methods detailed below are available from the variable the Scratch instance was assigned to.
+A Scratch instance can also be assigned to any variable using the `newScratch` function. In this case, no Page or Shortcode context is required and the scope of the scratch is only local. The methods detailed below are available from the variable the Scratch instance was assigned to.
 
 ```go-html-template
 {{ $data := newScratch }}
@@ -138,7 +138,7 @@ Return an array of values from `key` sorted by `mapKey`.
 
 #### .Delete
 
-{{< new-in "0.38" >}} Remove the given key.
+Remove the given key.
 
 ```go-html-template
 {{ $scratch.Set "greeting" "Hello" }}

--- a/content/en/functions/strings.Count.md
+++ b/content/en/functions/strings.Count.md
@@ -17,8 +17,6 @@ deprecated: false
 aliases: []
 ---
 
-{{< new-in "0.74.0" >}}
-
 If `SUBSTR` is an empty string, this function returns 1 plus the number of Unicode code points in `STRING`.
 
 Example|Result

--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -12,8 +12,6 @@ toc: true
 
 ## Configure Markup
 
-{{< new-in "0.60.0" >}}
-
 See [Goldmark](#goldmark) for settings related to the default Markdown handler in Hugo.
 
 Below are all markup related configuration in Hugo with their default settings:
@@ -43,7 +41,7 @@ typographer
 attribute
 : Enable custom attribute support for titles and blocks by adding attribute lists inside single curly brackets (`{.myclass class="class1 class2" }`) and placing it _after the Markdown element it decorates_, on the same line for titles and on a new line directly below for blocks.
 
-{{< new-in "0.81.0" >}} In Hugo 0.81.0 we added support for adding attributes (e.g. CSS classes) to Markdown blocks, e.g. tables, lists, paragraphs etc.
+Hugo supports adding attributes (e.g. CSS classes) to Markdown blocks, e.g. tables, lists, paragraphs etc.
 
 A blockquote with a CSS class:
 
@@ -76,7 +74,7 @@ Note that attributes in [code fences](/content-management/syntax-highlighting/#h
 ```
 ````
 
-autoHeadingIDType ("github") {{< new-in "0.62.2" >}}
+autoHeadingIDType ("github")
 : The strategy used for creating auto IDs (anchor names). Available types are `github`, `github-ascii` and `blackfriday`. `github` produces GitHub-compatible IDs, `github-ascii` will drop any non-Ascii characters after accent normalization, and `blackfriday` will make the IDs compatible with Blackfriday, the default Markdown engine before Hugo 0.60. Note that if Goldmark is your default Markdown engine, this is also the strategy used in the [anchorize](/functions/anchorize/) template func.
 
 ### Highlight

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -100,8 +100,6 @@ Default environments are __development__ with `hugo server` and __production__ w
 
 ## Merge Configuration from Themes
 
-{{< new-in "0.84.0" >}} The configuration merge described below was improved in Hugo 0.84.0 and made fully configurable. The big change/improvement was that we now, by default, do deep merging of `params` maps from themes.
-
 The configuration value for `_merge` can be one of:
 
 none
@@ -166,8 +164,6 @@ Include content with publishdate in the future.
 See [Configure File Caches](#configure-file-caches)
 
 ### cascade
-
-{{< new-in "0.86.0" >}}
 
 Pass down default configuration values (front matter) to pages in the content tree. The options in site config is the same as in page front matter, see [Front Matter Cascade](/content-management/front-matter#front-matter-cascade).
 
@@ -306,7 +302,7 @@ See [Disable a Language](/content-management/multilingual/#disable-a-language)
 
 ### markup
 
-See [Configure Markup](/getting-started/configuration-markup).{{< new-in "0.60.0" >}}
+See [Configure Markup](/getting-started/configuration-markup).
 
 ### mediaTypes
 
@@ -322,7 +318,7 @@ See [Configure Minify](#configure-minify)
 
 ### module
 
-Module config see [Module Config](/hugo-modules/configuration/).{{< new-in "0.56.0" >}}
+Module config see [Module Config](/hugo-modules/configuration/).
 
 ### newContentEditor
 
@@ -376,7 +372,7 @@ The directory to where Hugo will write the final static site (the HTML files etc
 
 ### related
 
-: See [Related Content](/content-management/related/#configure-related-content).{{< new-in "0.27" >}}
+: See [Related Content](/content-management/related/#configure-related-content).
 
 ### relativeURLs
 
@@ -450,8 +446,6 @@ Timeout for generating page contents, specified as a [duration](https://pkg.go.d
 
 ### timeZone
 
-{{< new-in "0.87.0" >}}
-
 The time zone (or location), e.g. `Europe/Oslo`,  used to parse front matter dates without such information and in the [`time` function](/functions/time/). The list of valid values may be system dependent, but should include `UTC`, `Local`, and any location in the [IANA Time Zone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ### title
@@ -492,8 +486,6 @@ enableemoji: true
 
 ## Configure Build
 
-{{< new-in "0.66.0" >}}
-
 The `build` configuration section contains global build-related configuration options.
 
 {{< code-toggle file="config">}}
@@ -507,17 +499,15 @@ noJSConfigInAssets = false
 useResourceCacheWhen
 : When to use the cached resources in `/resources/_gen` for PostCSS and ToCSS. Valid values are `never`, `always` and `fallback`. The last value means that the cache will be tried if PostCSS/extended version is not available.
 
-writeStats {{< new-in "0.69.0" >}}
+writeStats
 : When enabled, a file named `hugo_stats.json` will be written to your project root with some aggregated data about the build, e.g. list of HTML entities published to be used to do [CSS pruning](/hugo-pipes/postprocess/#css-purging-with-postcss). If you're only using this for the production build, you should consider placing it below [config/production](/getting-started/configuration/#configuration-directory). It's also worth mentioning that, due to the nature of the partial server builds, new HTML entities will be added when you add or change them while the server is running, but the old values will not be removed until you restart the server or run a regular `hugo` build.
 
 **Note** that the prime use case for this is purging of unused CSS; it is built for speed and there may be false positives (e.g., detection of HTML elements that are not HTML elements).
 
-noJSConfigInAssets {{< new-in "0.78.0" >}}
+noJSConfigInAssets
 : Turn off writing a `jsconfig.json` into your `/assets` folder with mapping of imports from running [js.Build](https://gohugo.io/hugo-pipes/js). This file is intended to help with intellisense/navigation inside code editors such as [VS Code](https://code.visualstudio.com/). Note that if you do not use `js.Build`, no file will be written.
 
 ## Configure Server
-
-{{< new-in "0.67.0" >}}
 
 This is only relevant when running `hugo server`, and it allows to set HTTP headers during development, which allows you to test out your Content Security Policy and similar. The configuration format matches [Netlify's](https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file) with slightly more powerful [Glob matching](https://github.com/gobwas/glob):
 
@@ -550,9 +540,6 @@ Referrer-Policy = "strict-origin-when-cross-origin"
 Content-Security-Policy = "script-src localhost:1313"
 {{< /code-toggle >}}
 
-
-{{< new-in "0.72.0" >}}
-
 You can also specify simple redirects rules for the server. The syntax is again similar to Netlify's.
 
 Note that a `status` code of 200 will trigger a [URL rewrite](https://docs.netlify.com/routing/redirects/rewrites-proxies/), which is what you want in SPA situations, e.g:
@@ -565,7 +552,7 @@ status = 200
 force = false
 {{< /code-toggle >}}
 
-{{< new-in "0.76.0" >}} Setting `force=true` will make a redirect even if there is existing content in the path. Note that before Hugo 0.76  `force` was the default behavior, but this is inline with how Netlify does it.
+Setting `force=true` will make a redirect even if there is existing content in the path. Note that before Hugo 0.76  `force` was the default behavior, but this is inline with how Netlify does it.
 
 ## 404 Server Error Page
 
@@ -637,7 +624,7 @@ Names must be prefixed with `HUGO_` and the configuration key must be set in upp
 To set config params, prefix the name with `HUGO_PARAMS_`
 {{% /note %}}
 
-{{< new-in "0.79.0" >}} If you are using snake_cased variable names, the above will not work, so since Hugo 0.79.0 Hugo determines the delimiter to use by the first character after `HUGO`. This allows you to define environment variables on the form `HUGOxPARAMSxAPI_KEY=abcdefgh`, using any [allowed](https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names#:~:text=So%20names%20may%20contain%20any,not%20begin%20with%20a%20digit.) delimiter.
+If you are using snake_cased variable names, the above will not work. Hugo determines the delimiter to use by the first character after `HUGO`. This allows you to define environment variables on the form `HUGOxPARAMSxAPI_KEY=abcdefgh`, using any [allowed](https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names#:~:text=So%20names%20may%20contain%20any,not%20begin%20with%20a%20digit.) delimiter.
 
 {{< todo >}}
 Test and document setting params via JSON env var.
@@ -724,8 +711,6 @@ The above will try first to extract the value for `.Date` from the filename, the
 Hugo v0.20 introduced the ability to render your content to multiple output formats (e.g., to JSON, AMP html, or CSV). See [Output Formats][] for information on how to add these values to your Hugo project's configuration file.
 
 ## Configure Minify
-
-{{< new-in "0.68.0" >}}
 
 Default configuration:
 

--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -26,10 +26,10 @@ replacements = ""
 workspace = ""
 {{< /code-toggle >}}
 
-noVendor {{< new-in "0.75.0" >}}
+noVendor
 : A optional Glob pattern matching module paths to skip when vendoring, e.g. "github.com/**"
 
-vendorClosest {{< new-in "0.81.0" >}}
+vendorClosest
 : When enabled, we will pick the vendored module closest to the module using it. The default behavior is to pick the first. Note that there can still be only one dependency of a given module path, so once it is in use it cannot be redefined.
 
 proxy
@@ -41,10 +41,10 @@ noProxy
 private
 : Comma separated glob list matching paths that should be treated as private.
 
-workspace {{< new-in "0.83.0" >}}
+workspace
 : The workspace file to use. This enables Go workspace mode. Note that this can also be set via OS env, e.g. `export HUGO_MODULE_WORKSPACE=/my/hugo.work` This only works with Go 1.18+.
 
-replacements {{< new-in "0.77.0" >}}
+replacements
 : A comma separated (or a slice) list of module path to directory replacement mapping, e.g. `github.com/bep/my-theme -> ../..,github.com/bep/shortcodes -> /some/path`. This is mostly useful for temporary locally development of a module, and then it makes sense to set it as an OS environment variable, e.g: `env HUGO_MODULE_REPLACEMENTS="github.com/bep/my-theme -> ../.."`. Any relative path is relate to [themesDir](https://gohugo.io/getting-started/configuration/#all-configuration-settings), and absolute paths are allowed.
 
 Note that the above terms maps directly to their counterparts in Go Modules. Some of these setting may be natural to set as OS environment variables. To set the proxy server to use, as an example:
@@ -98,13 +98,13 @@ path
 ignoreConfig
 : If enabled, any module configuration file, e.g. `config.toml`, will not be loaded. Note that this will also stop the loading of any transitive module dependencies.
 
-ignoreImports {{< new-in "0.80.0" >}}
+ignoreImports
 : If enabled, module imports will not be followed.
 
 disable
 : Set to `true` to disable the module while keeping any version info in the `go.*` files.
 
-noMounts {{< new-in "0.84.2" >}}
+noMounts
 :  Do not mount any folder in this import.
 
 noVendor
@@ -163,8 +163,6 @@ includeFiles (string or slice)
 The glob patterns are matched to the filenames starting from the `source` root, they should have Unix styled slashes even on Windows, `/` matches the mount root and `**` can be used as a  super-asterisk to match recursively down all directories, e.g `/posts/**.jpg`.
 
 The search is case-insensitive.
-
-{{< new-in "0.89.0" >}}
 
 excludeFiles (string or slice)
 : One or more glob patterns matching files to exclude.

--- a/content/en/hugo-modules/use-modules.md
+++ b/content/en/hugo-modules/use-modules.md
@@ -59,8 +59,6 @@ hugo mod get -u
 
 ### Update All Modules Recursively
 
-{{< new-in "0.65.0" >}}
-
 ```bash
 hugo mod get -u ./...
 ```
@@ -89,7 +87,7 @@ replace github.com/bep/hugotestmods/mypartials => /Users/bep/hugotestmods/mypart
 
 If you have the `hugo server` running, the configuration will be reloaded and `/Users/bep/hugotestmods/mypartials` put on the watch list.
 
-Note that since v.0.77.0 you can use modules config [`replacements`](https://gohugo.io/hugo-modules/configuration/#module-config-top-level) option. {{< new-in "0.77.0" >}}
+Instead of modifying the `go.mod` files, you can also use the modules config [`replacements`](https://gohugo.io/hugo-modules/configuration/#module-config-top-level) option.
 
 ## Print Dependency Graph
 
@@ -120,7 +118,7 @@ Note that:
 
 * You can run `hugo mod vendor` on any level in the module tree.
 * Vendoring will not store modules stored in your `themes` folder.
-* Most commands accept a `--ignoreVendorPaths` flag, which will then not use the vendored modules in `_vendor` for the module paths matching the [Glob](https://github.com/gobwas/glob) pattern given. Note that before Hugo 0.75 this flag was named `--ignoreVendor` and was a "all or nothing". {{< new-in "0.75.0" >}}
+* Most commands accept a `--ignoreVendorPaths` flag, which will then not use the vendored modules in `_vendor` for the module paths matching the [Glob](https://github.com/gobwas/glob) pattern given.
 
 Also see the [CLI Doc](/commands/hugo_mod_vendor/).
 

--- a/content/en/hugo-pipes/babel.md
+++ b/content/en/hugo-pipes/babel.md
@@ -24,9 +24,7 @@ If you are using the Hugo Snap package, Babel and plugin(s) need to be installed
 
 ### Config
 
-{{< new-in "v0.75.0" >}}
-
-In Hugo `v0.75` we improved the way we resolve JS configuration and dependencies. One of them is that we now add the main project's `node_modules` to `NODE_PATH` when running Babel and similar tools. There are some known [issues](https://github.com/babel/babel/issues/5618) with Babel in this area, so if you have a `babel.config.js` living in a Hugo Module (and not in the project itself), we recommend using `require` to load the presets/plugins, e.g.:
+We add the main project's `node_modules` to `NODE_PATH` when running Babel and similar tools. There are some known [issues](https://github.com/babel/babel/issues/5618) with Babel in this area, so if you have a `babel.config.js` living in a Hugo Module (and not in the project itself), we recommend using `require` to load the presets/plugins, e.g.:
 
 
 ```js

--- a/content/en/hugo-pipes/introduction.md
+++ b/content/en/hugo-pipes/introduction.md
@@ -75,8 +75,6 @@ By default, Hugo calculates a cache key based on the `URL` and the `options` (e.
 
 ### Error Handling
 
-{{< new-in "0.91.0" >}}
-
 The return value from `resources.GetRemote` includes an `.Err` method that will return an error if the call failed. If you want to just log any error as a `WARNING` you can use a construct similar to the one below.
 
 ```go-html-template

--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -21,7 +21,7 @@ targetPath [string]
 : If not set, the source path will be used as the base target path.
 Note that the target path's extension may change if the target MIME type is different, e.g. when the source is TypeScript.
 
-params [map or slice] {{< new-in "0.78.0" >}}
+params [map or slice]
 : Params that can be imported as JSON in your JS files, e.g.:
 
 ```go-html-template
@@ -38,10 +38,10 @@ Note that this is meant for small data sets, e.g. config settings. For larger da
 minify [bool]
 : Let `js.Build` handle the minification.
 
-inject [slice] {{< new-in "0.81.0" >}}
+inject [slice]
 : This option allows you to automatically replace a global variable with an import from another file. The path names must be relative to `assets`.  See https://esbuild.github.io/api/#inject
 
-shims {{< new-in "0.81.0" >}}
+shims
 : This option allows swapping out a component with another. A common use case is to load dependencies like React from a CDN  (with _shims_) when in production, but running with the full bundled `node_modules` dependency during development:
 
 ```go-html-template
@@ -67,7 +67,7 @@ With the above, these imports should work in both scenarios:
 import * as React from 'react'
 import * as ReactDOM from 'react-dom';
 ```
-sourceMap [string, bool] {{< new-in "0.75.0" >}}
+sourceMap [string, bool]
 : Let `js.Build` output sourceMap. Current only inline is supported. true defaults to inline.
   One of: '`inline`, `external`
   Default is "" (disabled)
@@ -88,7 +88,7 @@ defines [map]
 {{ $defines := dict "process.env.NODE_ENV" `"development"` }}
 ```
 
-format [string] {{< new-in "0.74.3" >}}
+format [string] 
 : The output format.
   One of: `iife`, `cjs`, `esm`.
   Default is `iife`, a self-executing function, suitable for inclusion as a <script> tag.
@@ -98,9 +98,7 @@ sourceMap
 
 ### Import JS code from /assets
 
-{{< new-in "0.78.0" >}}
-
-Since Hugo `v0.78.0` `js.Build` has full support for the virtual union file system in [Hugo Modules](/hugo-modules/). You can see some simple examples in this [test project](https://github.com/gohugoio/hugoTestProjectJSModImports), but in short this means that you can do this:
+`js.Build` has full support for the virtual union file system in [Hugo Modules](/hugo-modules/). You can see some simple examples in this [test project](https://github.com/gohugoio/hugoTestProjectJSModImports), but in short this means that you can do this:
 
 ```js
 import { hello } from 'my/module';
@@ -146,7 +144,7 @@ Hugo will, by default, generate a `assets/jsconfig.json` file that maps the impo
 
 Any imports in a file outside `/assets` or that does not resolve to a component inside `/assets` will be resolved by [ESBuild](https://esbuild.github.io/) with the **project directory** as the resolve directory (used as the starting point when looking for `node_modules` etc.). Also see [hugo mod npm pack](/commands/hugo_mod_npm_pack/).  If you have any imported npm dependencies in your project, you need to make sure to run `npm install` before you run `hugo`.
 
-{{< new-in "0.78.1" >}} From Hugo `0.78.1` the start directory for resolving npm packages (aka. packages that live inside a `node_modules` folder) is always the main project folder.
+The start directory for resolving npm packages (aka. packages that live inside a `node_modules` folder) is always the main project folder.
 
 **Note:** If you're developing a theme/component that is supposed to be imported and depends on dependencies inside `package.json`, we recommend reading about [hugo mod npm pack](/commands/hugo_mod_npm_pack/), a tool to consolidate all the npm dependencies in a project.
 

--- a/content/en/hugo-pipes/postcss.md
+++ b/content/en/hugo-pipes/postcss.md
@@ -36,7 +36,7 @@ config [string]
 noMap [bool]
 : Default is `false`. Disable the default inline sourcemaps
 
-inlineImports [bool] {{< new-in "0.66.0" >}}
+inlineImports [bool]
 : Default is `false`. Enable inlining of @import statements. It does so recursively, but will only import a file once.
 URL imports (e.g. `@import url('https://fonts.googleapis.com/css?family=Open+Sans&display=swap');`) and imports with media queries will be ignored.
 Note that this import routine does not care about the CSS spec, so you can have @import anywhere in the file.
@@ -68,8 +68,6 @@ syntax [string]
 ```
 
 ## Check Hugo Environment from postcss.config.js
-
-{{< new-in "0.66.0" >}}
 
 The current Hugo environment name (set by `--environment` or in config or OS environment) is available in the Node context, which allows constructs like this:
 

--- a/content/en/hugo-pipes/postprocess.md
+++ b/content/en/hugo-pipes/postprocess.md
@@ -12,7 +12,7 @@ weight: 39
 sections_weight: 39
 ---
 
-Marking a resource with `resources.PostProcess` delays any transformations to after the build, typically because one or more of the steps in the transformation chain depends on the result of the build (e.g. files in `public`).{{< new-in "0.69.0" >}}
+Marking a resource with `resources.PostProcess` delays any transformations to after the build, typically because one or more of the steps in the transformation chain depends on the result of the build (e.g. files in `public`).
 
 A prime use case for this is [CSS purging with PostCSS](#css-purging-with-postcss).
 

--- a/content/en/hugo-pipes/scss-sass.md
+++ b/content/en/hugo-pipes/scss-sass.md
@@ -22,9 +22,9 @@ Any Sass or SCSS file can be transformed into a CSS file using `resources.ToCSS`
 
 ### Options
 
-transpiler [string] {{< new-in "0.80.0" >}}
+transpiler [string]
 
-: The `transpiler` to use, valid values are `libsass` (default) and `dartsass`. Note that the Embedded Dart Sass project is still in beta. We will try to improve the installation process when it has stable releases, but if you want to use Hugo with Dart Sass you need to download a release binary from [Embedded Dart Sass](https://github.com/sass/dart-sass-embedded/releases) (Hugo after 0.81.0 requires beta 6 or newer) and make sure it's in your PC's `$PATH` (or `%PATH%` on Windows).
+: The `transpiler` to use, valid values are `libsass` (default) and `dartsass`. If you want to use Hugo with Dart Sass you need to download a release binary from [Embedded Dart Sass](https://github.com/sass/dart-sass-embedded/releases) and make sure it's in your PC's `$PATH` (or `%PATH%` on Windows).
 
 targetPath [string]
 : If not set, the resource's target path will be the asset file original path with its extension replaced by `.css`.

--- a/content/en/readfiles/pages-vs-site-pages.md
+++ b/content/en/readfiles/pages-vs-site-pages.md
@@ -27,7 +27,7 @@ the current _list_ page:
     current _list_ page. This **excludes** regular pages in nested sections/_list_ pages (those are subdirectories with an `_index.md` file.
 
 `.RegularPagesRecursive`
-: {{< new-in "0.68.0" >}} Collection of **all** _regular_ pages under a _list_ page. This **includes** regular pages in nested sections/_list_ pages.
+: Collection of **all** _regular_ pages under a _list_ page. This **includes** regular pages in nested sections/_list_ pages.
 
 Note
 : From the scope of _regular_ pages, `.Pages` and

--- a/content/en/templates/base.md
+++ b/content/en/templates/base.md
@@ -23,7 +23,7 @@ The `block` keyword allows you to define the outer shell of your pages' one or m
 
 ## Base Template Lookup Order
 
-{{< new-in "0.63.0" >}} Since Hugo v0.63, the base template lookup order closely follows that of the template it applies to (e.g. `_default/list.html`).
+The base template lookup order closely follows that of the template it applies to (e.g. `_default/list.html`).
 
 See [Template Lookup Order](/templates/lookup-order/) for details and examples.
 

--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -160,7 +160,7 @@ This will resolve internally to the following:
 
 ### Add HTTP headers
 
-{{< new-in "0.84.0" >}} Both `getJSON` and `getCSV` takes an optional map as the last argument, e.g.:
+Both `getJSON` and `getCSV` takes an optional map as the last argument, e.g.:
 
 ```go-html-template
 {{ $data := getJSON "https://example.org/api" (dict "Authorization" "Bearer abcd")  }}

--- a/content/en/templates/output-formats.md
+++ b/content/en/templates/output-formats.md
@@ -164,8 +164,6 @@ Example from site config file:
 Note that in the above examples, the _output formats_ for `section`,
 `taxonomy` and `term` will stay at their default value `["HTML", "RSS"]`.
 
-{{< new-in "0.73.0" >}} We have fixed the before confusing page kinds used for taxonomies (see the listing below) to be in line with the terms used when we talk about taxonomies. We have been careful to avoid site breakage, and you should get an ERROR in the console if you need to adjust your `outputs` section.
-
 {{% page-kinds %}}
 
 * The `outputs` definition is per [`Page` `Kind`][page_kinds] (`page`, `home`, `section`, `taxonomy`, or `term`).

--- a/content/en/templates/partials.md
+++ b/content/en/templates/partials.md
@@ -121,8 +121,6 @@ Only one `return` statement is allowed per partial file.
 
 ## Inline Partials
 
-{{< new-in "0.74.0" >}}
-
 You can also define partials inline in the template. But remember that template namespace is global, so you need to make sure that the names are unique to avoid conflicts.
 
 ```go-html-template

--- a/content/en/templates/render-hooks.md
+++ b/content/en/templates/render-hooks.md
@@ -13,17 +13,17 @@ menu:
     weight: 20
 ---
 
-{{< new-in "0.62.0" >}} Note that this is only supported with the [Goldmark](/getting-started/configuration-markup#goldmark) renderer.
+Note that this is only supported with the [Goldmark](/getting-started/configuration-markup#goldmark) renderer.
 
 You can override certain parts of the default Markdown rendering to HTML by creating templates with base names `render-{kind}` in `layouts/_default/_markup`.
 
-You can also create type/section specific hooks in `layouts/[type/section]/_markup`, e.g.: `layouts/blog/_markup`.{{< new-in "0.71.0" >}}
+You can also create type/section specific hooks in `layouts/[type/section]/_markup`, e.g.: `layouts/blog/_markup`.
 
 The hook kinds currently supported are:
 
 * `image`
 * `link`
-* `heading` {{< new-in "0.71.0" >}}
+* `heading`
 * `codeblock`{{< new-in "0.93.0" >}}
 
 You can define [Output-Format-](/templates/output-formats) and [language-](/content-management/multilingual/)specific templates if needed. Your `layouts` folder may look like this:
@@ -82,7 +82,7 @@ Text
 PlainText
 : The plain variant of the above.
 
-Attributes (map) {{< new-in "0.82.0" >}}
+Attributes (map)
 : A map of attributes (e.g. `id`, `class`)
 
 ### Link with title Markdown example

--- a/content/en/templates/shortcode-templates.md
+++ b/content/en/templates/shortcode-templates.md
@@ -370,9 +370,7 @@ More shortcode examples can be found in the [shortcodes directory for spf13.com]
 
 ## Inline Shortcodes
 
-{{< new-in "0.52" >}}
-
-Since Hugo 0.52, you can implement your shortcodes inline -- e.g. where you use them in the content file. This can be useful for scripting that you only need in one place.
+You can also implement your shortcodes inline -- e.g. where you use them in the content file. This can be useful for scripting that you only need in one place.
 
 This feature is disabled by default, but can be enabled in your site config:
 

--- a/content/en/variables/menus.md
+++ b/content/en/variables/menus.md
@@ -40,7 +40,7 @@ Reference to the [page object][page-object] associated with the menu entry. This
 will be non-nil if the menu entry is set via a page's front-matter and not via
 the site config.
 
-.PageRef {{< new-in "0.86.0" >}}
+.PageRef
 : _string_ <br /> Can be set if defined in site config and the menu entry refers to a Page. [site.GetPage](/functions/getpage/) will be used to do the page lookup. If this is set, you don't need to set the `URL`.
 
 .Name

--- a/content/en/variables/site.md
+++ b/content/en/variables/site.md
@@ -22,7 +22,7 @@ The following is a list of site-level (aka "global") variables. Many of these va
 
 ## Get the Site object from a partial
 
-All the methods below, e.g. `.Site.RegularPages` can also be reached via the global [`site`](/functions/site/) function, e.g. `site.RegularPages`, which can be handy in partials where the `Page` object isn't easily available. {{< new-in "0.53" >}}.
+All the methods below, e.g. `.Site.RegularPages` can also be reached via the global [`site`](/functions/site/) function, e.g. `site.RegularPages`, which can be handy in partials where the `Page` object isn't easily available.
 
 ## Site Variables List
 


### PR DESCRIPTION
This removes new-in flags older than v0.92.0, which was released at the beginning of 2022.

Closes #1877