### PR TITLE
Remove the `url` parameter

### DIFF
--- a/content/en/hugo-modules/theme-components.md
+++ b/content/en/hugo-modules/theme-components.md
@@ -2,7 +2,6 @@
 title: Theme Components
 description: Hugo provides advanced theming support with Theme Components.
 categories: [hugo modules]
-url: /templates/introduction/
 keywords: [themes, theme, source, organization, directories]
 menu:
   docs:


### PR DESCRIPTION
Wrong destination for the _theme components_ section.

![image](https://github.com/gohugoio/hugoDocs/assets/17720932/8c9c2cb5-908d-4aa3-b257-7008d60d5e2d)

Please close the PR if it's intentional.