### PR TITLE
Change writeStats to buildStats

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -539,7 +539,7 @@ The `build.cachebusters` configuration option was added to support development u
     target = "$1"
 {{< /code-toggle >}}
 
-Some key points in the above are `writeStats = true`, which writes a `hugo_stats.json` file on each build with HTML classes etc. that's used in the rendered output. Changes to this file will trigger a rebuild of the `styles.css` file. You also need to add `hugo_stats.json` to Hugo's server watcher. See [Hugo Starter Tailwind Basic](https://github.com/bep/hugo-starter-tailwind-basic) for a running example.
+When `buildStats` {{< new-in 0.115.1 >}} is enabled, Hugo writes a `hugo_stats.json` file on each build with HTML classes etc. that's used in the rendered output. Changes to this file will trigger a rebuild of the `styles.css` file. You also need to add `hugo_stats.json` to Hugo's server watcher. See [Hugo Starter Tailwind Basic](https://github.com/bep/hugo-starter-tailwind-basic) for a running example.
 
 source
 : A regexp matching file(s) relative to one of the virtual component directories in Hugo, typically `assets/...`.


### PR DESCRIPTION
The example code for cachebusters config showed buildStats, but the
prose below the example still referred to writeStats.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
