### PR TITLE
docs: Make section def more useful

### DIFF
--- a/content/en/methods/page/_common/definition-of-section.md
+++ b/content/en/methods/page/_common/definition-of-section.md
@@ -2,4 +2,4 @@
 # Do not remove front matter.
 ---
 
-A _section_ is a top-level content directory, or any content directory with an&nbsp;_index.md&nbsp;file.
+A [_section_](/content-management/sections/) is a top-level content directory, or any content directory with an&nbsp;[`_index.md`&nbsp;file](/troubleshooting/faq/#what-is-the-difference-between-an-indexmd-file-and-an-_indexmd-file).


### PR DESCRIPTION
Note that this section definition clearly overlaps with the glossary entry for ["section"](https://gohugo.io/getting-started/glossary/#section). If we would convert the glossary terms to structured data, we could actually re-use them at various places. What do you think @jmooring? I can open a separate issue if you agree.