### PR TITLE
Fix: Typo

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -140,7 +140,7 @@ When building the English site:
 {{ site.Params.subtitle }} --> Reference, Tutorials, and Explanations
 ```
 
-When building the English site:
+When building the German site:
 
 ```go-html-template
 {{ site.Params.color }} --> blue


### PR DESCRIPTION
Change "English" to "German" when referring to the German version of the site.