### PR TITLE
Clairfy figure shortcode output

### DIFF
--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -130,7 +130,7 @@ attrlink
 ```html
 <figure>
   <img src="elephant.jpg">
-  <figcaption>An elephant at sunset</figcaption>
+  <figcaption><h4>An elephant at sunset</h4></figcaption>
 </figure>
 ```
 


### PR DESCRIPTION
The current example for the `figure` shortcode uses the title parameter and shows the example output without the `h4` tags as it would be currently rendered as. This can lead to the user unknowingly skipping heading levels, unless they check the rendered output themselves.

I've added the `h4` tag in the `figure` output in the documentation so it's clearer what the output looks like.

Alternatively, I could also change the example input to use the caption parameter instead of title, as this will just render the user provided markdown. This has not been included in the commit but wanted to raise it in case it would be more valuable change.