### PR TITLE
Fix default value of `pluralizeListTitles`

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -385,7 +385,7 @@ See [Content Management](/content-management/urls/#permalinks).
 
 ###### pluralizeListTitles
 
-(`bool`) Pluralize titles in lists. Default is `false`.
+(`bool`) Pluralize titles in lists. Default is `true`.
 
 ###### publishDir
 


### PR DESCRIPTION
The value is incorrectly listed as `false` in the docs.