### PR TITLE
feat: use cache when deploy on github pages

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -120,6 +120,14 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Restore resources
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            resources
+          key: ${{ runner.os }}-resources-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-resources-
       - name: Build with Hugo
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
@@ -130,6 +138,12 @@ jobs:
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Save resources
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            resources
+          key: ${{ runner.os }}-resources-${{ github.run_id }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
I think use GitHub Action Cache to cache `resources` directory is a good practice when deploy on GitHub Pages. It helps build faster, especially when we have many resource like images or scss that need to be processed.