### PR TITLE
Update template-debugging.md to include a pretty printed JSON representation of the current context

### DIFF
--- a/content/en/templates/template-debugging.md
+++ b/content/en/templates/template-debugging.md
@@ -50,6 +50,8 @@ In some cases it might be more helpful to use the following snippet on the curre
 <pre>{{ . | jsonify (dict "indent" " ") }}</pre>
 ```
 
+Note that Hugo will throw an error if you attempt to use this construct to display context that includes a page collection (e.g., the context passed to home, section, taxonomy, and term templates).
+
 ## Why Am I Showing No Defined Variables?
 
 Check that you are passing variables in the `partial` function:

--- a/content/en/templates/template-debugging.md
+++ b/content/en/templates/template-debugging.md
@@ -44,6 +44,12 @@ When developing a [homepage], what does one of the pages you're looping through 
 {{ end }}
 ```
 
+In some cases it might be more helpful to use the following snippet on the current context to get a pretty printed view of what you're able to work with:
+
+```go-html-template
+<pre>{{ . | jsonify (dict "indent" " ") }}</pre>
+```
+
 ## Why Am I Showing No Defined Variables?
 
 Check that you are passing variables in the `partial` function:


### PR DESCRIPTION
Add tip to use jsonify on the current context. This is IMHO much more practical than the often garbage producing and or vars omitting printf ways described here.