### PR TITLE
Docs: markdownify - mention a context limitation

### DIFF
--- a/content/en/functions/markdownify.md
+++ b/content/en/functions/markdownify.md
@@ -4,7 +4,7 @@ linktitle: markdownify
 description: Runs the provided string through the Markdown processor.
 date: 2017-02-01
 publishdate: 2017-02-01
-lastmod: 2017-02-01
+lastmod: 2023-02-09
 keywords: [markdown,content]
 categories: [functions]
 menu:
@@ -23,6 +23,7 @@ aliases: []
 {{ .Title | markdownify }}
 ```
 
-{{< new-in "0.93.0" >}} **Note**: `markdownify` now supports [Render Hooks] just like [.RenderString](/functions/renderstring/).
+{{< new-in "0.93.0" >}} **Note**: `markdownify` now supports [Render Hooks] just like [`.Page.RenderString`]. However, if you use more complicated [Render Hooks] relying on page context, use [`.Page.RenderString`] instead. See [GitHub issue #9692](https://github.com/gohugoio/hugo/issues/9692) for more details.
 
 [Render Hooks]: /templates/render-hooks/
+[`.Page.RenderString`]: /functions/renderstring/


### PR DESCRIPTION
Repost of a PR from main repo: https://github.com/gohugoio/hugo/pull/10679#issuecomment-1424266597

---

Ran into an issue described in https://github.com/gohugoio/hugo/issues/9692 and spent quite some time debugging my render hooks.

It should be mentioned in the docs as well until it's resolved.