### PR TITLE
added instructions to install dart-scss on nix based distribution

### DIFF
--- a/content/en/functions/resources/ToCSS.md
+++ b/content/en/functions/resources/ToCSS.md
@@ -225,6 +225,7 @@ If you build Hugo from source and run `mage test -v`, the test will fail if you 
 [libsass]: https://sass-lang.com/libsass
 [prebuilt binaries]: https://github.com/sass/dart-sass/releases/latest
 [scoop.sh]: https://scoop.sh/#/apps?q=sass
+[nixos.org]: [https://scoop.sh/#/apps?q=sass](https://search.nixos.org/packages?channel=24.05&show=dart-sass&from=0&size=50&sort=relevance&type=packages&query=sass)
 [site configuration]: /getting-started/configuration/#configure-build
 [snap package]: /installation/linux/#snap
 [snapcraft.io]: https://snapcraft.io/dart-sass

--- a/content/en/functions/resources/ToCSS.md
+++ b/content/en/functions/resources/ToCSS.md
@@ -117,6 +117,7 @@ Linux|Snap|[snapcraft.io]|`sudo snap install dart-sass`
 macOS|Homebrew|[brew.sh]|`brew install sass/sass/sass`
 Windows|Chocolatey|[chocolatey.org]|`choco install sass`
 Windows|Scoop|[scoop.sh]|`scoop install sass`
+Nixos|Nix|[nixos.org]|`nix-env -iA nixos.dart-sass`
 
 You may also install [prebuilt binaries] for Linux, macOS, and Windows.
 

--- a/content/en/functions/resources/ToCSS.md
+++ b/content/en/functions/resources/ToCSS.md
@@ -225,7 +225,7 @@ If you build Hugo from source and run `mage test -v`, the test will fail if you 
 [libsass]: https://sass-lang.com/libsass
 [prebuilt binaries]: https://github.com/sass/dart-sass/releases/latest
 [scoop.sh]: https://scoop.sh/#/apps?q=sass
-[nixos.org]: [https://scoop.sh/#/apps?q=sass](https://search.nixos.org/packages?channel=24.05&show=dart-sass&from=0&size=50&sort=relevance&type=packages&query=sass)
+[nixos.org]: https://search.nixos.org/packages?channel=24.05&show=dart-sass&from=0&size=50&sort=relevance&type=packages&query=sass
 [site configuration]: /getting-started/configuration/#configure-build
 [snap package]: /installation/linux/#snap
 [snapcraft.io]: https://snapcraft.io/dart-sass


### PR DESCRIPTION
The package link : https://search.nixos.org/packages?channel=24.05&show=dart-sass&from=0&size=50&sort=relevance&type=packages&query=sass