### PR TITLE
Remove link to gitter from site footer

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,8 +8,6 @@ ghrepo = "https://github.com/gohugoio/hugoDocs/"
 github_repo = "https://github.com/gohugoio/hugo/issues/new"
 ### Edit content repo (set to automatically enter "edit" mode; this is good for "improve this page" links)
 ghdocsrepo = "https://github.com/gohugoio/hugoDocs/tree/master/docs"
-## Gitter URL
-gitter = "https://gitter.im/spf13/hugo"
 ## Discuss Forum URL
 forum = "https://discourse.gohugo.io/"
 ## Google Tag Manager


### PR DESCRIPTION
This option to "Discuss Source Code" is rarely used and not monitored.