### PR TITLE
add example to note in module mounts

### DIFF
--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -116,16 +116,7 @@ When the `mounts` config was introduced in Hugo 0.56.0, we were careful to prese
 {{% /note %}}
 
 {{% note %}}
-When you add a mount, the default mount for the concerned target root is ignored: be sure to explicitly add it. E.g.
-
-```yaml
-module:
-  mounts:
-    - source: node_modules
-      target: assets
-    - source: assets
-      target: assets
-```
+When you add a mount, the default mount for the concerned target root is ignored: be sure to explicitly add it.
 {{% /note %}}
 
 **Default mounts**
@@ -180,4 +171,10 @@ excludeFiles (string or slice)
     source="content"
     target="content"
     excludeFiles="docs/*"
+[[module.mounts]]
+    source="node_modules"
+    target="assets"
+[[module.mounts]]
+    source="assets"
+    target="assets"
 {{< /code-toggle >}}

--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -121,9 +121,9 @@ When you add a mount, the default mount for the concerned target root is ignored
 ```yaml
 module:
   mounts:
-    - source: assets
-      target: assets
     - source: node_modules
+      target: assets
+    - source: assets
       target: assets
 ```
 {{% /note %}}

--- a/content/en/hugo-modules/configuration.md
+++ b/content/en/hugo-modules/configuration.md
@@ -116,7 +116,16 @@ When the `mounts` config was introduced in Hugo 0.56.0, we were careful to prese
 {{% /note %}}
 
 {{% note %}}
-When you add a mount, the default mount for the concerned target root is ignored: be sure to explicitly add it.
+When you add a mount, the default mount for the concerned target root is ignored: be sure to explicitly add it. E.g.
+
+```yaml
+module:
+  mounts:
+    - source: assets
+      target: assets
+    - source: node_modules
+      target: assets
+```
 {{% /note %}}
 
 **Default mounts**


### PR DESCRIPTION
While reading the documentation for [adding mounts](https://gohugo.io/hugo-modules/configuration/#module-config-mounts), it was not immediately obvious that multiple directories could be mounted to the same component, and therefore the note wasn't clear on why one would have to care if the default got ignored (since it seemed that the configuration was confined to overwriting defaults and not extending them).

@jmooring cleared up my confusion [here](https://discourse.gohugo.io/t/mount-multiple-directories-as-hugo-assets/44267), and this PR proposes adding his example to the note.

NOTE: typically the documentation uses the `{{< code-toggle file="config">}}` shortcode, but I wasn't sure if that would properly nest inside of the `{{% note %}}` shortcode. Happy to revise if necessary.