### PR TITLE
Fixing typos

### DIFF
--- a/content/en/functions/findRe.md
+++ b/content/en/functions/findRe.md
@@ -12,7 +12,7 @@ signature:
 relatedfuncs: [replaceRE]
 aliases: []
 ---
-By default, the `findRE` function finds all matches. You can limit the number of matches with an optional LIMIT paramater.
+By default, the `findRE` function finds all matches. You can limit the number of matches with an optional LIMIT parameter.
 
 When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
 

--- a/content/en/functions/replace.md
+++ b/content/en/functions/replace.md
@@ -12,7 +12,7 @@ keywords: []
 signature: ["strings.Replace INPUT OLD NEW [LIMIT]", "replace INPUT OLD NEW [LIMIT]"]
 workson: []
 hugoversion:
-relatedfuncs: []
+relatedfuncs: [replaceRE]
 deprecated: false
 aliases: []
 ---

--- a/content/en/functions/replacere.md
+++ b/content/en/functions/replacere.md
@@ -9,10 +9,10 @@ keywords: [regex]
 signature:
   - "replaceRE PATTERN REPLACEMENT INPUT [LIMIT]"
   - "strings.ReplaceRE PATTERN REPLACEMENT INPUT [LIMIT]"
-relatedfuncs: [findRE]
+relatedfuncs: [replace,findRE]
 aliases: []
 ---
-By default, the `replaceRE` function replaces all matches. You can limit the number of matches with an optional LIMIT paramater.
+By default, the `replaceRE` function replaces all matches. You can limit the number of matches with an optional LIMIT parameter.
 
 When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
 


### PR DESCRIPTION
This PR fixes two typos found in the documentation. It also addes related functions for functions `replace` and `replaceRE`.