### PR TITLE
Clarify cardinalityThreshold

### DIFF
--- a/content/en/content-management/related.md
+++ b/content/en/content-management/related.md
@@ -150,7 +150,7 @@ weight
 : (`int`) An integer weight that indicates _how important_ this parameter is relative to the other parameters. It can be `0`, which has the effect of turning this index off, or even negative. Test with different values to see what fits your content best.
 
 cardinalityThreshold {{< new-in 0.111.0 >}}
-: (`int`) A percentage (0-100) used to remove common keywords from the index. As an example, setting this to `50` will remove all keywords that are used in more than 50% of the documents in the index. Default is `0`.
+: (`int`) If between 1 and 100, this is a percentage. All keywords that are used in more than this percentage of documents are removed. For example, setting this to `60` will remove all keywords that are used in more than 60% of the documents in the index. If `0`, no keyword is removed from the index. Default is `0`.
 
 pattern
 : (`string`) This is currently only relevant for dates. When listing related content, we may want to list content that is also close in time. Setting "2006" (default value for date indexes) as the pattern for a date index will add weight to pages published in the same year. For busier blogs, "200601" (year and month) may be a better default.


### PR DESCRIPTION
- Clarify that `0` has a special meaning.
- Use 60% instead of 50% in the example, because 50% is symmetric: 50% is above the threshold and 50% is below the threshold. Using a different percentage to remove ambiguity from the example.
- Text polishing.