### PR TITLE
Correct spelling for 'GitHub' and 'GitLab'

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-azure.md
+++ b/content/en/hosting-and-deployment/hosting-on-azure.md
@@ -1,6 +1,6 @@
 ---
 title: Host on Azure Static Web Apps
-description: Deploy Hugo to Azure Static Web Apps and automate the whole process with Github Action Workflow
+description: Deploy Hugo to Azure Static Web Apps and automate the whole process with GitHub Action Workflow
 categories: [hosting and deployment]
 keywords: [azure,git,deployment,hosting]
 menu:

--- a/content/en/hosting-and-deployment/hosting-on-firebase.md
+++ b/content/en/hosting-and-deployment/hosting-on-firebase.md
@@ -45,7 +45,7 @@ From here:
 4. Accept the default for the publish directory, which is `public`
 5. Choose "No" in the question if you are deploying a single-page app
 
-## Using Firebase & Github CI/CD
+## Using Firebase & GitHub CI/CD
 
 In new versions of Firebase, some other questions apply:
 
@@ -56,7 +56,7 @@ Here you will be redirected to login in your GitHub account to get permissions. 
 7. For which GitHub repository would you like to set up a GitHub workflow? (format: user/repository) 
 
 Include the repository you will use in the format above (Account/Repo)
-Firebase script with retrive credentials, create a service account you can later manage in your github settings.
+Firebase script with retrive credentials, create a service account you can later manage in your GitHub settings.
 
 8. Set up the workflow to run a build script before every deploy? 
 
@@ -72,7 +72,7 @@ After that Firebase has been set in your project with CI/CD. After that run:
 hugo && firebase deploy
 ```
 
-With this you will have the app initialized manually. After that you can manage and fix your github workflow from: https://github.com/your-account/your-repo/actions
+With this you will have the app initialized manually. After that you can manage and fix your GitHub workflow from: https://github.com/your-account/your-repo/actions
 
 Don't forget to update your static pages before push!
 

--- a/content/en/hosting-and-deployment/hosting-on-keycdn.md
+++ b/content/en/hosting-and-deployment/hosting-on-keycdn.md
@@ -82,7 +82,7 @@ git remote add origin git@gitlab.com:youruser/ci-example.git
 git push -u origin master
 ```
 
-You can watch the progress and CI job output in your Gitlab project under “Pipelines”.
+You can watch the progress and CI job output in your GitLab project under “Pipelines”.
 
 After verifying your CI job ran without issues, first check that your GitLab page shows up under `https://youruser.gitlab.io/reponame/` (it might look broken depending on your browser settings as all links point to your KeyCDN zone – don’t worry about that) and then by heading to whatever Zone alias / Zone URL you defined.
 

--- a/content/en/hosting-and-deployment/hosting-on-render.md
+++ b/content/en/hosting-and-deployment/hosting-on-render.md
@@ -38,7 +38,7 @@ Static sites are **completely free** on Render and include the following:
 
 You can set up a Hugo site on Render in two quick steps:
 
-1. Create a new **Static Site** on Render, and give Render permission to access your GitHub/Gitlab repo.
+1. Create a new **Static Site** on Render, and give Render permission to access your GitHub/GitLab repo.
 2. Use the following values during creation:
 
   Field                | Value
@@ -50,7 +50,7 @@ That's it! Your site will be live on your Render URL (which looks like `yoursite
 
 ## Continuous Deploys
 
-Now that Render is connected to your repo, it will **automatically build and publish your site** any time you push to your GitHub/Gitlab.
+Now that Render is connected to your repo, it will **automatically build and publish your site** any time you push to your GitHub/GitLab.
 
 You can choose to disable auto deploys under the **Settings** section for your site and deploy it manually from the Render dashboard.
 


### PR DESCRIPTION
Change to use only `GitHub` and `GitLab`.