### PR TITLE
Fix some typos in the content summaries page

### DIFF
--- a/content/en/content-management/summaries.md
+++ b/content/en/content-management/summaries.md
@@ -73,7 +73,7 @@ Cons
 
 Because there are multiple ways in which a summary can be specified it is useful to understand the order of selection Hugo follows when deciding on the text to be returned by `.Summary`. It is as follows:
 
-1. If there is a `<!--more-->` summary divider present in the article the text up to the divider will be provided as per the manual summary split method
+1. If there is a `<!--more-->` summary divider present in the article, the text up to the divider will be provided as per the manual summary split method
 2. If there is a `summary` variable in the article front matter the value of the variable will be provided as per the front matter summary method
 3. The text at the start of the article will be provided as per the automatic summary split method
 

--- a/content/en/content-management/summaries.md
+++ b/content/en/content-management/summaries.md
@@ -73,7 +73,7 @@ Cons
 
 Because there are multiple ways in which a summary can be specified it is useful to understand the order of selection Hugo follows when deciding on the text to be returned by `.Summary`. It is as follows:
 
-1. If there is a `<!--more-->`> summary divider present in the article the text up to the divider will be provided as per the manual summary split method
+1. If there is a `<!--more-->` summary divider present in the article the text up to the divider will be provided as per the manual summary split method
 2. If there is a `summary` variable in the article front matter the value of the variable will be provided as per the front matter summary method
 3. The text at the start of the article will be provided as per the automatic summary split method
 


### PR DESCRIPTION
Hi there!

While reading through your (really great) documentation, I noticed a small typo on the content management's summaries page. I also took the opportunity to clarify the same sentence, by splitting it into two clauses, to ease the reading flow.

Please don't hesitate to tell me if I should change something (like splitting up the two changes) ^^
