### PR TITLE
Clarify `languageCode` default in multilingual page

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -79,7 +79,7 @@ disabled
 : (`bool`) If `true`, Hugo will not render content for this language. Default is `false`.
 
 languageCode
-: (`string`) The language tag as described in [RFC 5646]. This value does not affect localization or URLs. Hugo uses this value to populate the `language` element in the [built-in RSS template], and the `lang` attribute of the `html` element in the [built-in alias template]. Examples:
+: (`string`) The language tag as described in [RFC 5646]. This value does not affect localization or URLs. Hugo uses this value to populate the `language` element in the [built-in RSS template], and the `lang` attribute of the `html` element in the [built-in alias template]. Defaults to the language key when unspecified. Examples:
 
 - `en`
 - `en-GB`


### PR DESCRIPTION
According to my tests, `languageCode` defaults to the active language's language key.