### PR TITLE
prevent Hugo Showcase template from showing on site

### DIFF
--- a/content/en/showcase/template/index.md
+++ b/content/en/showcase/template/index.md
@@ -1,11 +1,12 @@
 ---
 title: Hugo Showcase Template
-date: 2018-02-07
 description: "A short description of this page."
 siteURL: https://gohugo.io/
 siteSource: https://github.com/gohugoio/hugoDocs
 byline: "[bep](https://github.com/bep), Hugo Lead"
+draft: true
 ---
+
 Have a **notable Hugo site[^1]**? We would love to feature it in this **Showcase Section**
 
 Please:


### PR DESCRIPTION
Marking this as a `draft:` prevents it from displaying on the sidebar in the https://gohugo.io/showcase/ section