### PR TITLE
dev: Add prettier-plugin-void-html

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,8 @@
 {
-  "plugins": ["prettier-plugin-go-template"],
+  "plugins": [
+    "prettier-plugin-go-template",
+    "@awmottaz/prettier-plugin-void-html"
+  ],
   "overrides": [
     {
       "files": ["*.html"],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
+    "@awmottaz/prettier-plugin-void-html": "^1.8.0",
     "@tailwindcss/cli": "^4.0.0",
     "@tailwindcss/typography": "^0.5.15",
     "prettier": "^3.5.0",


### PR DESCRIPTION
This is a Prettier plugin to format void HTML elements using the void tag syntax instead of self-closing syntax. Additionally, if self-closing syntax is used on non-void elements, then they will be "unwrapped" so that both the opening and closing tags are present.

Justification: things like this generate validation "info" messages:

```
<img src="foo" />
```

![image](https://github.com/user-attachments/assets/c7bf5890-5716-4710-a342-12287ca5f2c9)

<https://html.spec.whatwg.org/multipage/syntax.html#start-tags>

> For such void elements, it [the trailing slash] should be used only with caution — especially since, if directly preceded by an [unquoted attribute value](https://html.spec.whatwg.org/multipage/syntax.html#unquoted), it becomes part of the attribute value rather than being discarded by the parser.
