### PR TITLE
Document usage of official Docker image

### DIFF
--- a/content/en/installation/linux.md
+++ b/content/en/installation/linux.md
@@ -168,6 +168,46 @@ sudo xbps-install -S hugo
 
 {{% include "/_common/installation/04-build-from-source.md" %}}
 
+## Docker container
+
+### Prerequisites {#docker-prerequisites}
+
+Before running the Docker container locally you must install Docker Desktop or Docker Engine. See the installation instructions for either [Docker Desktop] or [Docker Engine].
+
+When building your production site in a [CI/CD](g) workflow, whether you can run the Docker container depends on the service provider. For example, GitHub Pages and GitLab Pages allow you to run the Docker container.
+
+To prevent ownership and permission problems, create the Hugo [cache directory](#cache-directory) and ignore the error if the directory already exists:
+
+```text
+mkdir -p $HOME/.cache/hugo_cache
+```
+
+### Commands
+
+To build your site using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/.cache/hugo_cache:/cache ghcr.io/gohugoio/hugo:latest build
+```
+
+To build your site and start the embedded web server using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/.cache/hugo_cache:/cache -p 1313:1313 ghcr.io/gohugoio/hugo:latest server --bind="0.0.0.0"
+```
+
+To use a specific version, in the commands above replace `latest` with any of the [tagged image versions]. For example, to build your site using v0.136.1:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/.cache/hugo_cache:/cache ghcr.io/gohugoio/hugo:v0.136.1 build
+```
+
+### Cache directory
+
+Attaching the host's Hugo cache directory to the container can significantly enhance performance, particularly for large and image-heavy sites. This allows Hugo to reuse previously generated content, reducing the need for repeated processing and transpilation.
+
+If you are using a custom Hugo cache directory, in the commands above replace `$HOME/.cache/hugo_cache` with the absolute path to your cache directory.
+
 ## Comparison
 
 &nbsp;|Prebuilt binaries|Package managers|Repository packages|Build from source
@@ -186,6 +226,8 @@ Latest version available?|:heavy_check_mark:|:heavy_check_mark:|varies|:heavy_ch
 [Calculate Linux]: https://www.calculate-linux.org/
 [CentOS]: https://www.centos.org/
 [Debian]: https://www.debian.org/
+[Docker Desktop]: https://docs.docker.com/desktop/setup/install/linux/
+[Docker Engine]: https://docs.docker.com/engine/install/
 [EndeavourOS]: https://endeavouros.com/
 [Exherbo]: https://www.exherbolinux.org/
 [Fedora]: https://getfedora.org/
@@ -213,3 +255,4 @@ Latest version available?|:heavy_check_mark:|:heavy_check_mark:|varies|:heavy_ch
 [most distributions]: https://snapcraft.io/docs/installing-snapd
 [openSUSE]: https://www.opensuse.org/
 [strictly confined]: https://snapcraft.io/docs/snap-confinement
+[tagged image versions]: https://github.com/gohugoio/hugo/pkgs/container/hugo/versions?filters%5Bversion_type%5D=tagged

--- a/content/en/installation/macos.md
+++ b/content/en/installation/macos.md
@@ -26,6 +26,46 @@ sudo port install hugo
 
 {{% include "/_common/installation/04-build-from-source.md" %}}
 
+## Docker container
+
+### Prerequisites {#docker-prerequisites}
+
+Before running the Docker container locally you must install Docker Desktop. See the [installation instructions].
+
+When building your production site in a [CI/CD](g) workflow, whether you can run the Docker container depends on the service provider. For example, GitHub Pages and GitLab Pages allow you to run the Docker container.
+
+To prevent ownership and permission problems, create the Hugo [cache directory](#cache-directory) and ignore the error if the directory already exists:
+
+```text
+mkdir -p $HOME/Library/Caches/hugo_cache
+```
+
+### Commands
+
+To build your site using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/Library/Caches/hugo_cache:/cache ghcr.io/gohugoio/hugo:latest build
+```
+
+To build your site and start the embedded web server using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/Library/Caches/hugo_cache:/cache -p 1313:1313 ghcr.io/gohugoio/hugo:latest server --bind="0.0.0.0"
+```
+
+To use a specific version, in the commands above replace `latest` with any of the [tagged image versions]. For example, to build your site using v0.136.1:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $HOME/Library/Caches/hugo_cache:/cache ghcr.io/gohugoio/hugo:v0.136.1 build
+```
+
+### Cache directory
+
+Attaching the host's Hugo cache directory to the container can significantly enhance performance, particularly for large and image-heavy sites. This allows Hugo to reuse previously generated content, reducing the need for repeated processing and transpilation.
+
+If you are using a custom Hugo cache directory, in the commands above replace `$HOME/Library/Caches/hugo_cache` with the absolute path to your cache directory.
+
 ## Comparison
 
 &nbsp;|Prebuilt binaries|Package managers|Build from source
@@ -40,3 +80,5 @@ Latest version available?|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mar
 [^2]: Possible but requires advanced configuration.
 
 [MacPorts]: https://www.macports.org/
+[installation instructions]: https://docs.docker.com/desktop/install/mac-install/
+[tagged image versions]: https://github.com/gohugoio/hugo/pkgs/container/hugo/versions?filters%5Bversion_type%5D=tagged

--- a/content/en/installation/windows.md
+++ b/content/en/installation/windows.md
@@ -130,6 +130,49 @@ go install -tags extended,withdeploy github.com/gohugoio/hugo@latest
 > [!NOTE]
 > See these [detailed instructions][] to install GCC on Windows.
 
+## Docker container
+
+> [!note]
+> Run the commands in this section from [PowerShell] or a Linux terminal such as WSL or Git Bash. Do not use the Command Prompt.
+
+### Prerequisites {#docker-prerequisites}
+
+Before running the Docker container locally you must install Docker Desktop. See the [installation instructions].
+
+When building your production site in a [CI/CD](g) workflow, whether you can run the Docker container depends on the service provider. For example, GitHub Pages and GitLab Pages allow you to run the Docker container.
+
+To prevent ownership and permission problems, create the Hugo [cache directory](#cache-directory) and ignore the error if the directory already exists:
+
+```text
+mkdir -f $Env:LocalAppData/hugo_cache
+```
+
+### Commands
+
+To build your site using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $Env:LocalAppData/hugo_cache:/cache ghcr.io/gohugoio/hugo:latest build
+```
+
+To build your site and start the embedded web server using the latest version:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $Env:LocalAppData/hugo_cache:/cache -p 1313:1313 ghcr.io/gohugoio/hugo:latest server --bind="0.0.0.0"
+```
+
+To use a specific version, in the commands above replace `latest` with any of the [tagged image versions]. For example, to build your site using v0.136.1:
+
+```sh {copy=true}
+docker run --rm -v .:/project -v $Env:LocalAppData/hugo_cache:/cache ghcr.io/gohugoio/hugo:v0.136.1 build
+```
+
+### Cache directory
+
+Attaching the host's Hugo cache directory to the container can significantly enhance performance, particularly for large and image-heavy sites. This allows Hugo to reuse previously generated content, reducing the need for repeated processing and transpilation.
+
+If you are using a custom Hugo cache directory, in the commands above replace `%LocalAppData%/hugo_cache` with the absolute path to your cache directory.
+
 ## Comparison
 
 &nbsp;|Prebuilt binaries|Package managers|Build from source
@@ -148,6 +191,9 @@ Latest version available?|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mar
 [GCC]: https://gcc.gnu.org/
 [Git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [Go]: https://go.dev/doc/install
+[PowerShell]: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows
 [Scoop]: https://scoop.sh/
 [Winget]: https://learn.microsoft.com/en-us/windows/package-manager/
 [detailed instructions]: https://discourse.gohugo.io/t/41370
+[installation instructions]: https://docs.docker.com/desktop/install/windows-install/
+[tagged image versions]: https://github.com/gohugoio/hugo/pkgs/container/hugo/versions?filters%5Bversion_type%5D=tagged


### PR DESCRIPTION
Closes #2727

Previews:
- [Linux](https://deploy-preview-2741--gohugoio.netlify.app/installation/linux/#docker-container)
- [macOS](https://deploy-preview-2741--gohugoio.netlify.app/installation/macos/#docker-container)
- [Windows](https://deploy-preview-2741--gohugoio.netlify.app/installation/windows/#docker-container)

This needs more work. See <https://github.com/gohugoio/hugo/issues/14157#issuecomment-3540122620>.