### PR TITLE
add headings to distinguish render hook context params

### DIFF
--- a/content/en/templates/render-hooks.md
+++ b/content/en/templates/render-hooks.md
@@ -49,6 +49,8 @@ Some use cases for the above:
 
 ## Render Hooks for Headings, Links and Images
 
+### Context passed to `render-link` and `render-image`
+
 The `render-link` and `render-image` templates will receive this context:
 
 Page
@@ -65,6 +67,8 @@ Text
 
 PlainText
 : The plain variant of the above.
+
+### Context passed to `render-heading`
 
 The `render-heading` template will receive this context:
 


### PR DESCRIPTION
Looking at the docs for [render hooks](https://gohugo.io/templates/render-hooks/#render-hooks-for-headings-links-and-images), it's not immediately apparent which params apply to which hooks. At first glance, it appears as though there are duplicates, but that's only because the descriptions visually blend into the descriptions for each param.

I'm proposing headings to improve the distinction between the two sets of params.