### PR TITLE
content: add documentation for Timer.Stop

### DIFF
--- a/content/en/functions/debug/Timer.md
+++ b/content/en/functions/debug/Timer.md
@@ -2,12 +2,12 @@
 title: debug.Timer
 description: Creates a named timer that reports elapsed time to the console.
 categories: []
-keywords: []
+keywords: ["timer"]
 params:
   functions_and_methods:
     aliases: []
     returnType: debug.Timer
-    signatures: [debug.Timer NAME] 
+    signatures: [debug.Timer NAME]
 ---
 
 {{< new-in 0.120.0 />}}
@@ -34,4 +34,48 @@ The results are displayed in the console at the end of the build. You can have a
 
 ```text
 INFO  timer:  name TestSqrt count 1002 duration 2.496017496s average 2.491035ms median 2.282291ms
+```
+
+## Example - Named Timers
+
+All Timers with the same NAME are summed up to one output line providing the count and some additional measures.
+
+```go-html-template { hl_Lines=3 }
+{{ $t1 := debug.Timer "Outer" }}
+{{ range seq 2000 }}
+  {{ $t2 := debug.Timer "Inner" }}
+  {{ range seq 1000}}
+    {{ $f := math.Sqrt . }}
+  {{ end }}
+  {{ $t2.Stop }}
+{{ end }}
+{{ /* Timer $T1 "Outer" will be stopped at end of build */ }}
+```
+
+will produce the following result.
+
+````text { hl_Lines=1 }
+INFO  timer:  name Inner count 2000 duration 3.1275511s average 1.563775ms median 0s
+INFO  timer:  name Outer count 1 duration 3.9826673s average 3.9826673s median 0s```
+````
+
+> [!Note]
+> You don't have to explicitly stop a timer. It is automatically stopped when a new timer is created with the same name.
+
+## Example - Unique names
+
+To have each timer reporting it's execution time use unique names for example with math.Counter
+
+```go-html-template { hl_Lines=2}
+   {{ range seq 3 }}
+      {{ $t1 := debug.Timer (printf "Run %d" math.Counter) }}
+      {{ $f := math.Sqrt 4000 }}
+      {{ $t1.Stop }}
+   {{ end }}
+```
+
+```text
+INFO  timer:  name Run 2 count 1 duration 3.1216ms average 3.1216ms median 3.1216ms
+INFO  timer:  name Run 3 count 1 duration 3.1803ms average 3.1803ms median 3.1803ms
+INFO  timer:  name Run 1 count 1 duration 5.8833ms average 5.8833ms median 5.8833ms
 ```

--- a/content/en/methods/timer/Stop.md
+++ b/content/en/methods/timer/Stop.md
@@ -1,0 +1,32 @@
+---
+title: Stop
+description: Stops the timer.
+categories: []
+keywords: ["timer"]
+action:
+  related:
+    - functions/debug/Timer
+  signatures: [timer.Stop]
+---
+
+Stop a timer by explicitly calling it's `Stop` method.
+
+Although timers are stopped at the end of a build you sometimes want to explicitly stop it.
+
+```go-html-template {hl_Lines="5"}
+{{ $t1 := debug.Timer "Stopped" }}
+  {{ range seq 2000 }}
+      {{ $f := math.Sqrt . }}
+  {{ end }}
+  {{ $t1.Stop }}
+  {{ range seq 2000 }}
+      {{ $f := math.Sqrt . }}
+  {{ end }}
+{{ end }}
+```
+
+Here the timer is stopped after the first inner range. That way the rest of the code is not included in the timing report
+
+```go-html-template
+INFO  timer:  name Stopped count 1 duration 4.3045ms average 4.3045ms median 4.3045ms
+```

--- a/content/en/methods/timer/_index.md
+++ b/content/en/methods/timer/_index.md
@@ -1,0 +1,10 @@
+---
+title: Timer methods
+linkTitle: Timer
+description: Use these methods with debug.Timer values.
+categories: []
+keywords: []
+menu:
+  docs:
+    parent: methods
+---

--- a/data/keywords.yaml
+++ b/data/keywords.yaml
@@ -10,3 +10,4 @@
 - menu
 - resource
 - highlight
+- timer


### PR DESCRIPTION
implements: #3004 

- Add `debug.Timer` Method page
- Add Documentation of  `Stop` method
- Add keyword "timer" to data/keywords.yaml
- Add "timer" keyword to debug.Timer and timer.Stop

