### PR TITLE
content: Updates for v0.144.0

### DIFF
--- a/content/en/content-management/mathematics.md
+++ b/content/en/content-management/mathematics.md
@@ -230,8 +230,6 @@ To use KaTeX instead of MathJax, replace the partial template from [Step 2] with
 
 The delimiters above must match the delimiters in your site configuration.
 
-<!--
-
 ## Chemistry
 
 Both MathJax and KaTeX provide support for chemical equations. For example:
@@ -243,8 +241,6 @@ $$C_p[\ce{H2O(l)}] = \pu{75.3 J // mol K}$$
 $$C_p[\ce{H2O(l)}] = \pu{75.3 J // mol K}$$
 
 As shown in [Step 2] above, MathJax supports chemical equations without additional configuration. To add chemistry support to KaTeX, enable the mhchem extension as described in the KaTeX [documentation](https://katex.org/docs/libs).
-
--->
 
 [KaTeX]: https://katex.org/
 [LaTeX]: https://www.latex-project.org/

--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -306,16 +306,34 @@ Use these tokens when defining the URL pattern. You can also use these tokens wh
 : The content's sections hierarchy. You can use a selection of the sections using _slice syntax_: `:sections[1:]` includes all but the first, `:sections[:last]` includes all but the last, `:sections[last]` includes only the last, `:sections[1:2]` includes section 2 and 3. Note that this slice access will not throw any out-of-bounds errors, so you don't have to be exact.
 
 `:title`
-: The title as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.
+: The `title` as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.
 
 `:slug`
-: The slug as defined in front matter, else the title as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.
+: The `slug` as defined in front matter, else the `title` as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.
 
 `:filename`
 : The content's file name without extension, applicable to the `page` page kind.
 
+  {{< deprecated-in v0.144.0 >}}
+  The `:filename` token has been  deprecated. Use `:contentbasename` instead.
+  {{< /deprecated-in >}}
+
 `:slugorfilename`
-: The slug as defined in front matter, else the content's file name without extension, applicable to the `page` page kind.
+: The `slug` as defined in front matter, else the content's file name without extension, applicable to the `page` page kind.
+
+  {{< deprecated-in v0.144.0 >}}
+  The `:slugorfilename` token has been deprecated. Use `:slugorcontentbasename` instead.
+  {{< /deprecated-in >}}
+
+`:contentbasename`
+: {{< new-in 0.144.0 />}}
+: The [content base name].
+
+[content base name]: /methods/page/file/#contentbasename
+
+`:slugorcontentbasename`
+: {{< new-in 0.144.0 />}}
+: The `slug` as defined in front matter, else the [content base name].
 
 For time-related values, you can also use the layout string components defined in Go's [time package]. For example:
 

--- a/content/en/functions/transform/ToMath.md
+++ b/content/en/functions/transform/ToMath.md
@@ -159,3 +159,17 @@ These are block equations:
 
 $$a^*=x-b^*$$
 {{< /code >}}
+
+## Chemistry
+
+{{< new-in 0.144.0 />}}
+
+You can also use the `transform.ToMath` function to render chemical equations, leveraging the `\ce` and `\pu` functions from the [mhchem] package.
+
+[mhchem]: https://mhchem.github.io/MathJax-mhchem/
+
+```text
+$$C_p[\ce{H2O(l)}] = \pu{75.3 J // mol K}$$
+```
+
+$$C_p[\ce{H2O(l)}] = \pu{75.3 J // mol K}$$

--- a/content/en/getting-started/configuration-markup.md
+++ b/content/en/getting-started/configuration-markup.md
@@ -172,9 +172,17 @@ With multilingual single-host sites, setting this parameter to `false` will enab
 
 [image render hook]: /render-hooks/images/
 
-###### parser.autoHeadingIDType
+###### parser.autoDefinitionTermID
 
-(`string`) The strategy used to automatically generate heading `id` attributes, one of `github`, `github-ascii` or `blackfriday`.
+(`bool`) Whether to automatically add `id` attributes to description list terms (i.e., `dt` elements).
+
+###### parser.autoHeadingID
+
+(`bool`) Whether to automatically add `id` attributes to headings (i.e., `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` elements).
+
+###### parser.autoIDType
+
+(`string`) The strategy used to automatically generate `id` attributes, one of `github`, `github-ascii` or `blackfriday`.
 
 - `github` produces GitHub-compatible `id` attributes
 - `github-ascii` drops any non-ASCII characters after accent normalization

--- a/hugo.toml
+++ b/hugo.toml
@@ -59,16 +59,6 @@ disableAliases = true
         notAlternative = true
 
 [markup]
-    [markup.highlight]
-        style              = 'solarized-dark'
-        lineNumbersInTable = true
-        noClasses          = false
-        wrapperClass       = 'highlight not-prose'
-
-    [markup.goldmark.renderer]
-        hardWraps = false
-        unsafe    = false
-        xhtml     = false
 
     [markup.goldmark.extensions]
         definitionList = true
@@ -94,6 +84,17 @@ disableAliases = true
         [markup.goldmark.parser.attribute]
             block = true
             title = true
+
+    [markup.goldmark.renderer]
+        hardWraps = false
+        unsafe    = false
+        xhtml     = false
+
+    [markup.highlight]
+        style              = 'solarized-dark'
+        lineNumbersInTable = true
+        noClasses          = false
+        wrapperClass       = 'highlight not-prose'
 
 [mediaTypes]
     [mediaTypes."text/netlify"]


### PR DESCRIPTION
- [x] New permalink/url tokens
- [x] Uncomment LaTeX chemistry example
- [x] Add LaTeX chemistry example to the `transform.ToMath` page
- [x] Change `parser.autoHeadingIDType` to `parser.autoIDType`
- [x] Describe `parser.autoDefinitionTermID` and `parser.autoHeadingID`
- [x] Enable `parser.autoDefinitionTermID` in site configuration
- [x] Update `data/docs.yaml`

This PR will fail to build until we release v0.144.0.