### PR TITLE
Add Prettier and config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Ignore all SVG icons.
+**/icons.html
+# These are whitespace sensitive.
+layouts/_default/_markup/render-code*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,21 @@
+{
+  "plugins": ["prettier-plugin-go-template"],
+  "overrides": [
+    {
+      "files": ["*.html"],
+      "options": {
+        "parser": "go-template",
+        "goTemplateBracketSpacing": true,
+        "bracketSameLine": true
+      }
+    },
+    {
+      "files": ["*.js", "*.ts"],
+      "options": {
+        "useTabs": true,
+        "printWidth": 120,
+        "singleQuote": true
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "devDependencies": {
     "@tailwindcss/cli": "^4.0.0",
     "@tailwindcss/typography": "^0.5.15",
+    "prettier": "^3.5.0",
+    "prettier-plugin-go-template": "^0.0.15",
     "tailwindcss": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
One thing I like about Go that it's no discussing about formatting.

But when multiple people contribute to the same Go templates, there will eventually be conflicts coming from different formatting.

`prettier` has its issues, but I don't think there are any better option for Go/Hugo templates, but I open this PR so we can discuss and come to an agreement.

