### PR TITLE
Update listed titleCaseStyle default value

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -452,7 +452,7 @@ Site title.
 
 ### titleCaseStyle
 
-**Default value:**  "AP"
+**Default value:**  "ap"
 
 See [Configure Title Case](#configure-title-case)
 


### PR DESCRIPTION
As [further down](https://github.com/gohugoio/hugoDocs/blob/master/content/en/getting-started/configuration.md?plain=1#L640) on the same page it's listed as being `ap`.