### PR TITLE
Fix closing tag in notes docs

### DIFF
--- a/content/en/contribute/documentation.md
+++ b/content/en/contribute/documentation.md
@@ -269,7 +269,7 @@ Use the "note" shortcode with `{{%/* */%}}` delimiters to call attention to impo
 Use the [`math.Mod`] function to control...
 
 [`math.Mod`]: /functions/math/mod/
-{{%/* /code */%}}
+{{%/* /note */%}}
 ```
 
 Rendered:
@@ -278,7 +278,7 @@ Rendered:
 Use the [`math.Mod`] function to control...
 
 [`math.Mod`]: /functions/math/mod/
-{{% /code %}}
+{{% /note %}}
 
 ## New features
 


### PR DESCRIPTION
On https://gohugo.io/contribute/documentation/#note the closing tag does not match the opening tag:

```
{{% note %}}
Use the [`math.Mod`] function to control...

[`math.Mod`]: /functions/math/mod/
{{% /code %}}
```

It looks like a copy/paste error that somehow also didn't break things. This resolves the issue.