### PR TITLE
docs: fix typo in taxonomy variables

### DIFF
--- a/content/en/variables/taxonomy.md
+++ b/content/en/variables/taxonomy.md
@@ -33,7 +33,7 @@ For example, the following fields would be available in `layouts/_defaults/terms
 .Data.Pages
 : The list of pages in the taxonomy
 
-.Data.Terms
+.Data.Term
 : The taxonomy itself
 
 .Data.Terms.Alphabetical


### PR DESCRIPTION
The actual variable seems to be `.Data.Term` instead of `.Data.Terms`