### PR TITLE
add missing s to post directory name

### DIFF
--- a/content/en/getting-started/usage.md
+++ b/content/en/getting-started/usage.md
@@ -140,7 +140,7 @@ public/
 ├── categories/
 │   ├── index.html
 │   └── index.xml  <-- RSS feed for this section
-├── post/
+├── posts/
 │   ├── my-first-post/
 │   │   └── index.html
 │   ├── index.html


### PR DESCRIPTION
`post` to `posts` in `public` directory structure.