### PR TITLE
Modify inner variable shortcode-template explanation

### DIFF
--- a/content/en/templates/shortcode-templates.md
+++ b/content/en/templates/shortcode-templates.md
@@ -102,7 +102,7 @@ most helpful when the condition depends on either of the values, or both:
 
 If a closing shortcode is used, the `.Inner` variable will be populated with the content between the opening and closing shortcodes. If a closing shortcode is required, you can check the length of `.Inner` as an indicator of its existence.
 
-A shortcode with content declared via the `.Inner` variable can also be declared without the content and without the closing by using the self-closing syntax:
+A shortcode with content declared via the `.Inner` variable can also be declared without the content and without the closing tag by using the self-closing syntax:
 
 ```go-html-template
 {{</* innershortcode /*/>}}


### PR DESCRIPTION
Added "without the closing TAG by using the self-closing syntax" so that it is more comprehensible. Based on videos and blogs regarding the topic to make sure it makes sense.