### PR TITLE
fix: add conflict warning on relative url

### DIFF
--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -397,7 +397,8 @@ canonifyURLs = true
 #### Relative URLs
 
 {{< note >}}
-Do not enable this option unless you are creating a serverless site, navigable via the file system.
+Do not enable this option unless you are creating a serverless site, navigable via the file system. 
+This conflicts with `baseURL`. Setting `baseURL` will override this setting.
 {{< /note >}}
 
 If enabled, Hugo performs a search and replace _after_ it renders the page. It searches for site-relative URLs (those with a leading slash) associated with `action`, `href`, `src`, `srcset`, and `url` attributes. It then transforms the URL to be relative to the current page.


### PR DESCRIPTION
Change:
- Added a warning message that `relativeURLs` setting will conflict with `baseURL`

Reason:
- When `relativeURLs` and `baseURL` is set at the same time, `relativeURLs` will not go in effect and `baseURL` will still be used.
- Discovered this issue when trying to deploy hugo in Cloudflare Pages where relative URL not showing when using custom domain (i.e. Even with `relativeURLs` set to `true`, if there is a `baseURL` config, when I open my custom domain (CNAME to the Cloudflare Pages), the links are still showing the Cloudflare pages one.) 