### PR TITLE
Correct the sample code of mermaid

### DIFF
--- a/content/en/content-management/diagrams.md
+++ b/content/en/content-management/diagrams.md
@@ -47,9 +47,9 @@ Will be rendered as:
 Hugo currently does not provide default templates for Mermaid diagrams. But you can easily add your own. One way to do it would be to create `layouts/_default/_markup/render-codeblock-mermaid.html`:
 
 ```go-html-template
-<div class="mermaid">
+<pre class="mermaid">
   {{- .Inner | safeHTML }}
-</div>
+</pre>
 {{ .Page.Store.Set "hasMermaid" true }}
 ```
 


### PR DESCRIPTION
Hi,

I came across [the document on mermaid](https://gohugo.io/content-management/diagrams/#mermaid-diagrams) in the content-management/diagrams category which appears to be outdated. 

https://github.com/gohugoio/hugoDocs/blob/a4818d99b2e3557fec5392ee44ef47f62bba690f/content/en/content-management/diagrams.md?plain=1#L45-L54


There was a recent [commit](https://github.com/gohugoio/hugoDocs/commit/eddd25ff4633d0b76e9f155e70de065d754aac4f) where we changed the HTML tag from `div` to `pre` in order to improve semantics. 


Using `pre` instead of `div` is a better choice because when we run `hugo --minify`, 
any white space inside the `div` would be removed. 
This would cause a syntax error in the mermaid language and prevent the diagram from being rendered correctly.

