### PR TITLE
Update all transform.Unmarshal examples

### DIFF
--- a/content/en/functions/data/GetCSV.md
+++ b/content/en/functions/data/GetCSV.md
@@ -97,7 +97,7 @@ my-project/
 {{ $p := "data/pets.csv" }}
 {{ with resources.Get $p }}
   {{ $opts := dict "delimiter" "," }}
-  {{ $data = . | transform.Unmarshal $opts }}
+  {{ $data = .Content | transform.Unmarshal $opts }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -121,7 +121,7 @@ my-project/
 {{ $p := "pets.csv" }}
 {{ with .Resources.Get $p }}
   {{ $opts := dict "delimiter" "," }}
-  {{ $data = . | transform.Unmarshal $opts }}
+  {{ $data = .Content | transform.Unmarshal $opts }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -139,7 +139,7 @@ Consider using the [`resources.GetRemote`] function with [`transform.Unmarshal`]
     {{ errorf "%s" . }}
   {{ else }}
     {{ $opts := dict "delimiter" "," }}
-    {{ $data = . | transform.Unmarshal $opts }}
+    {{ $data = .Content | transform.Unmarshal $opts }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $u }}

--- a/content/en/functions/data/GetJSON.md
+++ b/content/en/functions/data/GetJSON.md
@@ -101,7 +101,7 @@ my-project/
 {{ $data := "" }}
 {{ $p := "data/books.json" }}
 {{ with resources.Get $p }}
-  {{ $data = . | transform.Unmarshal }}
+  {{ $data = .Content | transform.Unmarshal }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -124,7 +124,7 @@ my-project/
 {{ $data := "" }}
 {{ $p := "books.json" }}
 {{ with .Resources.Get $p }}
-  {{ $data = . | transform.Unmarshal }}
+  {{ $data = .Content | transform.Unmarshal }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -141,7 +141,7 @@ Consider using the [`resources.GetRemote`] function with [`transform.Unmarshal`]
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = . | transform.Unmarshal }}
+    {{ $data = .Content | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $u }}

--- a/content/en/functions/debug/Dump.md
+++ b/content/en/functions/debug/Dump.md
@@ -15,7 +15,7 @@ action:
 {{ $p := "data/books.json" }}
 {{ with resources.Get $p }}
   {{ $opts := dict "delimiter" "," }}
-  {{ $data = . | transform.Unmarshal $opts }}
+  {{ $data = .Content | transform.Unmarshal $opts }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}

--- a/content/en/functions/encoding/Base64Decode.md
+++ b/content/en/functions/encoding/Base64Decode.md
@@ -30,7 +30,7 @@ To retrieve and render the content:
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ with . | transform.Unmarshal }}
+    {{ with .Content | transform.Unmarshal }}
       {{ .content | base64Decode | markdownify }}
     {{ end }}
   {{ end }}

--- a/content/en/functions/resources/GetRemote.md
+++ b/content/en/functions/resources/GetRemote.md
@@ -79,7 +79,7 @@ When retrieving remote data, use the [`transform.Unmarshal`] function to [unmars
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = . | transform.Unmarshal }}
+    {{ $data = .Content | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}

--- a/content/en/functions/transform/Unmarshal.md
+++ b/content/en/functions/transform/Unmarshal.md
@@ -49,7 +49,7 @@ assets/
 {{ $data := "" }}
 {{ $path := "data/books.json" }}
 {{ with resources.Get $path }}
-  {{ with unmarshal . }}
+  {{ with unmarshal .Content }}
     {{ $data = . }}
   {{ end }}
 {{ else }}
@@ -78,7 +78,7 @@ content/
 {{ $data := "" }}
 {{ $path := "books.json" }}
 {{ with .Resources.Get $path }}
-  {{ with unmarshal . }}
+  {{ with unmarshal .Content }}
     {{ $data = . }}
   {{ end }}
 {{ else }}
@@ -101,7 +101,7 @@ A remote resource is a file on a remote server, accessible via HTTP or HTTPS.
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = . | transform.Unmarshal }}
+    {{ $data = .Content | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}
@@ -172,7 +172,7 @@ Get the remote data:
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = . | transform.Unmarshal }}
+    {{ $data = .Content | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}


### PR DESCRIPTION
Explicity unmarshal RESOURCE.Content in each example. Although a bit more verbose, this avoids situations where the resource's media type is not a known serialization format.