### PR TITLE
Fix parameter list for collections.Dictionary

### DIFF
--- a/content/en/functions/collections/Dictionary.md
+++ b/content/en/functions/collections/Dictionary.md
@@ -8,7 +8,7 @@ action:
   related:
     - functions/collections/Slice
   returnType: mapany
-  signatures: ['collections.Dictionary KEY VALUE [VALUE...]']
+  signatures: ['collections.Dictionary KEY VALUE [VALUE KEY]...']
 aliases: [/functions/dict]
 ---
 


### PR DESCRIPTION
must always be a key-value pair, so the current text is missleading.

moved the `...` behind the square brackets, so it stands for repeating the pair