### PR TITLE
Add an open-source project to developer tools and minor reviews

### DIFF
--- a/content/en/templates/data-templates.md
+++ b/content/en/templates/data-templates.md
@@ -150,8 +150,9 @@ If you change any local file and the LiveReload is triggered, Hugo will read the
 
 ## Examples of data-driven content
 
-- Photo gallery JSON powered: [https://github.com/pcdummy/hugo-lightslider-example](https://github.com/pcdummy/hugo-lightslider-example)
+- Photo gallery JSON powered: [https://github.com/pcdummy/hugo-lightslider-example](https://github.com/pcdummy/hugo-lightslider-example).
 - GitHub Starred Repositories [in a post](https://github.com/SchumacherFM/blog-cs/blob/master/content%2Fposts%2Fgithub-starred.md) using data-driven content in a [custom short code](https://github.com/SchumacherFM/blog-cs/blob/master/layouts%2Fshortcodes%2FghStarred.html).
+- Importing exported social media data from popular services using [https://github.com/ttybitnik/diego](https://github.com/ttybitnik/diego).
 
 ## Specs for data formats
 

--- a/content/en/tools/other.md
+++ b/content/en/tools/other.md
@@ -11,13 +11,14 @@ menu:
 weight: 60
 ---
 
-And for all the other small things around Hugo:
+And for all the other community projects around Hugo:
 
-- [hugo-gallery](https://github.com/icecreammatt/hugo-gallery) lets you create an image gallery for Hugo sites.
-- [flickr-hugo-embed](https://github.com/nikhilm/flickr-hugo-embed) prints shortcodes to embed a set of images from an album on Flickr into Hugo.
-- [hugo-openapispec-shortcode](https://github.com/tenfourty/hugo-openapispec-shortcode) A shortcode that allows you to include [Open API Spec](https://openapis.org) (formerly known as Swagger Spec) in a page.
-- [HugoPhotoSwipe](https://github.com/GjjvdBurg/HugoPhotoSwipe) makes it easy to create image galleries using PhotoSwipe.
-- [Hugo SFTP Upload](https://github.com/thomasmey/HugoSftpUpload) Syncs the local build of your Hugo website with your remote web server via SFTP.
-- [Emacs Easy Hugo](https://github.com/masasam/emacs-easy-hugo) Emacs package for writing blog posts in Markdown or org-mode and building your site with Hugo.
-- [JAMStack Themes](https://jamstackthemes.dev/ssg/hugo/). JAMStack themes is a collection of site themes filterable by static site generator and supported CMS to help build CMS-connected sites using Hugo (linking to Hugo-specific themes).
-- [plausible-hugo](https://github.com/divinerites/plausible-hugo). Easy Hugo integration for Plausible Analytics, a simple, open-source, lightweight and privacy-friendly web analytics alternative to Google Analytics.
+- [diego](https://github.com/ttybitnik/diego) - A CLI tool that integrates with Hugo to assist in importing and utilizing exported social media data from popular services on Hugo websites.
+- [Emacs Easy Hugo](https://github.com/masasam/emacs-easy-hugo) - Emacs package for writing blog posts in Markdown or org-mode and building your site with Hugo.
+- [Hugo SFTP Upload](https://github.com/thomasmey/HugoSftpUpload) - Sync the local build of your Hugo website with your remote web server via SFTP.
+- [HugoPhotoSwipe](https://github.com/GjjvdBurg/HugoPhotoSwipe) - Make it easy to create image galleries using PhotoSwipe.
+- [JAMStack Themes](https://jamstackthemes.dev/ssg/hugo/) -  A collection of site themes filterable by static site generator and supported CMS to help build CMS-connected sites using Hugo (linking to Hugo-specific themes).
+- [flickr-hugo-embed](https://github.com/nikhilm/flickr-hugo-embed) - Print shortcodes to embed a set of images from an album on Flickr into Hugo.
+- [hugo-gallery](https://github.com/icecreammatt/hugo-gallery) - Create an image gallery for Hugo sites.
+- [hugo-openapispec-shortcode](https://github.com/tenfourty/hugo-openapispec-shortcode) - A shortcode that allows you to include [Open API Spec](https://openapis.org) (formerly known as Swagger Spec) in a page.
+- [plausible-hugo](https://github.com/divinerites/plausible-hugo) - Easy Hugo integration for Plausible Analytics, a simple, open-source, lightweight and privacy-friendly web analytics alternative to Google Analytics.


### PR DESCRIPTION
This week I released [diego](https://github.com/ttybitnik/diego) (actually my open-source debut) and it would be nice to have it in the docs, enabling the community to use it if they wish so. I also did some minor reviews/restructuring.

**Summary of Changes**:

**others.md**
Using this [section](https://gohugo.io/commands/hugo/#see-also) of the docs as a baseline, I did the following:
- Sorted the listed items alphabetically
- Separated the project names and descriptions with `-`
- Minor phrasing adjustments
- Added diego

**data-templates.md**
- Added diego to the examples, since it might be relevant to the reader of data files/templates

You guys are way more experienced than me, so if you think it would not be pertinent to put it in the examples, feel free to drop it :+1: 

