### PR TITLE
Document markdownify quirk

### DIFF
--- a/content/en/functions/markdownify.md
+++ b/content/en/functions/markdownify.md
@@ -23,6 +23,8 @@ aliases: []
 {{ .Title | markdownify }}
 ```
 
+**Note**: If the content being processed is a single line of text, `markdownify` will not add any HTML tags. Multiple lines of text seperated by new lines will be wrapped in `<p>` tags.
+
 {{< new-in "0.93.0" >}} **Note**: `markdownify` now supports [Render Hooks] just like [`.Page.RenderString`]. However, if you use more complicated [Render Hooks] relying on page context, use [`.Page.RenderString`] instead. See [GitHub issue #9692](https://github.com/gohugoio/hugo/issues/9692) for more details.
 
 [Render Hooks]: /templates/render-hooks/


### PR DESCRIPTION
Same as https://github.com/gohugoio/hugo/pull/10799

I would like to have the note from #6398 added to the documentation.

The weird conditional way that `mardownify` behaves will spiral the user into the following journey:

1) Figure out what's going on (i.e. that some contents get wrapped in `<p>`, others don't)
2) Go and look for a way to make `markdownify` behave consistently
3) Come up empty-handed
4) Figure out if it's a bug
5) Understand the history of https://github.com/gohugoio/hugo/issues/3040
6) See that there is a closed attempt to document the behavior
7) Open up this PR :smile: 

Chapter 2:
1) Sign Hugo CLA
2) You can't make documentation PRs on `/docs` in hugo, so go to another repo with identical files
3) Fork and clone hugoDocs
4) Make new PR :tada: 