### PR TITLE
theme: Add horizontal border before content

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,14 +49,16 @@
       {{ $t.Stop }}
 
       {{ if .Params.functions_and_methods.signatures }}
-        <div class="mb-4 not-prose">
+        <div class="mb-6 not-prose">
           {{- partial "docs/functions-signatures.html" . -}}
           {{- partial "docs/functions-return-type.html" . -}}
           {{- partial "docs/functions-aliases.html" . -}}
         </div>
       {{ end }}
       {{ $t := debug.Timer "single.content" }}
-      {{ .Content }}
+      <div class="border-t-1 border-gray-400 dark:border-gray-600 pt-1">
+        {{ .Content }}
+      </div>
       {{ $t.Stop }}
       {{ $t := debug.Timer "single.page-edit" }}
       {{ partial "layouts/page-edit.html" . }}


### PR DESCRIPTION
I really don't care how it's styled, but I think we need some visual separation.

#### Examples

- [about/features](https://deploy-preview-2985--gohugoio.netlify.app/methods/page/params/)
- [templates/introduction](https://deploy-preview-2985--gohugoio.netlify.app/templates/introduction/)

#### Before

![image](https://github.com/user-attachments/assets/3950f5c4-da10-46be-aa3f-726f520c842e)


#### After

![image](https://github.com/user-attachments/assets/e268131d-6a4c-4b9e-9a6b-db00b04f4143)

