### PR TITLE
Fixing typo in configuration.md doc

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -125,7 +125,6 @@ Note that you don't need to be so verbose as in the default setup below; a `_mer
 
 The following is the full list of Hugo-defined variables. Users may choose to override those values in their site
 config file(s).
-value in double quotes. Users may choose to override those values in their site
 config file(s).
 
 ### archetypeDir

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -123,7 +123,8 @@ Note that you don't need to be so verbose as in the default setup below; a `_mer
 
 ## All Configuration Settings
 
-The following is the full list of Hugo-defined variables with their default
+The following is the full list of Hugo-defined variables. Users may choose to override those values in their site
+config file(s).
 value in double quotes. Users may choose to override those values in their site
 config file(s).
 

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -124,7 +124,7 @@ Note that you don't need to be so verbose as in the default setup below; a `_mer
 ## All Configuration Settings
 
 The following is the full list of Hugo-defined variables with their default
-value in parentheses. Users may choose to override those values in their site
+value in double quotes. Users may choose to override those values in their site
 config file(s).
 
 ### archetypeDir

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -125,7 +125,6 @@ Note that you don't need to be so verbose as in the default setup below; a `_mer
 
 The following is the full list of Hugo-defined variables. Users may choose to override those values in their site
 config file(s).
-config file(s).
 
 ### archetypeDir
 


### PR DESCRIPTION
Addresses issue here: https://github.com/gohugoio/hugo/issues/10705

Changes wording in Getting Started docs