### PR TITLE
Update link to Modules page of Go Wiki

### DIFF
--- a/content/en/hugo-modules/_index.md
+++ b/content/en/hugo-modules/_index.md
@@ -20,7 +20,7 @@ You can combine modules in any combination you like, and even mount directories 
 
 Hugo Modules are powered by Go Modules. For more information about Go Modules, see:
 
-- [https://github.com/golang/go/wiki/Modules](https://github.com/golang/go/wiki/Modules)
+- [https://go.dev/wiki/Modules](https://go.dev/wiki/Modules)
 - [https://go.dev/blog/using-go-modules](https://go.dev/blog/using-go-modules)
 
 Some example projects:


### PR DESCRIPTION
Per [this page](https://github.com/golang/go/wiki/Modules), the Go Wiki has migrated from the GitHub wiki to [https://go.dev/wiki/Modules](https://go.dev/wiki/Modules).

This PR updates the [Hugo Modules](https://gohugo.io/hugo-modules/) page to correctly link to the new Go Wiki.