### PR TITLE
Update a url in gomodules-info.html

### DIFF
--- a/_vendor/github.com/gohugoio/gohugoioTheme/layouts/shortcodes/gomodules-info.html
+++ b/_vendor/github.com/gohugoio/gohugoioTheme/layouts/shortcodes/gomodules-info.html
@@ -4,7 +4,7 @@ If you have an "older" site running on Netlify, you may have to set GO_VERSION t
 
 For more information about Go Modules, see:
 
-* https://github.com/golang/go/wiki/Modules
+* https://go.dev/wiki/Modules
 * https://blog.golang.org/using-go-modules
 ` }}
 


### PR DESCRIPTION
The Go wiki on GitHub has moved to go.dev