### PR TITLE
content: Update GitHub Pages sample workflow

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -133,7 +133,9 @@ jobs:
         with:
           path: |
             ${{ runner.temp }}/hugo_cache
-          key: hugo
+          key: hugo-${{ github.run_id }}
+          restore-keys:
+            hugo-
       - name: Build with Hugo
         run: |
           hugo \


### PR DESCRIPTION
The cache created by actions/cache is immutable, so we need to create a new cache every run, then use a wildcard restore to restore the latest cache. Sigh.

GitHub will remove any cache entries that have not been accessed in over 7 days. There is no limit on the number of caches you can store, but the total size of all caches in a repository is limited to 10 GB. Once a repository has reached its maximum cache storage, the cache eviction policy will create space by deleting the oldest caches in the repository.

If you exceed the limit, GitHub will save the new cache but will begin evicting caches until the total size is less than the repository limit.

You can also manage the cache with the GitHub CLI.

    gh cache delete [<cache-id> | <cache-key> | --all] [flags]

Note that using `<cache-key>` does not need an exact match, which is a bit surprising: https://github.com/cli/cli/issues/10624.