### PR TITLE
Update segments example

### DIFF
--- a/content/en/getting-started/configuration.md
+++ b/content/en/getting-started/configuration.md
@@ -853,7 +853,7 @@ It is recommended to put coarse grained filters (e.g. for language and output fo
     lang   = "en"
     output = "rss"
   [[segments.segment1.includes]]
-    term = "{home,term,taxonomy}"
+    kind = "{home,term,taxonomy}"
   [[segments.segment1.includes]]
     path = "{/docs,/docs/**}"
 {{< /code-toggle >}}


### PR DESCRIPTION
Stumbled across the line `term = "{home,term,taxonomy}"` in the segments example, I guess this is meant to be a filter for page `kind`.