### PR TITLE
Fix netlify.toml examples in hosting-on-netlify

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-netlify/index.md
+++ b/content/en/hosting-and-deployment/hosting-on-netlify/index.md
@@ -100,6 +100,7 @@ In the procedure above we configured our site using the Netlify user interface. 
 Create a new file named netlify.toml in the root of your project directory. In its simplest form, the configuration file might look like this:
 
 {{< code file=netlify.toml >}}
+[build.environment]
 HUGO_VERSION = "0.124.0"
 TZ = "America/Los_Angeles"
 
@@ -111,6 +112,7 @@ command = "hugo --gc --minify"
 If your site requires Dart Sass to transpile Sass to CSS, the configuration file should look something like this:
 
 {{< code file=netlify.toml >}}
+[build.environment]
 HUGO_VERSION = "0.124.0"
 DART_SASS_VERSION = "1.72.0"
 TZ = "America/Los_Angeles"


### PR DESCRIPTION
The build.environment line was missing in both configuration examples.
See also [Hugo on Netlify](https://docs.netlify.com/frameworks/hugo/)