### PR TITLE
Chomp whitespace in example templates for `transform.ToMath`

### DIFF
--- a/content/en/functions/transform/ToMath.md
+++ b/content/en/functions/transform/ToMath.md
@@ -101,7 +101,7 @@ There are 3 ways to handle errors from KaTeX:
   {{ with .Err }}
     {{ errorf "Failed to render KaTeX: %q. See %s" . $.Position }}
   {{ else }}
-    {{ . }}
+    {{- . }}
   {{ end }}
 {{ end }}
 {{- /* chomp trailing newline */ -}}

--- a/content/en/render-hooks/passthrough.md
+++ b/content/en/render-hooks/passthrough.md
@@ -106,9 +106,9 @@ As an alternative to rendering mathematical expressions with the MathJax or KaTe
 {{< code file=layouts/_default/_markup/render-passthrough.html copy=true >}}
 {{ if eq .Type "block" }}
   {{ $opts := dict "displayMode" true }}
-  {{ transform.ToMath .Inner $opts }}
+  {{- transform.ToMath .Inner $opts -}}
 {{ else }}
-  {{ transform.ToMath .Inner }}
+  {{- transform.ToMath .Inner -}}
 {{ end }}
 {{< /code >}}
 


### PR DESCRIPTION
Chomp whitespace in the example templates for `transform.ToMath` to avoid generating code blocks and/or unwanted newlines (see https://github.com/gohugoio/hugo/issues/12736#issuecomment-2293340971).