### PR TITLE
Update support list of js.Build / esbuild with more recent targets

### DIFF
--- a/content/en/functions/js/_common/options.md
+++ b/content/en/functions/js/_common/options.md
@@ -54,7 +54,7 @@ shims
   ```
 
 target
-: (`string`) The language target. One of: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021`, `es2022`,`es2023`, or `esnext`. Default is `esnext`.
+: (`string`) The language target. One of: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021`, `es2022`, `es2023`, `es2024`, or `esnext`. Default is `esnext`.
 
 platform
 : {{< new-in 0.140.0 />}}

--- a/content/en/functions/js/_common/options.md
+++ b/content/en/functions/js/_common/options.md
@@ -54,7 +54,7 @@ shims
   ```
 
 target
-: (`string`) The language target. One of: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020` or `esnext`. Default is `esnext`.
+: (`string`) The language target. One of: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021`, `es2022`,`es2023`, or `esnext`. Default is `esnext`.
 
 platform
 : {{< new-in 0.140.0 />}}


### PR DESCRIPTION
This commit added support for up to es2023, but the docs need to be updated to reflect that

https://github.com/gohugoio/hugo/commit/1cdd3d0a9e4a988fb505a1bcbb3e7692b64bef55#diff-5223fc9312c6fe5c4ef688ea1007031d660142fb76b601e2c75bbff9dbb814e7

And it looks like in the file, it now supports up to es2024 https://github.com/gohugoio/hugo/blob/master/internal/js/esbuild/options.go

Which was added here:
https://github.com/gohugoio/hugo/pull/12641/files#diff-7cdb1b21088d3cf238702166ae0ebc064f18894c9cc7b065de47b954946e4044