### PR TITLE
[copyedit] `Sites` method: consistently use "default content"

### DIFF
--- a/content/en/methods/site/Sites.md
+++ b/content/en/methods/site/Sites.md
@@ -49,7 +49,7 @@ Produces a list of links to each home page:
 </ul>
 ```
 
-To render a link to home page of the primary (first) language:
+To render a link to home page of the default content (first) language:
 
 ```go-html-template
 {{ with .Site.Sites.First }}


### PR DESCRIPTION
Replaces "primary" by "default content" to describe the first entry in `Sites`, which I feel is clearer (given that `defaultContentLanguage` is the actual config parameter name). This matches the terminology in the page description: "Returns ... ordered by default content language then by language weight".