### PR TITLE
Added missing `/` in URL generator

### DIFF
--- a/content/en/templates/single-page-templates.md
+++ b/content/en/templates/single-page-templates.md
@@ -49,14 +49,14 @@ This single page template makes use of Hugo [base templates], the [`.Format` fun
     {{ with .Params.topics }}
     <ul id="topics">
       {{ range . }}
-        <li><a href="{{ "topics" | absURL}}{{ . | urlize }}">{{ . }}</a> </li>
+        <li><a href="{{ "topics" | absURL}}/{{ . | urlize }}">{{ . }}</a> </li>
       {{ end }}
     </ul>
     {{ end }}
     {{ with .Params.tags }}
     <ul id="tags">
       {{ range . }}
-        <li> <a href="{{ "tags" | absURL }}{{ . | urlize }}">{{ . }}</a> </li>
+        <li> <a href="{{ "tags" | absURL }}/{{ . | urlize }}">{{ . }}</a> </li>
       {{ end }}
     </ul>
     {{ end }}

--- a/content/en/templates/single-page-templates.md
+++ b/content/en/templates/single-page-templates.md
@@ -6,7 +6,7 @@ date: 2017-02-01
 publishdate: 2017-02-01
 lastmod: 2017-04-06
 categories: [templates]
-keywords: [page,templates]
+keywords: [page, templates]
 menu:
   docs:
     parent: "templates"
@@ -32,6 +32,7 @@ This single page template makes use of Hugo [base templates], the [`.Format` fun
 
 {{< code file="layouts/posts/single.html" download="single.html" >}}
 {{ define "main" }}
+
 <section id="main">
   <h1 id="title">{{ .Title }}</h1>
   <div>
@@ -46,20 +47,20 @@ This single page template makes use of Hugo [base templates], the [`.Format` fun
       <h4 id="date"> {{ .Date.Format "Mon Jan 2, 2006" }} </h4>
       <h5 id="wordcount"> {{ .WordCount }} Words </h5>
     </section>
-    {{ with .Params.topics }}
-    <ul id="topics">
-      {{ range . }}
-        <li><a href="{{ "topics" | absURL}}/{{ . | urlize }}">{{ . }}</a> </li>
+      {{ with .GetTerms "topics" }}
+        <ul id="topics">
+          {{ range . }}
+            <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
+          {{ end }}
+        </ul>
       {{ end }}
-    </ul>
-    {{ end }}
-    {{ with .Params.tags }}
-    <ul id="tags">
-      {{ range . }}
-        <li> <a href="{{ "tags" | absURL }}/{{ . | urlize }}">{{ . }}</a> </li>
+      {{ with .GetTerms "tags" }}
+        <ul id="tags">
+          {{ range . }}
+            <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
+          {{ end }}
+        </ul>
       {{ end }}
-    </ul>
-    {{ end }}
     </div>
     <div>
         {{ with .PrevInSection }}
@@ -81,7 +82,7 @@ To easily generate new instances of a content type (e.g., new `.md` files in a s
 [content type]: /content-management/types/
 [directory structure]: /getting-started/directory-structure/
 [dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
-[`.Format` function]: /functions/format/
+[`.format` function]: /functions/format/
 [front matter]: /content-management/front-matter/
 [pagetaxonomy]: /templates/taxonomy-templates/#display-a-single-piece-of-contents-taxonomies
 [pagevars]: /variables/page/


### PR DESCRIPTION
In the example to render tags and topics, we use:
```html
<a href="{{ "tags" | absURL }}{{ . | urlize }}">
```
But this will produce links like `www.example.com/tagsTerm`  where `Term` is a tag. So added the missing `/`.

Hope I didn't mistake :sweat_smile: 