### PR TITLE
Use shared file to describe regex syntax

### DIFF
--- a/content/en/functions/common/index.md
+++ b/content/en/functions/common/index.md
@@ -1,0 +1,3 @@
++++
+headless = true
++++

--- a/content/en/functions/common/regular-expressions.md
+++ b/content/en/functions/common/regular-expressions.md
@@ -1,0 +1,8 @@
+When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
+
+Go's regular expression package implements the [RE2 syntax]. The RE2 syntax is a subset of that accepted by [PCRE], roughly speaking, and with various [caveats]. Note that the RE2 `\C` escape sequence is not supported.
+
+[caveats]: https://swtch.com/~rsc/regexp/regexp3.html#caveats
+[PCRE]: https://www.pcre.org/
+[RE2 syntax]: https://github.com/google/re2/wiki/Syntax/
+[string literal]: https://go.dev/ref/spec#String_literals

--- a/content/en/functions/findRe.md
+++ b/content/en/functions/findRe.md
@@ -13,21 +13,7 @@ relatedfuncs: [findRESubmatch, replaceRE]
 ---
 By default, `findRE` finds all matches. You can limit the number of matches with an optional LIMIT parameter.
 
-When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
-
-[string literal]: https://go.dev/ref/spec#String_literals
-
-This function uses the [RE2] regular expression library. See the [RE2 syntax documentation] for details. Note that the RE2 `\C` escape sequence is not supported.
-
-[RE2]: https://github.com/google/re2/
-[RE2 syntax documentation]: https://github.com/google/re2/wiki/Syntax/
-
-{{% note %}}
-The RE2 syntax is a subset of that accepted by [PCRE], roughly speaking, and with various [caveats].
-
-[caveats]: https://swtch.com/~rsc/regexp/regexp3.html#caveats
-[PCRE]: https://www.pcre.org/
-{{% /note %}}
+{{% readfile file="/functions/common/regular-expressions.md" %}}
 
 This example returns a slice of all second level headings (`h2` elements) within the rendered `.Content`:
 

--- a/content/en/functions/findresubmatch.md
+++ b/content/en/functions/findresubmatch.md
@@ -14,21 +14,7 @@ relatedfuncs: [findRE, replaceRE]
 
 By default, `findRESubmatch` finds all matches. You can limit the number of matches with an optional LIMIT parameter. A return value of nil indicates no match.
 
-When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
-
-[string literal]: https://go.dev/ref/spec#String_literals
-
-This function uses the [RE2] regular expression library. See the [RE2 syntax documentation] for details. Note that the RE2 `\C` escape sequence is not supported.
-
-[RE2]: https://github.com/google/re2/
-[RE2 syntax documentation]: https://github.com/google/re2/wiki/Syntax/
-
-{{% note %}}
-The RE2 syntax is a subset of that accepted by [PCRE], roughly speaking, and with various [caveats].
-
-[caveats]: https://swtch.com/~rsc/regexp/regexp3.html#caveats
-[PCRE]: https://www.pcre.org/
-{{% /note %}}
+{{% readfile file="/functions/common/regular-expressions.md" %}}
 
 ## Demonstrative examples
 

--- a/content/en/functions/replacere.md
+++ b/content/en/functions/replacere.md
@@ -13,21 +13,7 @@ relatedfuncs: [findRE, FindRESubmatch, replace]
 ---
 By default, `replaceRE` replaces all matches. You can limit the number of matches with an optional LIMIT parameter.
 
-When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
-
-[string literal]: https://go.dev/ref/spec#String_literals
-
-This function uses the [RE2] regular expression library. See the [RE2 syntax documentation] for details. Note that the RE2 `\C` escape sequence is not supported.
-
-[RE2]: https://github.com/google/re2/
-[RE2 syntax documentation]: https://github.com/google/re2/wiki/Syntax/
-
-{{% note %}}
-The RE2 syntax is a subset of that accepted by [PCRE], roughly speaking, and with various [caveats].
-
-[caveats]: https://swtch.com/~rsc/regexp/regexp3.html#caveats
-[PCRE]: https://www.pcre.org/
-{{% /note %}}
+{{% readfile file="/functions/common/regular-expressions.md" %}}
 
 This example replaces two or more consecutive hyphens with a single hyphen:
 

--- a/content/en/functions/where.md
+++ b/content/en/functions/where.md
@@ -109,25 +109,12 @@ You can also put the returned value of the `where` clauses into a variable:
 This example matches pages where the "foo" parameter begins with "ab":
 
 ```go-html-template
-{{ range where site.RegularPages "Params.foo" "like" "^ab" }}
+{{ range where site.RegularPages "Params.foo" "like" `^ab` }}
   <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
 {{ end }}
 ```
 
-When specifying the regular expression, use a raw [string literal] (backticks) instead of an interpreted string literal (double quotes) to simplify the syntax. With an interpreted string literal you must escape backslashes.
-
-[string literal]: https://go.dev/ref/spec#String_literals
-
-Go's regular expression package implements the [RE2 syntax]. Note that the RE2 `\C` escape sequence is not supported.
-
-[RE2 syntax]: https://github.com/google/re2/wiki/Syntax/
-
-{{% note %}}
-The RE2 syntax is a subset of that accepted by [PCRE], roughly speaking, and with various [caveats].
-
-[caveats]: https://swtch.com/~rsc/regexp/regexp3.html#caveats
-[PCRE]: https://www.pcre.org/
-{{% /note %}}
+{{% readfile file="/functions/common/regular-expressions.md" %}}
 
 ## Use `where` with `first`
 


### PR DESCRIPTION
Provides consistent description for:
- strings.ReplaceRE
- strings.FindRE
- strings.FindRESubmatch
- where "like" comparison operator