### PR TITLE
Hide the "new in" button after some period of time

### DIFF
--- a/layouts/shortcodes/new-in.html
+++ b/layouts/shortcodes/new-in.html
@@ -1,0 +1,36 @@
+{{- /*
+Renders a "new in" button indicating the version in which a feature was added.
+
+When comparing the current version to the specified version, the "new in"
+button will be hidden if:
+
+- The major version difference exceeds the majorVersionDiffThreshold
+- The minor version difference exceeds the minorVersionDiffThreshold
+
+@param {string} version The semantic version string, with or without a leading v.
+@returns {template.HTML}
+
+@example {{< new-in 0.100.0 }}
+*/}}
+
+{{- /* Set defaults. */}}
+{{- $majorVersionDiffThreshold := 0 }}
+{{- $minorVersionDiffThreshold := 30 }}
+{{- $displayExpirationWarning := true}}
+
+{{- /* Render. */}}
+{{- with $version := .Get 0 | strings.TrimPrefix "v" }}
+  {{- $majorVersionDiff := sub (index (split hugo.Version ".") 0 | int) (index (split $version ".") 0 | int) }}
+  {{- $minorVersionDiff := sub (index (split hugo.Version ".") 1 | int) (index (split $version ".") 1 | int) }}
+  {{- if or (gt $majorVersionDiff $majorVersionDiffThreshold) (gt $minorVersionDiff $minorVersionDiffThreshold) }}
+    {{- if $displayExpirationWarning }}
+      {{- warnf "This call to the %q shortcode should be removed: %s. The button is now hidden because the specified version (%s) is older than the display threshold." $.Name $.Position $version }}
+    {{- end }}
+  {{- else }}
+    <button class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 mr2 px-4 border border-gray-400 rounded shadow">
+      <a href="{{ printf "https://github.com/gohugoio/hugo/releases/tag/v%s" $version }}">New in v{{ $version }}</a>
+    </button>
+  {{- end }}
+{{- else }}
+  {{- errorf "The %q shortcode requires a positional parameter (version). See %s" .Name .Position }}
+{{- end -}}


### PR DESCRIPTION
When comparing the current version to the specified version, the "new in" button will be hidden if:

- The major version difference exceeds the majorVersionDiffThreshold
- The minor version difference exceeds the minorVersionDiffThreshold

Currently the thresholds are 0 and 30, respectively.