### PR TITLE
content: Fix position of new-in badges

### DIFF
--- a/content/en/functions/collections/Where.md
+++ b/content/en/functions/collections/Where.md
@@ -87,7 +87,8 @@ Use any of the following logical operators:
 `intersect`
 : (`bool`) Reports whether the given field value (a slice) contains one or more elements in common with `VALUE`. See&nbsp;[details](/functions/collections/intersect).
 
-`like` {{< new-in 0.116.0 />}}
+`like`
+: {{< new-in 0.116.0 />}}
 : (`bool`) Reports whether the given field value matches the regular expression specified in `VALUE`. Use the `like` operator to compare `string` values. The `like` operator returns `false` when comparing other data types to the regular expression.
 
 {{< note >}}

--- a/content/en/functions/images/Text.md
+++ b/content/en/functions/images/Text.md
@@ -15,7 +15,7 @@ params:
 Although none of the options are required, at a minimum you will want to set the `size` to be some reasonable percentage of the image height.
 
 alignx
- {{< new-in 0.141.0 />}}
+: {{< new-in 0.141.0 />}}
 : (`string`) The horizontal alignment of the text relative to the horizontal offset, one of `left`, `center`, or `right`. Default is `left`.
 
 color
@@ -23,8 +23,6 @@ color
 
 font
 : (`resource.Resource`) The font can be a [global resource](g), a [page resource](g), or a [remote resource](g). Default is [Go Regular], a proportional sans-serif TrueType font.
-
-[Go Regular]: https://go.dev/blog/go-fonts#sans-serif
 
 linespacing
 : (`int`) The number of pixels between each line. For a line height of 1.4, set the `linespacing` to 0.4 multiplied by the `size`. Default is `2`.
@@ -37,6 +35,8 @@ x
 
 y
 : (`int`) The vertical offset, in pixels, relative to the top of the image. Default is `10`.
+
+[Go Regular]: https://go.dev/blog/go-fonts#sans-serif
 
 ## Usage
 

--- a/content/en/functions/transform/Unmarshal.md
+++ b/content/en/functions/transform/Unmarshal.md
@@ -127,7 +127,8 @@ delimiter
 comment
 : (`string`) The comment character used in the CSV. If set, lines beginning with the comment character without preceding whitespace are ignored.
 
-lazyQuotes {{< new-in 0.122.0 />}}
+lazyQuotes
+: {{< new-in 0.122.0 />}}
 : (`bool`) Whether to allow a quote in an unquoted field, or to allow a non-doubled quote in a quoted field. Default is `false`.
 
 ```go-html-template

--- a/content/en/shortcodes/youtube.md
+++ b/content/en/shortcodes/youtube.md
@@ -35,38 +35,38 @@ id
 : (`string`) The video `id`. Optional if the `id` is provided as a positional argument as shown in the example above.
 
 allowFullScreen
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`bool`) Whether the `iframe` element can activate full screen mode. Default is `true`.
 
 autoplay
- {{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to automatically play the video. Forces `mute` to `true`. Default is `false`.
 
 class
 : (`string`) The `class` attribute of the wrapping `div` element. When specified, removes the `style` attributes from the `iframe` element and its wrapping `div` element.
 
 controls
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to display the video controls. Default is `true`.
 
 end
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`int`) The time, measured in seconds from the start of the video, when the player should stop playing the video.
 
 loading
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`string`) The loading attribute of the `iframe` element, either `eager` or `lazy`. Default is `eager`.
 
 loop
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to indefinitely repeat the video. Ignores the `start` and `end` arguments after the first play. Default is `false`.
 
 mute
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to mute the video. Always `true` when `autoplay` is `true`. Default is `false`.
 
 start
-{{< new-in 0.125.0 />}}
+: {{< new-in 0.125.0 />}}
 : (`int`) The time, measured in seconds from the start of the video, when the player should start playing the video.
 
 title


### PR DESCRIPTION
When inserting a new-in badge into a description list, place the badge like this:

term
: {{< new-in 0.999.0 >}}
: description

If you place the badge adjacent to the term, or beneath the term without a leading colon, the id attribute will contain the string hahahugo.