### PR TITLE
Fix a typo in diagrams documentation

### DIFF
--- a/content/en/content-management/diagrams.md
+++ b/content/en/content-management/diagrams.md
@@ -17,7 +17,7 @@ toc: true
 
 ## GoAT Diagrams (Ascii)
 
-Hugo! supports [GoAT](https://github.com/bep/goat) natively. This means that this code block:
+Hugo supports [GoAT](https://github.com/bep/goat) natively. This means that this code block:
 
 ````txt
 ```goat


### PR DESCRIPTION
It looks like `!` after `Hugo` was added accidentally.