### PR TITLE
Fix file extension typo in page-bundles.md

### DIFF
--- a/content/en/content-management/page-bundles.md
+++ b/content/en/content-management/page-bundles.md
@@ -118,8 +118,8 @@ content/
 │   ├── _index.md
 │   ├── content-1.md
 │   ├── content-2.md
-│   ├── image-1.md
-│   └── image-2.md
+│   ├── image-1.jpg
+│   └── image-2.png
 ├── branch-bundle-2/
 │   ├── a-leaf-bundle/
 │   │   └── index.md


### PR DESCRIPTION
Change from `.md` to `.jpg` and `.png` extensions for the two image resources in the branch bundle example.