### PR TITLE
Add Hugo Module examples and remove 'brand new' text

### DIFF
--- a/content/en/hugo-modules/_index.md
+++ b/content/en/hugo-modules/_index.md
@@ -22,7 +22,9 @@ Hugo Modules are powered by Go Modules. For more information about Go Modules, s
 - [https://github.com/golang/go/wiki/Modules](https://github.com/golang/go/wiki/Modules)
 - [https://go.dev/blog/using-go-modules](https://go.dev/blog/using-go-modules)
 
-This is all very much brand new and there are only a few example projects around:
+Hugo Modules were introduced in [Hugo v0.56.0](https://github.com/gohugoio/hugo/releases/tag/v0.56.0). Here are some example projects that use Hugo Modules:
 
 - [https://github.com/bep/docuapi](https://github.com/bep/docuapi) is a theme that has been ported to Hugo Modules while testing this feature. It is a good example of a non-Hugo-project mounted into Hugo’s folder structure. It even shows a JS Bundler implementation in regular Go templates.
 - [https://github.com/bep/my-modular-site](https://github.com/bep/my-modular-site) is a very simple site used for testing.
+- [https://github.com/google/docsy-example](https://github.com/google/docsy-example) is a Hugo theme module for technical documentation sites.
+- [https://github.com/rootwork/hugo-module-site](https://github.com/rootwork/hugo-module-site) is an example of how to load both themes and content as Hugo Modules.


### PR DESCRIPTION
The latest version of Hugo is 0.111.3, so it feels that Hugo Modules are no longer "all very much brand new" since they were introduced in 0.56.0.

As well as removing that text, this PR also adds 2 more example projects which users who are new to Hugo Modules might find useful.