### PR TITLE
Quick start guide: fix broken links

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -171,7 +171,7 @@ Most theme authors provide configuration guidelines and options. Make sure to vi
 
 [demonstration site]: https://gohugo-ananke-theme-demo.netlify.app/
 [documentation]: https://github.com/theNewDynamic/gohugo-theme-ananke#readme
-[The New Dynamic]: [https://www.thenewdynamic.com/]
+[The New Dynamic]: https://www.thenewdynamic.com/
 {{% /note %}}
 
 ## Publish the site
@@ -199,7 +199,7 @@ For other resources to help you learn Hugo, including books and video tutorials,
 [Ananke]: https://github.com/theNewDynamic/gohugo-theme-ananke
 [directory structure]: /getting-started/directory-structure
 [draft, future, and expired content]: /getting-started/usage/#draft-future-and-expired-content
-[draft, future, or expired content]: /getting-started/usage/#draft-future-end-expired-content
+[draft, future, or expired content]: /getting-started/usage/#draft-future-and-expired-content
 [external learning resources]:/getting-started/external-learning-resources/
 [forum]: https://discourse.gohugo.io/
 [forum]: https://discourse.gohugo.io/


### PR DESCRIPTION
This PR fixes 2 broken links in the quick start guide.

**Additional remark**:

The quick guide uses this command to define the theme in the site configuration:

```
echo "theme = 'ananke'" >> config.toml
```

While this command works fine on unix-based systems, it does not work well on the windows command line (it adds this line to `config.toml`):

```
"theme = 'ananke'"
```

I don't have a good solution for this other than providing a tabbed pane with one tab for unix and one for windows systems. Not sure whether the theme provides the ability to author tabbed panes, though.