### PR TITLE
Add output format information to lookup order section

### DIFF
--- a/content/en/templates/shortcode.md
+++ b/content/en/templates/shortcode.md
@@ -46,7 +46,7 @@ Shortcode templates have a simple [lookup order], which first looks for a shortc
 3. `/layouts/shortcodes/<SHORTCODE>.html`
 4. `/themes/<THEME>/layouts/shortcodes/<SHORTCODE>.html`
 
-For example, the built-in RSS output format uses a baseName of `index` and suffix of `xml` by default. When calling a shortcut via `{{< example >}}`, the RSS template will first look for a file `example.index.xml` and if one doesn't exist will fall back to `example.html`.
+For example, the built-in RSS output format uses a baseName of `index` and suffix of `xml` by default. When calling a shortcut via `{{</* example */>}}`, the RSS template will first look for a file `example.index.xml` and if one doesn't exist will fall back to `example.html`.
 
 ### Positional vs. named arguments
 

--- a/content/en/templates/shortcode.md
+++ b/content/en/templates/shortcode.md
@@ -41,12 +41,12 @@ Note the forward slash.
 
 Shortcode templates have a simple [lookup order], which first looks for a shortcode unique to the [output format] and then falls back to a generic HTML version.
 
-1. `/layouts/shortcodes/<SHORTCODE>.<OUTPUT-BASENAME>.<OUTPUT-SUFFIX>`
-2. `/themes/<THEME>/layouts/shortcodes/<OUTPUT-BASENAME>.<OUTPUT-SUFFIX>`
+1. `/layouts/shortcodes/<SHORTCODE>.<OUTPUT-NAME>.<OUTPUT-SUFFIX>`
+2. `/themes/<THEME>/layouts/shortcodes/<OUTPUT-NAME>.<OUTPUT-SUFFIX>`
 3. `/layouts/shortcodes/<SHORTCODE>.html`
 4. `/themes/<THEME>/layouts/shortcodes/<SHORTCODE>.html`
 
-For example, the built-in RSS output format uses a baseName of `index` and suffix of `xml` by default. When calling a shortcut via `{{</* example */>}}`, the RSS template will first look for a file `example.index.xml` and if one doesn't exist will fall back to `example.html`.
+For example, the built-in feed output format is called `rss` and uses a suffix of `xml` by default. When calling a shortcut via `{{</* example */>}}`, the RSS template will first look for a file `example.rss.xml` and if one doesn't exist will fall back to `example.html`.
 
 ### Positional vs. named arguments
 

--- a/content/en/templates/shortcode.md
+++ b/content/en/templates/shortcode.md
@@ -39,10 +39,14 @@ Note the forward slash.
 
 ### Shortcode template lookup order
 
-Shortcode templates have a simple [lookup order]:
+Shortcode templates have a simple [lookup order], which first looks for a shortcode unique to the [output format] and then falls back to a generic HTML version.
 
-1. `/layouts/shortcodes/<SHORTCODE>.html`
-2. `/themes/<THEME>/layouts/shortcodes/<SHORTCODE>.html`
+1. `/layouts/shortcodes/<SHORTCODE>.<OUTPUT-BASENAME>.<OUTPUT-SUFFIX>`
+2. `/themes/<THEME>/layouts/shortcodes/<OUTPUT-BASENAME>.<OUTPUT-SUFFIX>`
+3. `/layouts/shortcodes/<SHORTCODE>.html`
+4. `/themes/<THEME>/layouts/shortcodes/<SHORTCODE>.html`
+
+For example, the built-in RSS output format uses a baseName of `index` and suffix of `xml` by default. When calling a shortcut via `{{< example >}}`, the RSS template will first look for a file `example.index.xml` and if one doesn't exist will fall back to `example.html`.
 
 ### Positional vs. named arguments
 
@@ -400,6 +404,7 @@ The same inline shortcode can be reused later in the same content file, with dif
 [built-in shortcode]: /content-management/shortcodes/
 [figure]: /content-management/shortcodes/#figure
 [lookup order]: /templates/lookup-order/
+[output format]: templates/output-formats/
 [source organization]: /getting-started/directory-structure/
 [vimeoexample]: #single-flexible-example-vimeo
 [youtubeshortcode]: /content-management/shortcodes/#youtube


### PR DESCRIPTION
Hugo supports different shortcodes per output format. This PR updates the docs to describe this.

I think this has been the case ever since https://github.com/gohugoio/hugo/issues/3220 was fixed in https://github.com/dmerejkowsky/hugo/commit/af72db806f2c1c0bf1dfe5832275c41eeba89906