### PR TITLE
Front matter docu: improve link to TOML spec

### DIFF
--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -233,7 +233,7 @@ It's possible to set some options for Markdown rendering in a content's front ma
 [pagevars]: /variables/page/
 [section]: /content-management/sections/
 [taxweight]: /content-management/taxonomies/
-[toml]: https://github.com/toml-lang/toml "Specification for TOML, Tom's Obvious Minimal Language"
+[toml]: https://toml.io/
 [urls]: /content-management/urls/
 [variables]: /variables/
 [yaml]: https://yaml.org/spec/ "Specification for YAML, YAML Ain't Markup Language"


### PR DESCRIPTION
This PR improves a link to the TOML specification.