### PR TITLE
Fix example to convert image with same dimensions

### DIFF
--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -278,7 +278,7 @@ To convert an image without scaling, use the dimensions of the original image:
 
 ```go-html-template
 {{ with .Resources.GetMatch "sunset.jpg" }}
-  {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
+  {{ with .Resize (printf "%dx%d webp" .Height .Width) }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}">
   {{ end }}
 {{ end }}


### PR DESCRIPTION
The example shows how to convert image format without changing the image dimensions. This is similar to the example above about rotating an image without resizing.

However, the height/width were swapped. Height should come first (as it does in the rotation example)