### PR TITLE
Resource methods: add signatures, minor improvements

### DIFF
--- a/content/en/hugo-pipes/babel.md
+++ b/content/en/hugo-pipes/babel.md
@@ -11,7 +11,10 @@ menu:
     weight: 48
 weight: 48
 sections_weight: 48
+signature: ["resources.Babel RESOURCE [OPTIONS]", "babel RESOURCE [OPTIONS]"]
 ---
+
+## Usage
 
 Any JavaScript resource file can be transpiled to another JavaScript version using `resources.Babel` which takes for argument the resource object and an optional dict of options listed below. Babel uses the [babel cli](https://babeljs.io/docs/en/babel-cli).
 

--- a/content/en/hugo-pipes/bundling.md
+++ b/content/en/hugo-pipes/bundling.md
@@ -1,6 +1,7 @@
 ---
-title: Asset bundling
-description: Hugo Pipes can bundle any number of assets together.
+title: Concat
+linkTitle: Concatenating assets
+description: Bundle any number of assets into one resource.
 date: 2018-07-14
 publishdate: 2018-07-14
 lastmod: 2018-07-14
@@ -12,9 +13,12 @@ menu:
     weight: 60
 weight: 60
 sections_weight: 60
+signature: ["resources.Concat TARGET_PATH SLICE_RESOURCES"]
 ---
 
-Asset files of the same MIME type can be bundled into one resource using `resources.Concat` which takes two arguments, a target path and a slice of resource objects.
+## Usage
+
+Asset files of the same MIME type can be bundled into one resource using `resources.Concat` which takes two arguments, the target path for the created resource bundle and a slice of resource objects to be concatenated.
 
 ```go-html-template
 {{ $plugins := resources.Get "js/plugins.js" }}

--- a/content/en/hugo-pipes/fingerprint.md
+++ b/content/en/hugo-pipes/fingerprint.md
@@ -1,6 +1,7 @@
 ---
-title: Fingerprinting and SRI
-description: Hugo Pipes allows Fingerprinting and Subresource Integrity.
+title: Fingerprint
+linkTitle: Fingerprinting and SRI
+description: Process a given resource, adding a hash string of the resource's content.
 date: 2018-07-14
 publishdate: 2018-07-14
 categories: [asset management]
@@ -11,9 +12,12 @@ menu:
     weight: 70
 weight: 70
 sections_weight: 70
+signature: ["resources.Fingerprint RESOURCE [ALGORITHM]", "fingerprint RESOURCE [ALGORITHM]"]
 ---
 
-Fingerprinting and [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) can be applied to any asset file using `resources.Fingerprint` which takes two arguments, the resource object and a [hash algorithm](https://en.wikipedia.org/wiki/Secure_Hash_Algorithms).
+## Usage
+
+Fingerprinting and [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) can be applied to any asset file using `resources.Fingerprint` which takes two arguments, the resource object and an optional [hash algorithm](https://en.wikipedia.org/wiki/Secure_Hash_Algorithms).
 
 The default hash algorithm is `sha256`. Other available algorithms are `sha384` and (as of Hugo `0.55`) `sha512` and `md5`.
 

--- a/content/en/hugo-pipes/js.md
+++ b/content/en/hugo-pipes/js.md
@@ -1,6 +1,7 @@
 ---
-title: JavaScript Building
-description: Hugo Pipes can process JavaScript files with [ESBuild](https://github.com/evanw/esbuild).
+title: js.Build
+linkTitle: JavaScript Building
+description: Process a JavaScript file with [ESBuild](https://github.com/evanw/esbuild).
 date: 2020-07-20
 publishdate: 2020-07-20
 categories: [asset management]
@@ -11,7 +12,10 @@ menu:
     weight: 45
 weight: 45
 sections_weight: 45
+signature: ["js.Build RESOURCE [OPTIONS]"]
 ---
+
+## Usage
 
 Any JavaScript resource file can be transpiled and "tree shaken" using `js.Build` which takes for argument either a string for the filepath or a dict of options listed below.
 

--- a/content/en/hugo-pipes/minification.md
+++ b/content/en/hugo-pipes/minification.md
@@ -1,6 +1,7 @@
 ---
-title: Asset minification
-description: Hugo Pipes allows the minification of any CSS, JS, JSON, HTML, SVG or XML resource.
+title: Minify
+linkTitle: Asset minification
+description: Minifies a given resource.
 date: 2018-07-14
 publishdate: 2018-07-14
 categories: [asset management]
@@ -11,9 +12,12 @@ menu:
     weight: 50
 weight: 50
 sections_weight: 50
+signature: ["resources.Minify RESOURCE", "minify RESOURCE"]
 ---
 
-Any resource of the aforementioned types can be minified using `resources.Minify` which takes for argument the resource object.
+## Usage
+
+Any CSS, JS, JSON, HTML, SVG or XML resource can be minified using `resources.Minify` which takes for argument the resource object.
 
 ```go-html-template
 {{ $css := resources.Get "css/main.css" }}

--- a/content/en/hugo-pipes/postcss.md
+++ b/content/en/hugo-pipes/postcss.md
@@ -1,6 +1,6 @@
 ---
 title: PostCSS
-description: Use PostCSS to transform CSS using any of the available plugins.
+description: Process CSS files with PostCSS, using any of the available plugins.
 categories: [asset management]
 keywords: []
 menu:
@@ -9,6 +9,7 @@ menu:
     weight: 40
 toc: true
 weight: 40
+signature: ["resources.PostCSS RESOURCE [OPTIONS]", "postCSS RESOURCE [OPTIONS]"]
 ---
 
 ## Setup

--- a/content/en/hugo-pipes/postprocess.md
+++ b/content/en/hugo-pipes/postprocess.md
@@ -10,7 +10,10 @@ menu:
     weight: 39
 weight: 39
 sections_weight: 39
+signature: ["resources.PostProcess RESOURCE"]
 ---
+
+## Usage
 
 Marking a resource with `resources.PostProcess` delays any transformations to after the build, typically because one or more of the steps in the transformation chain depends on the result of the build (e.g. files in `public`).
 

--- a/content/en/hugo-pipes/resource-from-string.md
+++ b/content/en/hugo-pipes/resource-from-string.md
@@ -1,7 +1,7 @@
 ---
-title: Creating a resource from a string
+title: FromString
 linkTitle: Resource from String
-description: Hugo Pipes allows the creation of a resource from a string.
+description: Creates a resource from a string.
 date: 2018-07-14
 publishdate: 2018-07-14
 categories: [asset management]
@@ -12,9 +12,12 @@ menu:
     weight: 90
 weight: 90
 sections_weight: 90
+signature: ["resources.FromString TARGET_PATH CONTENT"]
 ---
 
-It is possible to create a resource directly from the template using `resources.FromString` which takes two arguments, the given string and the resource target path.
+## Usage
+
+It is possible to create a resource directly from the template using `resources.FromString` which takes two arguments, the target path for the created resource and the given content string.
 
 The following example creates a resource file containing localized variables for every project's languages.
 

--- a/content/en/hugo-pipes/resource-from-template.md
+++ b/content/en/hugo-pipes/resource-from-template.md
@@ -1,7 +1,7 @@
 ---
-title: Creating a resource from template
+title: ExecuteAsTemplate
 linkTitle: Resource from Template
-description: Hugo Pipes allows the creation of a resource from an asset file using Go Template.
+description: Creates a resource from a template
 date: 2018-07-14
 publishdate: 2018-07-14
 categories: [asset management]
@@ -12,11 +12,14 @@ menu:
     weight: 80
 weight: 80
 sections_weight: 80
+signature: ["resources.ExecuteAsTemplate TARGET_PATH CONTEXT RESOURCE"]
 ---
+
+## Usage
 
 In order to use Hugo Pipes function on an asset file containing Go Template magic the function `resources.ExecuteAsTemplate` must be used.
 
-The function takes three arguments: the resource target path, the template context, and the resource object.
+The function takes three arguments: the target path for the created resource, the template context, and the resource object.
 
 ```go-html-template
 // assets/sass/template.scss

--- a/content/en/hugo-pipes/transform-to-css.md
+++ b/content/en/hugo-pipes/transform-to-css.md
@@ -1,6 +1,7 @@
 ---
-title: Sass / SCSS
-description: Hugo Pipes allows the processing of Sass and SCSS files.
+title: ToCSS
+linkTitle: Transpile Sass to SCSS
+description: Transpile Sass to CSS.
 date: 2018-07-14
 publishdate: 2018-07-14
 categories: [asset management]
@@ -11,7 +12,10 @@ menu:
     weight: 30
 weight: 02
 sections_weight: 02
+signature: ["resources.ToCSS RESOURCE [OPTIONS]", "toCSS RESOURCE [OPTIONS]"]
 ---
+
+## Usage
 
 Any Sass or SCSS file can be transformed into a CSS file using `resources.ToCSS` which takes two arguments, the resource object and a map of options listed below.
 

--- a/content/en/news/0.80.0-relnotes/index.md
+++ b/content/en/news/0.80.0-relnotes/index.md
@@ -6,7 +6,7 @@ description: "This release brings Dart Sass support, a new image overlay functio
 categories: ["Releases"]
 ---
 
-The last Hugo release of the year brings a new [images.Overlay](https://gohugo.io/functions/images/#overlay) filter to overlay an image on top of another, e.g. for watermarking, and [Dart Sass](https://gohugo.io/hugo-pipes/scss-sass/#options) support.
+The last Hugo release of the year brings a new [images.Overlay](https://gohugo.io/functions/images/#overlay) filter to overlay an image on top of another, e.g. for watermarking, and [Dart Sass](https://gohugo.io/hugo-pipes/toCSS/#options) support.
 
 This release represents **29 contributions by 12 contributors** to the main Hugo code base. [@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@moorereason](https://github.com/moorereason), and [@davidsneighbour](https://github.com/davidsneighbour) for their ongoing contributions.
 And a big thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his relentless work on keeping the themes site in pristine condition and to [@davidsneighbour](https://github.com/davidsneighbour), [@coliff](https://github.com/coliff) and [@kaushalmodi](https://github.com/kaushalmodi) for all the great work on the documentation site.

--- a/content/en/news/0.81.0-relnotes/index.md
+++ b/content/en/news/0.81.0-relnotes/index.md
@@ -154,7 +154,7 @@ Hugo now has:
 
 ## Notes
 
-* We have updated to Beta 6 of the Dart Sass Protocol which is not backwards compatible, so if you use Dart Sass you need to also update [that binary](https://gohugo.io/hugo-pipes/scss-sass/#options).
+* We have updated to Beta 6 of the Dart Sass Protocol which is not backwards compatible, so if you use Dart Sass you need to also update [that binary](https://gohugo.io/hugo-pipes/toCSS/#options).
 * `hugo gen autocomplete` now default to `stdout`; you can change this by setting `--completionfile`. As an added bonus we now also support auto completion for zsh, fish and powershell.
 
 ## Changelog


### PR DESCRIPTION
This PR improves the documentation of hugo pipes by adding method signatures for the available `resources.nn` functions. It also comes with minor textual  improvements.