### PR TITLE
Update quick-start.md, changing 'hugo.toml' to 'config.toml'

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -52,7 +52,7 @@ hugo new site quickstart
 cd quickstart
 git init
 git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke
-echo "theme = 'ananke'" >> hugo.toml
+echo "theme = 'ananke'" >> config.toml
 hugo server
 ```
 

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -153,7 +153,7 @@ Hugo's rendering engine conforms to the CommonMark [specification] for markdown.
 
 ## Configure the site
 
-With your editor, open the [site configuration] file (`hugo.toml`) in the root of your project.
+With your editor, open the [site configuration] file (`config.toml`) in the root of your project.
 
 ```text
 baseURL = 'http://example.org/'


### PR DESCRIPTION
Was encountering an error following the directions to start a Hugo site; the instructions added the theme information to 'hugo.toml' instead of the necessary 'config.toml'. Feel free to double check this, I'm quite new to the project.