### PR TITLE
Add Discourse to the comment system list

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -59,6 +59,7 @@ Open-source commenting systems:
 - [Comentario](https://gitlab.com/comentario/comentario/)
 - [Comma](https://github.com/Dieterbe/comma/)
 - [Commento](https://commento.io/)
+- [Discourse](https://meta.discourse.org/t/embed-discourse-comments-on-another-website-via-javascript/31963)
 - [Giscus](https://giscus.app/)
 - [Isso](https://isso-comments.de/)
 - [Remark42](https://remark42.com/)


### PR DESCRIPTION
Discourse has builtin support for being used as a comment system