### PR TITLE
Fix inverted examples in Permalink and RelPermalink

### DIFF
--- a/content/en/methods/page/Permalink.md
+++ b/content/en/methods/page/Permalink.md
@@ -21,5 +21,5 @@ Template:
 
 ```go-html-template
 {{ $page := .Site.GetPage "/about" }}
-{{ $page.RelPermalink }} → https://example.org/docs/about/
+{{ $page.Permalink }} → https://example.org/docs/about/
 ```

--- a/content/en/methods/page/RelPermalink.md
+++ b/content/en/methods/page/RelPermalink.md
@@ -21,5 +21,5 @@ Template:
 
 ```go-html-template
 {{ $page := .Site.GetPage "/about" }}
-{{ $page.Permalink }} → /docs/about/
+{{ $page.RelPermalink }} → /docs/about/
 ```


### PR DESCRIPTION
Stumbled upon this small typo in the documentation