### PR TITLE
Fix the broken url in `taxonomies.md`

### DIFF
--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -198,4 +198,4 @@ wikipedia: "https://en.wikipedia.org/wiki/Bruce_Willis"
 [taxonomy list templates]: /templates/taxonomy-templates/#taxonomy-list-templates
 [taxonomy templates]: /templates/taxonomy-templates/
 [terms within the taxonomy]: /templates/taxonomy-templates/#taxonomy-terms-templates
-[configuration]: /getting-started/configuration/
+[site configuration]: /getting-started/configuration/


### PR DESCRIPTION
The link definition of `[site configuration]` was not set up correctly. Fixed it.