### PR TITLE
Update render hook documentation

### DIFF
--- a/content/en/about/features.md
+++ b/content/en/about/features.md
@@ -49,7 +49,7 @@ toc: true
 : Leverage the embedded Markdown extensions to create tables, definition lists, footnotes, task lists, inserted text, mark text, subscripts, superscripts, and more.
 
 [Markdown render hooks]
-: Override the conversion of Markdown to HTML when rendering blockquotes, fenced code blocks, headings, images, and links. For example, render every standalone image as an HTML `figure` element.
+: Override the conversion of Markdown to HTML when rendering blockquotes, fenced code blocks, headings, images, links, and tables. For example, render every standalone image as an HTML `figure` element.
 
 [Diagrams]
 : Use fenced code blocks and Markdown render hooks to include diagrams in your content.

--- a/content/en/render-hooks/blockquotes.md
+++ b/content/en/render-hooks/blockquotes.md
@@ -54,7 +54,7 @@ block = true
 (`string`) The position of the blockquote within the page content.
 
 ###### Text
-(`string`) The blockquote text, excluding the alert designator if present. See the [alerts](#alerts) section below.
+(`template.HTML`) The blockquote text, excluding the alert designator if present. See the [alerts](#alerts) section below.
 
 ###### Type
 
@@ -68,7 +68,7 @@ In its default configuration, Hugo renders Markdown blockquotes according to the
 
 {{< code file=layouts/_default/_markup/render-blockquote.html copy=true >}}
 <blockquote>
-  {{ .Text | safeHTML }}
+  {{ .Text }}
 </blockquote>
 {{< /code >}}
 
@@ -77,7 +77,7 @@ To render a blockquote as an HTML `figure` element with an optional citation and
 {{< code file=layouts/_default/_markup/render-blockquote.html copy=true >}}
 <figure>
   <blockquote {{ with .Attributes.cite }}cite="{{ . }}"{{ end }}>
-    {{ .Text | safeHTML }}
+    {{ .Text }}
   </blockquote>
   {{ with .Attributes.caption }}
     <figcaption class="blockquote-caption">
@@ -115,11 +115,9 @@ Also known as _callouts_ or _admonitions_, alerts are blockquotes used to emphas
 > Advises about risks or negative outcomes of certain actions.
 {{< /code >}}
 
-
 {{% note %}}
 This syntax is compatible with the GitHub Alert Markdown extension.
 {{% /note %}}
-
 
 The first line of each alert is an alert designator consisting of an exclamation point followed by the alert type, wrapped within brackets.
 
@@ -140,11 +138,11 @@ The blockquote render hook below renders a multilingual alert if an alert desgin
       {{ transform.Emojify (index $emojis .AlertType) }}
       {{ or (i18n .AlertType) (title .AlertType) }}
     </p>
-    {{ .Text | safeHTML }}
+    {{ .Text }}
   </blockquote>
 {{ else }}
   <blockquote>
-    {{ .Text | safeHTML }}
+    {{ .Text }}
   </blockquote>
 {{ end }}
 {{< /code >}}

--- a/content/en/render-hooks/blockquotes.md
+++ b/content/en/render-hooks/blockquotes.md
@@ -45,7 +45,7 @@ block = true
 
 ###### PageInner
 
-(`page`) A reference to a page nested via the [`RenderShortcodes`] method.
+(`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
 
 [`RenderShortcodes`]: /methods/page/rendershortcodes
 
@@ -169,3 +169,5 @@ layouts/
         ├── render-blockquote-alert.html
         └── render-blockquote-regular.html
 ```
+
+{{% include "/render-hooks/_common/pageinner.md" %}}

--- a/content/en/render-hooks/headings.md
+++ b/content/en/render-hooks/headings.md
@@ -55,7 +55,7 @@ title = true
 
 ###### Text
 
-(`string`) The heading text.
+(`template.HTML`) The heading text.
 
 ## Examples
 
@@ -65,7 +65,7 @@ In its default configuration, Hugo renders Markdown headings according to the [C
 
 {{< code file=layouts/_default/_markup/render-heading.html copy=true >}}
 <h{{ .Level }} id="{{ .Anchor }}">
-  {{- .Text | safeHTML -}}
+  {{- .Text -}}
 </h{{ .Level }}>
 {{< /code >}}
 
@@ -73,7 +73,7 @@ To add an anchor link to the right of each heading:
 
 {{< code file=layouts/_default/_markup/render-heading.html copy=true >}}
 <h{{ .Level }} id="{{ .Anchor }}">
-  {{ .Text | safeHTML }}
+  {{ .Text }}
   <a href="#{{ .Anchor }}">#</a>
 </h{{ .Level }}>
 {{< /code >}}

--- a/content/en/render-hooks/images.md
+++ b/content/en/render-hooks/images.md
@@ -73,7 +73,7 @@ block = true
 
 ###### Text
 
-(`string`) The image description.
+(`template.HTML`) The image description.
 
 ###### Title
 
@@ -143,7 +143,7 @@ The embedded image render hook is automatically enabled for multilingual single-
 [duplication of shared page resources]: /getting-started/configuration-markup/#duplicateresourcefiles
 {{% /note %}}
 
-The embedded image render hook resolves internal Markdown destinations by looking for a matching [page resource], falling back to a matching [global resource]. Remote destinations are passed through, and the render hook will not throw an error or warning if it is unable to resolve a destination.
+The embedded image render hook resolves internal Markdown destinations by looking for a matching [page resource], falling back to a matching [global resource]. Remote destinations are passed through, and the render hook will not throw an error or warning if unable to resolve a destination.
 
 [page resource]: /getting-started/glossary/#page-resource
 [global resource]: /getting-started/glossary/#global-resource

--- a/content/en/render-hooks/introduction.md
+++ b/content/en/render-hooks/introduction.md
@@ -19,6 +19,7 @@ When rendering Markdown to HTML, render hooks override the conversion. Each rend
 - [Images](/render-hooks/images)
 - [Links](/render-hooks/links)
 - [Passthrough elements](/render-hooks/passthrough)
+- [Tables](/render-hooks/tables)
 
 {{% note %}}
 Hugo supports multiple [content formats] including Markdown, HTML, AsciiDoc, Emacs Org Mode, Pandoc, and reStructuredText.
@@ -60,7 +61,9 @@ layouts/
         ├── render-codeblock.html
         ├── render-heading.html
         ├── render-image.html
-        └── render-link.html    
+        ├── render-link.html
+        ├── render-passthrough.html
+        └── render-table.html
 ```
 
 The template lookup order allows you to create different render hooks for each page [type], [kind], language, and [output format]. For example:

--- a/content/en/render-hooks/links.md
+++ b/content/en/render-hooks/links.md
@@ -54,7 +54,7 @@ Link render hook templates receive the following context:
 
 ###### Text
 
-(`string`) The link description.
+(`template.HTML`) The link description.
 
 ###### Title
 
@@ -74,7 +74,7 @@ In its default configuration, Hugo renders Markdown links according to the [Comm
 <a href="{{ .Destination | safeURL }}"
   {{- with .Title }} title="{{ . }}"{{ end -}}
 >
-  {{- with .Text | safeHTML }}{{ . }}{{ end -}}
+  {{- with .Text }}{{ . }}{{ end -}}
 </a>
 {{- /* chomp trailing newline */ -}}
 {{< /code >}}
@@ -87,7 +87,7 @@ To include a `rel` attribute set to `external` for external links:
   {{- with .Title }} title="{{ . }}"{{ end -}}
   {{- if $u.IsAbs }} rel="external"{{ end -}}
 >
-  {{- with .Text | safeHTML }}{{ . }}{{ end -}}
+  {{- with .Text }}{{ . }}{{ end -}}
 </a>
 {{- /* chomp trailing newline */ -}}
 {{< /code >}}
@@ -113,7 +113,7 @@ The embedded link render hook is automatically enabled for multilingual single-h
 [duplication of shared page resources]: /getting-started/configuration-markup/#duplicateresourcefiles
 {{% /note %}}
 
-The embedded link render hook resolves internal Markdown destinations by looking for a matching page, falling back to a matching [page resource], then falling back to a matching [global resource]. Remote destinations are passed through, and the render hook will not throw an error or warning if it is unable to resolve a destination.
+The embedded link render hook resolves internal Markdown destinations by looking for a matching page, falling back to a matching [page resource], then falling back to a matching [global resource]. Remote destinations are passed through, and the render hook will not throw an error or warning if unable to resolve a destination.
 
 [page resource]: /getting-started/glossary/#page-resource
 [global resource]: /getting-started/glossary/#global-resource

--- a/content/en/render-hooks/tables.md
+++ b/content/en/render-hooks/tables.md
@@ -63,7 +63,7 @@ Each table cell within the slice of slices returned by the `THead` and `TBody` m
 (`string`) The alignment of the text within the table cell, one of `left`, `center`, or `right`.
 
 ###### Text
-(`string`) The text within the table cell.
+(`template.HTML`) The text within the table cell.
 
 ## Example
 
@@ -83,7 +83,7 @@ In its default configuration, Hugo renders Markdown tables according to the [Git
       <tr>
         {{- range . }}
           <th {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
-            {{- .Text | safeHTML -}}
+            {{- .Text -}}
           </th>
         {{- end }}
       </tr>
@@ -94,7 +94,7 @@ In its default configuration, Hugo renders Markdown tables according to the [Git
       <tr>
         {{- range . }}
           <td {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
-            {{- .Text | safeHTML -}}
+            {{- .Text -}}
           </td>
         {{- end }}
       </tr>

--- a/content/en/render-hooks/tables.md
+++ b/content/en/render-hooks/tables.md
@@ -1,0 +1,106 @@
+---
+title: Table render hooks
+linkTitle: Tables
+description: Create a table render hook to override the rendering of Markdown tables to HTML.
+categories: [render hooks]
+keywords: []
+menu:
+  docs:
+    parent: render-hooks
+    weight: 90
+weight: 90
+toc: true
+---
+
+{{< new-in 0.134.0 >}}
+
+## Context
+
+Table render hook templates receive the following [context]:
+
+[context]: /getting-started/glossary/#context
+
+###### Attributes
+
+(`map`) The [Markdown attributes], available if you configure your site as follows:
+
+[Markdown attributes]: /content-management/markdown-attributes/
+
+{{< code-toggle file=hugo >}}
+[markup.goldmark.parser.attribute]
+block = true
+{{< /code-toggle >}}
+
+###### Ordinal
+
+(`int`) The zero-based ordinal of the table on the page.
+
+###### Page
+
+(`page`) A reference to the current page.
+
+###### PageInner
+
+(`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
+
+[`RenderShortcodes`]: /methods/page/rendershortcodes
+
+###### Position
+
+(`string`) The position of the table within the page content.
+
+###### THead
+(`slice`) A slice of table header rows, where each element is a slice of table cells.
+
+###### TBody
+(`slice`) A slice of table body rows, where each element is a slice of table cells.
+
+## Table cells
+
+Each table cell within the slice of slices returned by the `THead` and `TBody` methods has the following fields:
+
+###### Alignment
+(`string`) The alignment of the text within the table cell, one of `left`, `center`, or `right`.
+
+###### Text
+(`string`) The text within the table cell.
+
+## Example
+
+In its default configuration, Hugo renders Markdown tables according to the [GitHub Flavored Markdown specification]. To create a render hook that does the same thing:
+
+[GitHub Flavored Markdown specification]: https://github.github.com/gfm/#tables-extension-
+
+{{< code file=layouts/_default/_markup/render-table.html copy=true >}}
+<table
+  {{- range $k, $v := .Attributes }}
+    {{- if $v }}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+    {{- end }}
+  {{- end }}>
+  <thead>
+    {{- range .THead }}
+      <tr>
+        {{- range . }}
+          <th {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+            {{- .Text | safeHTML -}}
+          </th>
+        {{- end }}
+      </tr>
+    {{- end }}
+  </thead>
+  <tbody>
+    {{- range .TBody }}
+      <tr>
+        {{- range . }}
+          <td {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+            {{- .Text | safeHTML -}}
+          </td>
+        {{- end }}
+      </tr>
+    {{- end }}
+  </tbody>
+</table>
+{{< /code >}}
+
+{{% include "/render-hooks/_common/pageinner.md" %}}


### PR DESCRIPTION
- [x] Document table render hooks
- [x] Document change to data type returned by render hook Text methods 

<https://deploy-preview-2689--gohugoio.netlify.app/render-hooks/tables/>

Please don't squash commits. Merge upon release of v0.134.0.