### PR TITLE
fix name of config file in quickstart guide

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -59,7 +59,7 @@ hugo new site quickstart
 cd quickstart
 git init
 git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke
-echo "theme = 'ananke'" >> hugo.toml
+echo "theme = 'ananke'" >> config.toml
 hugo server
 ```
 


### PR DESCRIPTION
In the quickstart guide, the name of the theme is written to hugo.toml, which does not work. Instead, it should be written into config.toml