### PR TITLE
Update site.md: fix conflicting text

### DIFF
--- a/content/en/functions/global/site.md
+++ b/content/en/functions/global/site.md
@@ -19,7 +19,8 @@ At the top level of a template that receives the `Site` object in context, these
 {{ site.Params.foo }}
 ```
 
-When the `Site` object is not in context, use the global `site` function:
+When the `Site` object is not in context, only the global `site` function is guaranteed to return
+the current site:
 
 ```go-html-template
 {{ site.Params.foo }}


### PR DESCRIPTION
The current page gives conflicting info about whether to prefer `site` vs. `.Site`. This edit removes the ambiguity.