### PR TITLE
remove duplicate go-html-template in chroma lexer

### DIFF
--- a/data/docs.yaml
+++ b/data/docs.yaml
@@ -310,9 +310,6 @@ chroma:
     - go-html-template
     Name: Go HTML Template
   - Aliases:
-    - go-html-template
-    Name: Go HTML Template
-  - Aliases:
     - go-text-template
     Name: Go Text Template
   - Aliases:


### PR DESCRIPTION
this PR to remove duplicate go-html-template in chroma lexer