### PR TITLE
hasSuffix, hasPreFix: Correct capitalization + frontmatter

### DIFF
--- a/content/en/functions/hasPrefix.md
+++ b/content/en/functions/hasPrefix.md
@@ -1,5 +1,6 @@
 ---
-title: hasprefix
+title: hasPrefix
+linkTitle: hasPrefix
 description: Tests whether a string begins with prefix.
 date: 2017-02-01
 publishdate: 2017-02-01

--- a/content/en/functions/hasSuffix.md
+++ b/content/en/functions/hasSuffix.md
@@ -1,5 +1,5 @@
 ---
-title: hassuffix
+title: hasSuffix
 linkTitle: hasSuffix
 description: Tests whether a string ends with suffix.
 date: 2023-03-01
@@ -7,8 +7,8 @@ publishdate: 2023-03-01
 lastmod: 2023-03-01
 categories: [functions]
 menu:
-docs:
-parent: "functions"
+  docs:
+    parent: "functions"
 keywords: [strings]
 signature: ["hasSuffix STRING SUFFIX"]
 workson: []


### PR DESCRIPTION
Documentation on functions ´hasSuffix` and `hasPrefix` has two shortages
- function ´hasSuffix` does not show up in the left sidebar (function list)
- capitalization for both functions is incorrect (title, see also)

This PR corrects both issues.