### PR TITLE
theme: Display short command on commands list

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,12 @@
           {{ end }}
           <p
             class="text-black dark:text-gray-100 leading-6 text-sm md:text-base three-lines-ellipsis">
-            {{ (or .Params.description .Summary) | plainify | safeHTML }}
+            {{ if and (eq .Section "commands") .IsPage }}
+              {{ $simpleCobraCommandShort := .RawContent | strings.ReplaceRE `(?s)^##\s.+?\n\n(.+?)\n\n.*` "$1" }}
+              {{ printf "%s." $simpleCobraCommandShort }}
+            {{ else }}
+              {{ (or .Params.description .Summary) | plainify | safeHTML }}
+            {{ end }}
           </p>
         </a>
       {{ end }}


### PR DESCRIPTION
Admittedly this is a hack. To do this right we would need a breaking upstream change to `github.com/spf13/cobra`, specifically the `filePrepender` callback function:

https://github.com/spf13/cobra/blob/680936a2200be363c61feda8cd29287f0726a48c/doc/md_docs.go#L131-L158

Before this change:

![image](https://github.com/user-attachments/assets/7d27470d-0a80-43cb-a667-ddf8815f87a6)

After this change:

![image](https://github.com/user-attachments/assets/a8164f54-28ef-4cb6-8145-b36008bfd8e6)

