### PR TITLE
Added space after pipe so titles look more uniform in tabs.

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/_default/baseof.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/_default/baseof.html
@@ -33,7 +33,7 @@
     {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
     <title>
       {{ block "title" . }}
-        {{ with .Title }}{{ . }} |{{ end }}{{ .Site.Title }}
+        {{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}
       {{ end }}
 
     </title>


### PR DESCRIPTION
I know it's such a miniscule thing but it was bugging me and I figured I'd do something about it. If this isn't the right place to make the change, please let me know!

![doc-before](https://user-images.githubusercontent.com/27108677/211168762-d08a79df-10cb-4a79-861b-a1cb6cece55c.png)
![doc-after](https://user-images.githubusercontent.com/27108677/211168771-01688750-f408-4bb1-8186-ecfb99afee9a.png)
