### PR TITLE
Update definition of falsy to include zero time.Time values

### DIFF
--- a/content/en/functions/go-template/_common/truthy-falsy.md
+++ b/content/en/functions/go-template/_common/truthy-falsy.md
@@ -2,4 +2,6 @@
 # Do not remove front matter.
 ---
 
-In Go templates, the falsy values are `false`, `0`, any nil pointer or interface value, and any array, slice, map, or string of length zero. Everything else is truthy.
+The falsy values are `false`, `0`, any `nil` pointer or interface value, any array, slice, map, or string of length zero, and zero `time.Time` values.
+
+Everything else is truthy.


### PR DESCRIPTION
This affects documentation for `with`, `if`, `range`, `and`, `or`, and `compare.Default`.