### PR TITLE
Replaced sudo in OpenBSD with doas

### DIFF
--- a/content/en/installation/bsd.md
+++ b/content/en/installation/bsd.md
@@ -57,7 +57,7 @@ sudo pkgin install go-hugo
 [OpenBSD] includes Hugo in its package repository. This will prompt you to select which flavor of Hugo to install:
 
 ```sh
-sudo pkg_add hugo
+doas pkg_add hugo
 ```
 
 [OpenBSD]: https://www.openbsd.org/


### PR DESCRIPTION
OpenBSD doesn't ship with sudo. It ships with the sudo alternative doas.