### PR TITLE
Complete documentation on '.Scratch' and '.Store'

### DIFF
--- a/content/en/variables/page.md
+++ b/content/en/variables/page.md
@@ -20,10 +20,6 @@ toc: true
 
 The following is a list of page-level variables. Many of these will be defined in the front matter, derived from file location, or extracted from the content itself.
 
-{{% note "`.Scratch`" %}}
-See [`.Scratch`](/functions/scratch/) for page-scoped, writable variables.
-{{% /note %}}
-
 ## Page Variables
 
 .AlternativeOutputFormats
@@ -186,6 +182,14 @@ https://remarkjs.com)
 
 .WordCount
 : the number of words in the content.
+
+## Writable Page-scoped Variables
+
+[.Scratch][scratch]
+: returns a Scratch to store and manipulate data. In contrast to the [`.Store`][store] method, this scratch is reset on server rebuilds.
+
+[.Store][store]
+: returns a Scratch to store and manipulate data. In contrast to the [`.Scratch`][scratch] method, this scratch is not reset on server rebuilds.
 
 ## Section Variables and Methods
 
@@ -352,4 +356,5 @@ The top-level key will be preferred. Therefore, the following method, when appli
 [gitinfo]: /variables/git/
 [File Variables]: /variables/files/
 [bundle]: {{< relref "content-management/page-bundles" >}}
-
+[scratch]: /functions/scratch
+[store]: /functions/store

--- a/content/en/variables/shortcodes.md
+++ b/content/en/variables/shortcodes.md
@@ -39,9 +39,13 @@ toc: false
 .Inner
 : represents the content between the opening and closing shortcode tags when a [closing shortcode][markdownshortcode] is used
 
-[getfunction]: /functions/get/
-[markdownshortcode]: /content-management/shortcodes/#shortcodes-with-markdown
-[shortcodes]: /templates/shortcode-templates/
+.Scratch
+: returns a writable [`Scratch`][scratch] to store and manipulate data which will be attached to the shortcode context. This scratch is reset on server rebuilds.
 
 .InnerDeindent {{< new-in "0.100.0" >}}
 : Gets the `.Inner` with any indentation removed. This is what's used in the built-in `{{</* highlight */>}}` shortcode.
+
+[getfunction]: /functions/get/
+[markdownshortcode]: /content-management/shortcodes/#shortcodes-with-markdown
+[shortcodes]: /templates/shortcode-templates/
+[scratch]: /functions/scratch


### PR DESCRIPTION
This PR follows up on this [discussion comment](https://discourse.gohugo.io/t/correct-way-to-embed-mermaid-js/43491/6) on hugo discourse. It is also somehow related to #2015. The PR aims at making the documentation on `.Scratch` and `.Store` more complete.