### PR TITLE
docs: Remove note about hugo server not using custom 404 page

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -52,10 +52,4 @@ Your 404.html file can be set to load automatically when a visitor enters a mist
 * DigitalOcean App Platform. You can specify `error_document` in your app specification file or use control panel to set up error document. [Details here](https://docs.digitalocean.com/products/app-platform/how-to/manage-static-sites/#configure-a-static-site).
 * [Firebase Hosting](https://firebase.google.com/docs/hosting/full-config#404): `/404.html` automatically gets used as the 404 page.
 
-{{% note %}}
-`hugo server` will not automatically load your custom `404.html` file, but you
-can test the appearance of your custom "not found" page by navigating your
-browser to `/404.html`.
-{{% /note %}}
-
 [pagevars]: /variables/page/


### PR DESCRIPTION
The server uses custom 404 pages as of gohugoio/hugo#10267.