### PR TITLE
ci(Netlify): specify `HUGO_VERSION` environment variable once

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,10 @@
 publish = "public"
 command = "hugo --gc --minify"
 
+[build.environment]
+  HUGO_VERSION = "0.117.0"
+
 [context.production.environment]
-HUGO_VERSION = "0.117.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +13,13 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.117.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
-[context.deploy-preview.environment]
-HUGO_VERSION = "0.117.0"
-
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
-
-[context.branch-deploy.environment]
-HUGO_VERSION = "0.117.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
## What does this PR do?

Fixes redundant environment variable specification across contexts.

## Explanation

The environment variable `HUGO_VERSION` holds the same value for all contexts (including production, deploy-preview, and branch-deploy). Specifying it separately for each context becomes redundant.

Specifying it once under `[build.environment]` should be enough.

## Reference

From https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts :

>any property of a context-aware key, such as [build] or [[plugins]], will be applied to all contexts unless the same property key is present in a more specific context.

## Verification

Consider this PR. `HUGO_VERSION` is not specified for the deploy-preview context in `netlify.toml`. It can be seen from the corresponding Netlify log that Hugo 0.117.0 was used.

1. Output in [L37](https://app.netlify.com/sites/gohugoio/deploys/64ef19606e525900076de477#L37)

        
        Installing Hugo 0.117.0
        
3. Output in [L76](https://app.netlify.com/sites/gohugoio/deploys/64ef19606e525900076de477#L76)
        
        
        hugo v0.117.0-b2f0696cad918fb61420a6aff173eb36662b406e+extended linux/amd64 BuildDate=2023-08-07T12:49:48Z VendorInfo=gohugoio
        