### PR TITLE
Make code header text selectable

### DIFF
--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -15,8 +15,7 @@
       {{- $codeLang = cond (eq $ext "html") "go-html-template" $ext }}
     {{- end }}
     <div
-      class="san-serif text-sm inline-block leading-none pl-2 py-3 bg-gray-300 dark:bg-slate-700 dark: w-full select-none
-">
+      class="san-serif text-sm inline-block leading-none pl-2 py-3 bg-gray-300 dark:bg-slate-700 dark: w-full">
       {{ . }}
     </div>
   {{- end -}}

--- a/layouts/shortcodes/code.html
+++ b/layouts/shortcodes/code.html
@@ -21,7 +21,7 @@
   {{- end -}}
 
 
-  <div class="" x-ref="code">
+  <div x-ref="code">
     {{ $inner := trim .Inner "\n" | safeHTML }}
     {{ if .Get "nocode" }}
       {{ $inner }}


### PR DESCRIPTION
It's annoying that I can't copy the file path `layouts/_default/_markup/render-heading.html` from the code header in https://gohugo.io/render-hooks/headings/.