### PR TITLE
Align permalinks examples

### DIFF
--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -111,7 +111,8 @@ content/
 Create a date-based hierarchy, recursively, for regular pages within the `posts` section:
 
 {{< code-toggle file="config" copy=false >}}
-posts = '/posts/:year/:month/:title/'
+[permalinks]
+  posts = '/posts/:year/:month/:title/'
 {{< /code-toggle >}}
 
 The structure of the published site will be:
@@ -133,7 +134,8 @@ public/
 To create a date-based hierarchy for regular pages in the content root:
 
 {{< code-toggle file="config" copy=false >}}
-'/' = '/:year/:month/:title/'
+[permalinks]
+  '/' = '/:year/:month/:title/'
 {{< /code-toggle >}}
 
 {{% note %}}
@@ -143,7 +145,8 @@ A URL pattern defined for the content root is not recursive.
 Use the same approach with taxonomies. For example, to omit the taxonomy segment of the URL:
 
 {{< code-toggle file="config" copy=false >}}
-'tags' = '/:title/'
+[permalinks]
+  'tags' = '/:title/'
 {{< /code-toggle >}}
 
 Front matter `url` values take precedence over URL patterns defined in `permalinks`.


### PR DESCRIPTION
This PR aligns examples in [`/content-management/urls/#site-configuration`](https://gohugo.io/content-management/urls/#site-configuration) in such a way that they all contain the `permalinks` config key like the one for the example for `posts` under [`#tokens`](https://gohugo.io/content-management/urls/#tokens) does.

For context: I opted to add the config key for the other three because that one made it clear to me, that the `permalinks` key is the one to put these under (in order to use this feature).

Aligning the examples in such a way might make them eligible to remove the `copy=false` flag, what do you think?

I'm also open to change this PR so that the example for `posts` does not have the `permalinks` key in it.