### PR TITLE
Improve embedded.md: fix filename patterns for OG and Twitter images.

### DIFF
--- a/content/en/templates/embedded.md
+++ b/content/en/templates/embedded.md
@@ -203,7 +203,7 @@ description = "Text about this post"
 images = ["post-cover.png"]
 {{</ code-toggle >}}
 
-If `images` aren't specified in the page front-matter, then hugo searches for [image page resources](/content-management/image-processing/) with `*feature*`, `*cover*`, or `*thumbnail*` in their name.
+If [page bundles](/content-management/page-bundles/) are used and the `images` array is empty or undefined, images with file names matching `*feature*`, `*cover*`, or `*thumbnail*` are used for image metadata.
 If no image resources with those names are found, the images defined in the [site config](/getting-started/configuration/) are used instead.
 If no images are found at all, then an image-less Twitter `summary` card is used instead of `summary_large_image`.
 

--- a/content/en/templates/embedded.md
+++ b/content/en/templates/embedded.md
@@ -135,7 +135,7 @@ tags = []
 
 Hugo uses the page title and description for the title and description metadata.
 The first 6 URLs from the `images` array are used for image metadata.
-If [page bundles](/content-management/page-bundles/) are used and the `images` array is empty or undefined, images with file names matching `*feature*` or `*cover*,*thumbnail*` are used for image metadata.
+If [page bundles](/content-management/page-bundles/) are used and the `images` array is empty or undefined, images with file names matching `*feature*`, `*cover*`, or `*thumbnail*` are used for image metadata.
 
 Various optional metadata can also be set:
 
@@ -203,7 +203,7 @@ description = "Text about this post"
 images = ["post-cover.png"]
 {{</ code-toggle >}}
 
-If `images` aren't specified in the page front-matter, then hugo searches for [image page resources](/content-management/image-processing/) with `feature`, `cover`, or `thumbnail` in their name.
+If `images` aren't specified in the page front-matter, then hugo searches for [image page resources](/content-management/image-processing/) with `*feature*`, `*cover*`, or `*thumbnail*` in their name.
 If no image resources with those names are found, the images defined in the [site config](/getting-started/configuration/) are used instead.
 If no images are found at all, then an image-less Twitter `summary` card is used instead of `summary_large_image`.
 


### PR DESCRIPTION
I've read the following implementations.
`opengraph.html` and `twitter_cards.html` are both using `get-page-images.html`. So, the descriptions for the two embedded templates should be the same.

https://github.com/gohugoio/hugo/blob/2fcc53780f765c05dd6b7ec41c6bb76308362e5e/tpl/tplimpl/embedded/templates/opengraph.html#L38-L42

![image](https://github.com/user-attachments/assets/9b880a85-f9ac-4928-8986-283e1b7b9fcf)

https://github.com/gohugoio/hugo/blob/2fcc53780f765c05dd6b7ec41c6bb76308362e5e/tpl/tplimpl/embedded/templates/twitter_cards.html#L1-L5

![image](https://github.com/user-attachments/assets/2797886a-53b6-46b1-9bf3-75022bb554b2)

https://github.com/gohugoio/hugo/blob/2fcc53780f765c05dd6b7ec41c6bb76308362e5e/tpl/tplimpl/embedded/templates/partials/_funcs/get-page-images.html#L5-L9

![image](https://github.com/user-attachments/assets/68d68d00-5518-4c97-89a6-4ef264216b74)
