### PR TITLE
fix: change heading level

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -808,7 +808,7 @@ dir
 [static-files]: /content-management/static-files/
 
 
-### Configure cacheDir
+## Configure cacheDir
 
 This is the directory where Hugo by default will store its file caches. See [Configure File Caches](#configure-file-caches).
 

--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -808,7 +808,7 @@ dir
 [static-files]: /content-management/static-files/
 
 
-# Configure cacheDir
+### Configure cacheDir
 
 This is the directory where Hugo by default will store its file caches. See [Configure File Caches](#configure-file-caches).
 


### PR DESCRIPTION
I have modified a `h1` heading on `content/en/getting-started/configuration.md`.
I believe this heading can't be `h1`. It can be `h2` or `h3`.