### PR TITLE
Fix `hardWraps` config spelling

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -32,7 +32,7 @@ For details on the extensions, refer to [this section](https://github.com/yuin/g
 
 Some settings explained:
 
-hardWrap
+hardWraps
 : By default, Goldmark ignores newlines within a paragraph. Set to `true` to render newlines as `<br>` elements.
 
 unsafe


### PR DESCRIPTION
The default config snippet right above the explanation contains the correct key (`hardWraps`), while the explanation says `hardWrap`, which is incorrect.