### PR TITLE
Remove erroneous sourcemap desc

### DIFF
--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -67,10 +67,6 @@ With the above, these imports should work in both scenarios:
 import * as React from 'react'
 import * as ReactDOM from 'react-dom';
 ```
-sourceMap [string, bool]
-: Let `js.Build` output sourceMap. Current only inline is supported. true defaults to inline.
-  One of: '`inline`, `external`
-  Default is "" (disabled)
 
 target [string]
 : The language target.


### PR DESCRIPTION
There were two sourceMap descriptions. This removes the erroneous one. The remaining description is correct.