### PR TITLE
theme: Include section pages in related content

### DIFF
--- a/layouts/partials/layouts/related.html
+++ b/layouts/partials/layouts/related.html
@@ -1,6 +1,6 @@
 {{- $heading := "See also" }}
-{{- $related := site.RegularPages.Related . }}
-{{- $related = $related | complement .CurrentSection.RegularPages | first 7 }}
+{{- $related := site.Pages.Related . }}
+{{- $related = $related | complement .CurrentSection.Pages | first 7 }}
 
 {{- with $related }}
   {{ $.Store.Set "hasRelated" true }}


### PR DESCRIPTION
There are cases where it makes sense to relate a section page to a regular page:

`content/en/docs/concepts/shortcodes.md`
`content/en/docs/guides/embedded-shortcodes/_index.md`
