### PR TITLE
Fix typo in figure example in shortcodes.md

### DIFF
--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -128,7 +128,7 @@ attrlink
 #### Example `figure` Input
 
 {{< code file="figure-input-example.md" >}}
-{{</* figure src="elephant.jpg" title=">An elephant at sunset" */>}}
+{{</* figure src="elephant.jpg" title="An elephant at sunset" */>}}
 {{< /code >}}
 
 #### Example `figure` Output


### PR DESCRIPTION
There was an erroneous `>` in the figure title.