### PR TITLE
Update MultiLingual and MultiHost methods/functions

### DIFF
--- a/content/en/functions/hugo/IsMultihost.md
+++ b/content/en/functions/hugo/IsMultihost.md
@@ -5,7 +5,8 @@ categories: []
 keywords: []
 action:
   aliases: []
-  related: []
+  related:
+    - /functions/hugo/IsMultilingual
   returnType: bool
   signatures: [hugo.IsMultihost]
 ---

--- a/content/en/functions/hugo/IsMultilingual.md
+++ b/content/en/functions/hugo/IsMultilingual.md
@@ -1,19 +1,16 @@
 ---
-title: IsMultiLingual
+title: hugo.IsMultilingual
 description: Reports whether there are two or more configured languages.
 categories: []
 keywords: []
 action:
-  related: []
+  related:
+    - /functions/hugo/IsMultihost
   returnType: bool
-  signatures: [SITE.IsMultiLingual]
+  signatures: [hugo.IsMultilingual]
 ---
 
-{{% deprecated-in 0.124.0 %}}
-Use [`hugo.IsMultilingual`] instead.
-
-[`hugo.IsMultilingual`]: /functions/hugo/ismultilingual/
-{{% /deprecated-in %}}
+{{< new-in v0.124.0 >}}
 
 Site configuration:
 
@@ -36,5 +33,5 @@ defaultContentLanguageInSubdir = true
 Template:
 
 ```go-html-template
-{{ .Site.IsMultiLingual }} → true
+{{ hugo.IsMultilingual }} → true
 ```


### PR DESCRIPTION
- Deprecate .Site.MultiLingual in favor of hugo.IsMultilingual
- Rename hugo.IsMultiHost to hugo.IsMultihost. Cannot deprecate
  in documentation because they have the same published path, but this
  shouldn't be a problem because hugo.IsMultiHost was introduced in the
  last patch release.

See https://github.com/gohugoio/hugo/issues/12232

Merge upon release of v0.124.0.