### PR TITLE
theme: Implement related content tooling

### DIFF
--- a/content/en/functions/math/Acos.md
+++ b/content/en/functions/math/Acos.md
@@ -2,7 +2,7 @@
 title: math.Acos
 description: Returns the arccosine, in radians, of the given number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Asin.md
+++ b/content/en/functions/math/Asin.md
@@ -2,7 +2,7 @@
 title: math.Asin
 description: Returns the arcsine, in radians, of the given number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Atan.md
+++ b/content/en/functions/math/Atan.md
@@ -2,7 +2,7 @@
 title: math.Atan
 description: Returns the arctangent, in radians, of the given number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Atan2.md
+++ b/content/en/functions/math/Atan2.md
@@ -2,7 +2,7 @@
 title: math.Atan2
 description: Returns the arctangent, in radians, of the given number pair, determining the correct quadrant from their signs.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Cos.md
+++ b/content/en/functions/math/Cos.md
@@ -2,7 +2,7 @@
 title: math.Cos
 description: Returns the cosine of the given radian number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Pi.md
+++ b/content/en/functions/math/Pi.md
@@ -2,7 +2,7 @@
 title: math.Pi
 description: Returns the mathematical constant pi.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Sin.md
+++ b/content/en/functions/math/Sin.md
@@ -2,7 +2,7 @@
 title: math.Sin
 description: Returns the sine of the given radian number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/Tan.md
+++ b/content/en/functions/math/Tan.md
@@ -2,7 +2,7 @@
 title: math.Tan
 description: Returns the tangent of the given radian number.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/ToDegrees.md
+++ b/content/en/functions/math/ToDegrees.md
@@ -2,7 +2,7 @@
 title: math.ToDegrees
 description: ToDegrees converts radians into degrees.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/math/ToRadians.md
+++ b/content/en/functions/math/ToRadians.md
@@ -2,7 +2,7 @@
 title: math.ToRadians
 description: ToRadians converts degrees into radians.
 categories: []
-keywords: []
+keywords: [trigonometry]
 params:
   functions_and_methods:
     aliases: []

--- a/data/keywords.yaml
+++ b/data/keywords.yaml
@@ -1,0 +1,12 @@
+# We use the front matter keywords field to determine related content. To
+# ensure consistency, during site build we validate each keyword against the
+# entries in data/keywords.yaml.
+
+# As of March 5, 2025, this feature is experimental, pending usability
+# assessment. We anticipate that the number of additions to data/keywords.yaml
+# will decrease over time, though the initial implementation will require some
+# effort.
+
+- menu
+- resource
+- trigonometry

--- a/hugo.toml
+++ b/hugo.toml
@@ -36,7 +36,7 @@ disableAliases = true
         path = '{/news/**}'
 
 [frontmatter]
-    date        = ['date'] # do not add publishdate; it will affect page sorting
+    date        = ['date']                                   # do not add publishdate; it will affect page sorting
     expiryDate  = ['expirydate']
     lastmod     = [':git', 'lastmod', 'publishdate', 'date']
     publishDate = ['publishdate', 'date']
@@ -109,6 +109,14 @@ disableAliases = true
     ghrepo      = "https://github.com/gohugoio/hugoDocs/"
     [params.render_hooks.link]
         errorLevel = 'warning' # ignore (default), warning, or error (fails the build)
+
+[related]
+    includeNewer = true
+    threshold    = 80
+    toLower      = true
+    [[related.indices]]
+        name = 'keywords'
+        weight = 1
 
 [security]
     [security.funcs]

--- a/layouts/partials/helpers/validation/validate-keywords.html
+++ b/layouts/partials/helpers/validation/validate-keywords.html
@@ -1,0 +1,22 @@
+{{/* prettier-ignore-start */ -}}
+{{- /*
+We use the front matter keywords field to determine related content. To ensure
+consistency, during site build we validate each keyword against the entries in
+data/keywords.yaml.
+
+As of March 5, 2025, this feature is experimental, pending usability
+assessment. We anticipate that the number of additions to data/keywords.yaml
+will decrease over time, though the initial implementation will require some
+effort.
+*/}}
+{{/* prettier-ignore-end */ -}}
+{{- $t := debug.Timer "validateKeywords" }}
+{{- $allowedKeywords := collections.Apply site.Data.keywords "strings.ToLower" "." }}
+{{- range $p := site.Pages }}
+  {{- range .Params.keywords }}
+    {{- if not (in $allowedKeywords (lower .)) }}
+      {{- warnf "The word or phrase %q is not in the keywords data file. See %s." . $p.Page.String }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $t.Stop }}

--- a/layouts/partials/layouts/hooks/body-end.html
+++ b/layouts/partials/layouts/hooks/body-end.html
@@ -1,1 +1,3 @@
-{{/* Empty for now */}}
+{{- if .IsHome }}
+  {{- partial "helpers/validation/validate-keywords.html" }}
+{{- end }}


### PR DESCRIPTION
1. Site configuration
2. Create keyword database (`data/keywords.yaml`)
3. Create keyword validation mechanism (warning not error)

We use the front matter `keywords` field to determine related content. To ensure consistency, during site build we validate each keyword against the entries in `data/keywords.yaml.`

This feature is experimental, and easily removed, pending usability assessment. We anticipate that the number of additions to `data/keywords.yaml` will decrease over time, though the initial implementation will require some effort.

I do not know what effect validation will have on build time, but I suspect it's negligible. I wrapped a debug timer around the partial.

---

As an example, I added the keyword "trigonometry" to the keywords data file and to all the trigonometric  functions. See the "see also" panel in the side bar:

<https://deploy-preview-2969--gohugoio.netlify.app/functions/math/acos/>