### PR TITLE
Fix typos found with codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,13 @@
+# Config file for codespell.
+# https://github.com/codespell-project/codespell#using-a-config-file
+
+[codespell]
+
+# Comma separated list of dirs to be skipped.
+skip = _vendor,.cspell.json
+
+# Comma separated list of words to be ignored. Words must be lowercased.
+ignore-words-list = abl,edn,te,ue,trys,januar,womens,crossreferences
+
+# Check file names as well.
+check-filenames = true

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -20,3 +20,8 @@ jobs:
           incremental_files_only: true
           inline: warning
           strict: false
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          check_filenames: true
+          check_hidden: true
+          # by default, codespell uses configuration from the .codespellrc

--- a/content/en/content-management/shortcodes.md
+++ b/content/en/content-management/shortcodes.md
@@ -236,6 +236,6 @@ Shortcodes (excluding [inline](#inline) shortcodes) can be nested, creating pare
 {{</* /gallery */>}}
 {{< /code >}}
 
-The [shortcode templates][nesting] section provides a detailed explantion and examples.
+The [shortcode templates][nesting] section provides a detailed explanation and examples.
 
 [nesting]: /templates/shortcode/#nesting

--- a/content/en/functions/js/Babel.md
+++ b/content/en/functions/js/Babel.md
@@ -103,4 +103,4 @@ module.exports = {
 
 ###### verbose
 
-(`bool`) Whether to enable verbose logging. Default is `fasle`
+(`bool`) Whether to enable verbose logging. Default is `false`

--- a/content/en/functions/resources/PostProcess.md
+++ b/content/en/functions/resources/PostProcess.md
@@ -13,7 +13,7 @@ action:
 toc: true
 ---
 
-The `resources.PostProces`s function delays resource transformation steps until the build is complete, primarily for tasks like removing unused CSS rules.
+The `resources.PostProcess`s function delays resource transformation steps until the build is complete, primarily for tasks like removing unused CSS rules.
 
 ## Example
 

--- a/content/en/functions/resources/PostProcess.md
+++ b/content/en/functions/resources/PostProcess.md
@@ -13,7 +13,7 @@ action:
 toc: true
 ---
 
-The `resources.PostProcess`s function delays resource transformation steps until the build is complete, primarily for tasks like removing unused CSS rules.
+The `resources.PostProcess` function delays resource transformation steps until the build is complete, primarily for tasks like removing unused CSS rules.
 
 ## Example
 

--- a/content/en/shortcodes/vimeo.md
+++ b/content/en/shortcodes/vimeo.md
@@ -46,7 +46,7 @@ id
 title
 : (`string`) The `title` attribute of the `iframe` element.
 
-If you proivde a `class` or `title` you must use a named parameter for the `id`.
+If you provide a `class` or `title` you must use a named parameter for the `id`.
 
 ```text
 {{</* vimeo id=55073825 class="foo bar" title="My Video" */>}}

--- a/content/en/templates/embedded.md
+++ b/content/en/templates/embedded.md
@@ -106,7 +106,7 @@ disable
 : (`bool`) Whether to disable the template. Default is `false`.
 
 respectDoNotTrack
-: (`bool`) Whether to respect the brower's "do not track" setting. Default is `false`.
+: (`bool`) Whether to respect the browser's "do not track" setting. Default is `false`.
 
 ## Open Graph
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -282,7 +282,7 @@ either of these shortcodes in conjunction with this render hook.
     {{- errorf "The %q render hook was unable to find %s: see %s" $renderHookName $glossaryPath $contentPath }}
   {{- end }}
 
-  {{- /* Theres a better way to handle this, but it works for now. */}}
+  {{- /* There's a better way to handle this, but it works for now. */}}
   {{- $cheating := dict
     "chaining" "chain"
     "localize" "localization"


### PR DESCRIPTION
This PR fixes typos and integrates [`codespell`](https://github.com/codespell-project/codespell) into CI.