### PR TITLE
Update index.md

### DIFF
--- a/content/en/hosting-and-deployment/hosting-on-github/index.md
+++ b/content/en/hosting-and-deployment/hosting-on-github/index.md
@@ -59,7 +59,7 @@ Step 5
 
 ```text
 mkdir -p .github/workflows
-touch hugo.yaml
+touch .gihub/workflows/hugo.yaml
 ```
 
 Step 6


### PR DESCRIPTION
fixes the code snippet in creation of the hugo.yaml file. 

The code block when copied as a whole and run creates a file in the `pwd` and not in `.github/workflows/`. Another way could be to `cd` to `.github/workflows/` and `touch hugo.yaml` but feels more tedious