### PR TITLE
templates/internal.md: use `ID` key name for `googleAnalytics`

### DIFF
--- a/content/en/templates/internal.md
+++ b/content/en/templates/internal.md
@@ -27,7 +27,7 @@ Provide your tracking ID in your configuration file:
 
 {{< code-toggle file=hugo >}}
 [services.googleAnalytics]
-googleAnalytics = "G-MEASUREMENT_ID"
+ID = "G-MEASUREMENT_ID"
 {{</ code-toggle >}}
 
 ### Use the Google Analytics template


### PR DESCRIPTION
The proper field according to the docs is [`.Site.Config.Services.GoogleAnalytics.ID`](https://gohugo.io/templates/internal/#use-the-google-analytics-template), not <code>.Site.Config.Services.<strong>GoogleAnalytics.GoogleAnalytics</strong></code>. This fixes what is probably a search/replace error introduced via #2296?