### PR TITLE
use-modules: clarify the example of initializing a new module

### DIFF
--- a/content/en/hugo-modules/use-modules.md
+++ b/content/en/hugo-modules/use-modules.md
@@ -21,7 +21,7 @@ toc: true
 Use `hugo mod init` to initialize a new Hugo Module. If it fails to guess the module path, you must provide it as an argument, e.g.:
 
 ```sh
-hugo mod init github.com/gohugoio/myShortcodes
+hugo mod init github.com/<your_user>/<your_project>
 ```
 
 Also see the [CLI Doc](/commands/hugo_mod_init/).


### PR DESCRIPTION
Every time I read this documentation to using Hugo Modules, I get confused about what initializing a new module is for, and run `hugo mod init <name of dependency>`, rather than `hugo mod init <name of my project>`.
I think this clarifies that a bit.
