### PR TITLE
command 'hugo server': preserve two hypens for option 'renderToMemory'

### DIFF
--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -14,7 +14,7 @@ typographer = true
 
     [goldmark.extensions.passthrough.delimiters]
       block = [['\[', '\]'], ['$$', '$$']]
-      inline = [['\(', '\)']]
+      inline = [['\(', '\)'], ["'", 'renderToMemory']]
 
 [goldmark.parser]
 autoHeadingID = true


### PR DESCRIPTION
This PR is a follow-up of rejected PR #2446. I found another way to preserve the two dashes and hope this approach can be accepted.