### PR TITLE
Add warning for AVIF image format

### DIFF
--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -108,6 +108,10 @@ The `image` resource implements the  [`Process`],  [`Resize`], [`Fit`], [`Fill`]
 Metadata (EXIF, IPTC, XMP, etc.) is not preserved during image transformation. Use the `Exif` method with the _original_ image to extract EXIF metadata from JPEG, PNG, TIFF, and WebP images.
 {{% /note %}}
 
+{{% warning %}}
+AVIF image format is not supported.
+{{% /warning %}}
+
 ### Process
 
 {{< new-in 0.119.0 />}}

--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -108,9 +108,9 @@ The `image` resource implements the  [`Process`],  [`Resize`], [`Fit`], [`Fill`]
 Metadata (EXIF, IPTC, XMP, etc.) is not preserved during image transformation. Use the `Exif` method with the _original_ image to extract EXIF metadata from JPEG, PNG, TIFF, and WebP images.
 {{% /note %}}
 
-{{% warning %}}
-AVIF image format is not supported.
-{{% /warning %}}
+{{% note %}}
+Warning: AVIF image format is not supported.
+{{% /note %}}
 
 ### Process
 


### PR DESCRIPTION
Nowhere in the doc the absence of AVIF processing is stated.