### PR TITLE
Document strings.FirstUpper

### DIFF
--- a/archetypes/functions.md
+++ b/archetypes/functions.md
@@ -1,16 +1,12 @@
 ---
 linktitle: ""
 description: ""
-publishdate: ""
-lastmod: ""
 categories: [functions]
 tags: []
 ns: ""
 signature: []
-workson: []
 hugoversion: ""
 aliases: []
 relatedfuncs: []
 toc: false
-deprecated: false
 ---

--- a/content/en/functions/replace.md
+++ b/content/en/functions/replace.md
@@ -8,7 +8,7 @@ categories: [functions]
 menu:
   docs:
     parent: "functions"
-keywords: []
+keywords: [replace]
 signature: ["strings.Replace INPUT OLD NEW [LIMIT]", "replace INPUT OLD NEW [LIMIT]"]
 workson: []
 hugoversion:

--- a/content/en/functions/replacere.md
+++ b/content/en/functions/replacere.md
@@ -5,7 +5,7 @@ categories: [functions]
 menu:
   docs:
     parent: functions
-keywords: [regex]
+keywords: [replace regex]
 signature:
   - "replaceRE PATTERN REPLACEMENT INPUT [LIMIT]"
   - "strings.ReplaceRE PATTERN REPLACEMENT INPUT [LIMIT]"

--- a/content/en/functions/strings.FirstUpper.md
+++ b/content/en/functions/strings.FirstUpper.md
@@ -1,0 +1,14 @@
+---
+title: strings.FirstUpper
+description: Capitalizes the first character of a given string.
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+keywords: [strings capitalize uppercase first]
+signature: ["strings.FirstUpper STRING"]
+hugoversion:
+aliases: []
+---
+
+    {{ strings.FirstUpper "foo" }} → "Foo"


### PR DESCRIPTION
This PR addresses #739 by adding a new documentation page for function `strings.FirstUpper`. It also fixes 2 typos I spotted.
One quirk I came across while previewing the new page locally:
In the frontmatter of the newly created page, `relatedfuncs` is empty. However, at be bottom of the page, there is a section `See Also`, containing entries for `anchorize`, `strings.Repeat`, `errorf and warnf`, `float`, and `emojify`. This is weird.

_Additional note_: to me it seems like the section `See Also` for existing functions `string.xxx` is often filled with somehow unrelated entries.
