### PR TITLE
Update configuration-markup.md: remove ambiguity

### DIFF
--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -104,10 +104,10 @@ Superscript|`1^st^`|`1<sup>st</sup>`
 [subscript]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
 [superscript]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
 
-To avoid a conflict when enabling the Hugo Goldmark Extras subscript extension, if you want to render subscript and strikethrough text concurrently you must:
+To avoid a conflict when enabling the Hugo Goldmark Extras "subscript" extension, if you want to render subscript and strikethrough text concurrently you must:
 
-1. Disable the Goldmark strikethrough extension
-1. Enable the Hugo Goldmark Extras delete extension
+1. Disable the Goldmark "strikethrough" extension
+1. Enable the Hugo Goldmark Extras "delete" extension
 
 For example:
 
@@ -126,7 +126,7 @@ enable = true
 
 {{< new-in 0.122.0 />}}
 
-Enable the passthrough extension to include mathematical equations and expressions in Markdown using LaTeX markup. See [mathematics in Markdown] for details.
+Enable the "passthrough" extension to include mathematical equations and expressions in Markdown using LaTeX markup. See [mathematics in Markdown] for details.
 
 [mathematics in Markdown]: content-management/mathematics/
 


### PR DESCRIPTION
Add double quotes around the names, otherwise I read it twice as a verb there.

---

Although a [couple paragraphs above](https://github.com/vadcx/hugoDocs/blob/367d3a7ab8b11a5228b4eb317f11002dbc48f77d/content/en/getting-started/configuration-markup.md?plain=1#L61) the names are capitalized (if you care about consistency) I decided not to change them, because capitalization is appropriate there.