### PR TITLE
theme: Fix inline partial refs

### DIFF
--- a/layouts/partials/layouts/header/qr.html
+++ b/layouts/partials/layouts/header/qr.html
@@ -1,9 +1,9 @@
 {{ $t := debug.Timer "qr" }}
-{{ $qr := partial "partials/_inline/qr" (dict
+{{ $qr := partial "_inline/qr" (dict
   "page" $
   "img_class" "w-10 bg-white view-transition-qr" )
 }}
-{{ $qrBig := partial "partials/_inline/qr" (dict "page" $ "img_class" "w-64 p-4") }}
+{{ $qrBig := partial "_inline/qr" (dict "page" $ "img_class" "w-64 p-4") }}
 {{ $t.Stop }}
 <div
   class="hidden lg:block cursor-pointer outline-2 hover:outline-3 outline-blue-500 w-10 h-10">


### PR DESCRIPTION
I had a head scratching moment as to why this failed in my re-implementation of template handling in Hugo, but this isn't how we can have it behave going forward.
