### PR TITLE
Update versions in GitHub hosting example

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github/index.md
+++ b/content/en/hosting-and-deployment/hosting-on-github/index.md
@@ -97,7 +97,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.7
+      HUGO_VERSION: 0.123.8
     steps:
       - name: Install Hugo CLI
         run: |
@@ -126,7 +126,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -140,7 +140,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
 {{< /code >}}
 
 Step 7


### PR DESCRIPTION
This avoids the following warning when using the action workflow from the GitHub hosting example: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3.`