### PR TITLE
Change transform.Unmarshal remote data examples

### DIFF
--- a/content/en/functions/data/GetCSV.md
+++ b/content/en/functions/data/GetCSV.md
@@ -97,7 +97,7 @@ my-project/
 {{ $p := "data/pets.csv" }}
 {{ with resources.Get $p }}
   {{ $opts := dict "delimiter" "," }}
-  {{ $data = .Content | transform.Unmarshal $opts }}
+  {{ $data = . | transform.Unmarshal $opts }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -121,7 +121,7 @@ my-project/
 {{ $p := "pets.csv" }}
 {{ with .Resources.Get $p }}
   {{ $opts := dict "delimiter" "," }}
-  {{ $data = .Content | transform.Unmarshal $opts }}
+  {{ $data = . | transform.Unmarshal $opts }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -139,7 +139,7 @@ Consider using the [`resources.GetRemote`] function with [`transform.Unmarshal`]
     {{ errorf "%s" . }}
   {{ else }}
     {{ $opts := dict "delimiter" "," }}
-    {{ $data = .Content | transform.Unmarshal $opts }}
+    {{ $data = . | transform.Unmarshal $opts }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $u }}

--- a/content/en/functions/data/GetJSON.md
+++ b/content/en/functions/data/GetJSON.md
@@ -101,7 +101,7 @@ my-project/
 {{ $data := dict }}
 {{ $p := "data/books.json" }}
 {{ with resources.Get $p }}
-  {{ $data = .Content | transform.Unmarshal }}
+  {{ $data = . | transform.Unmarshal }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -124,7 +124,7 @@ my-project/
 {{ $data := dict }}
 {{ $p := "books.json" }}
 {{ with .Resources.Get $p }}
-  {{ $data = .Content | transform.Unmarshal }}
+  {{ $data = . | transform.Unmarshal }}
 {{ else }}
   {{ errorf "Unable to get resource %q" $p }}
 {{ end }}
@@ -141,7 +141,7 @@ Consider using the [`resources.GetRemote`] function with [`transform.Unmarshal`]
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = .Content | transform.Unmarshal }}
+    {{ $data = . | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $u }}

--- a/content/en/functions/encoding/Base64Decode.md
+++ b/content/en/functions/encoding/Base64Decode.md
@@ -30,7 +30,7 @@ To retrieve and render the content:
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ with .Content | transform.Unmarshal }}
+    {{ with . | transform.Unmarshal }}
       {{ .content | base64Decode | markdownify }}
     {{ end }}
   {{ end }}

--- a/content/en/functions/resources/GetRemote.md
+++ b/content/en/functions/resources/GetRemote.md
@@ -79,12 +79,22 @@ When retrieving remote data, use the [`transform.Unmarshal`] function to [unmars
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = .Content | transform.Unmarshal }}
+    {{ $data = . | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}
 {{ end }}
 ```
+
+{{% note %}}
+When retrieving remote data, a misconfigured server may send a response header with an incorrect [Content-Type]. For example, the server may set the Content-Type header to `application/octet-stream` instead of `application/json`.
+
+In these cases, pass the resource `Content` through the `transform.Unmarshal` function instead of passing the resource itself. For example, in the above, do this instead:
+
+`{{ $data = .Content | transform.Unmarshal }}`
+
+[Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+{{% /note %}}
 
 ## Error handling
 

--- a/content/en/functions/transform/Unmarshal.md
+++ b/content/en/functions/transform/Unmarshal.md
@@ -49,7 +49,7 @@ assets/
 {{ $data := dict }}
 {{ $path := "data/books.json" }}
 {{ with resources.Get $path }}
-  {{ with .Content | transform.Unmarshal }}
+  {{ with . | transform.Unmarshal }}
     {{ $data = . }}
   {{ end }}
 {{ else }}
@@ -78,7 +78,7 @@ content/
 {{ $data := dict }}
 {{ $path := "books.json" }}
 {{ with .Resources.Get $path }}
-  {{ with .Content | transform.Unmarshal }}
+  {{ with . | transform.Unmarshal }}
     {{ $data = . }}
   {{ end }}
 {{ else }}
@@ -101,7 +101,7 @@ A remote resource is a file on a remote server, accessible via HTTP or HTTPS.
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = .Content | transform.Unmarshal }}
+    {{ $data = . | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}
@@ -112,8 +112,15 @@ A remote resource is a file on a remote server, accessible via HTTP or HTTPS.
 {{ end }}
 ```
 
-[resource]: /getting-started/glossary/#resource
-[page bundle]: /content-management/page-bundles/
+{{% note %}}
+When retrieving remote data, a misconfigured server may send a response header with an incorrect [Content-Type]. For example, the server may set the Content-Type header to `application/octet-stream` instead of `application/json`.
+
+In these cases, pass the resource `Content` through the `transform.Unmarshal` function instead of passing the resource itself. For example, in the above, do this instead:
+
+`{{ $data = .Content | transform.Unmarshal }}`
+
+[Content-Type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+{{% /note %}}
 
 ## Options
 
@@ -172,7 +179,7 @@ Get the remote data:
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $data = .Content | transform.Unmarshal }}
+    {{ $data = . | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}
@@ -290,3 +297,5 @@ Hugo renders this to:
 
 [`index`]: /functions/collections/indexfunction/
 [identifiers]: https://go.dev/ref/spec#Identifiers
+[resource]: /getting-started/glossary/#resource
+[page bundle]: /content-management/page-bundles/


### PR DESCRIPTION
- Pass the resource itself through transform.Unmarshal
- Add an admonition regarding misconfigured servers that send an incorrect Content-Type header, and what to do about it