### PR TITLE
Fixing a typo in the Quick Start page

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -110,7 +110,7 @@ Press `Ctrl + C` to stop Hugo's development server.
 Add a new page to your site.
 
 ```text
-hugo new content/posts/my-first-post.md
+hugo new content content/posts/my-first-post.md
 ```
 
 Hugo created the file in the `content/posts` directory. Open the file with your editor.

--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -110,7 +110,7 @@ Press `Ctrl + C` to stop Hugo's development server.
 Add a new page to your site.
 
 ```text
-hugo new content posts/my-first-post.md
+hugo new content/posts/my-first-post.md
 ```
 
 Hugo created the file in the `content/posts` directory. Open the file with your editor.


### PR DESCRIPTION
Under the Add content section, a backslash was missing from the command to add a new page.