### PR TITLE
Fix typo data-templates.md

### DIFF
--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -127,7 +127,7 @@ Achievements:
 You can use the following code to render the `Short Description` in your layout:
 
 ```go-html-template
-<div>Short Description of {{ .Site.Data.User0123.Name }}: <p>{{ index .Site.Data.User0123 "Short Description" | markdownify }}</p></div>
+<div>Short Description of {{ .Site.Data.user0123.Name }}: <p>{{ index .Site.Data.user0123 "Short Description" | markdownify }}</p></div>
 ```
 
 Note the use of the [`markdownify`] function. This will send the description through the Markdown rendering engine.


### PR DESCRIPTION
The file name was called "user0123" in the example but the sample code accidentally utilised a capital "User0123" for the file name.