### PR TITLE
Add example to exclude files using module config

### DIFF
--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -163,3 +163,12 @@ The search is case-insensitive.
 
 excludeFiles (string or slice)
 : One or more glob patterns matching files to exclude.
+
+**Example**
+{{< code-toggle file="config">}}
+[module]
+[[module.mounts]]
+    source="content"
+    target="content"
+    excludeFiles="docs/*"
+{{< /code-toggle >}}


### PR DESCRIPTION
It isn't clear from the docs currently how to use this feature even though it is now the [preferred way to exclude files](https://gohugo.io/getting-started/configuration/)