### PR TITLE
content: Algolia DocSearch clarification

### DIFF
--- a/content/en/tools/search.md
+++ b/content/en/tools/search.md
@@ -44,7 +44,7 @@ A static website with a dynamic search function? Yes, Hugo provides an alternati
 ## Commercial
 
 [Algolia DocSearch](https://docsearch.algolia.com/)
-: Algolia DocSearch is free for public technical documentation sites and easy to set up. For other use cases, Algolia's Search API makes it easy to deliver a great search experience in your apps and websites. Algolia Search provides hosted full-text, numerical, faceted, and geolocalized search.
+: Algolia DocSearch is free for public technical documentation sites and easy to set up. For other use cases, [Algolia's Search API](https://www.algolia.com) makes it easy to deliver a great search experience in your apps and websites. Algolia Search provides hosted full-text, numerical, faceted, and geolocalized search.
 
 [Bonsai](https://www.bonsai.io)
 : Bonsai is a fully-managed hosted Elasticsearch service that is fast, reliable, and simple to set up. Easily ingest your docs from Hugo into Elasticsearch following [this guide from the docs](https://bonsai.io/docs/hugo).

--- a/content/en/tools/search.md
+++ b/content/en/tools/search.md
@@ -43,8 +43,8 @@ A static website with a dynamic search function? Yes, Hugo provides an alternati
 
 ## Commercial
 
-[Algolia](https://www.algolia.com/)
-: Algolia's Search API makes it easy to deliver a great search experience in your apps and websites. Algolia Search provides hosted full-text, numerical, faceted, and geolocalized search.
+[Algolia DocSearch](https://docsearch.algolia.com/)
+: Algolia DocSearch is free for public technical documentation sites and easy to set up. For other use cases, Algolia's Search API makes it easy to deliver a great search experience in your apps and websites. Algolia Search provides hosted full-text, numerical, faceted, and geolocalized search.
 
 [Bonsai](https://www.bonsai.io)
 : Bonsai is a fully-managed hosted Elasticsearch service that is fast, reliable, and simple to set up. Easily ingest your docs from Hugo into Elasticsearch following [this guide from the docs](https://bonsai.io/docs/hugo).


### PR DESCRIPTION
I thought it would be good to mention here that Algolia DocSearch, which powers many popular technical sites, is free. Of course for other use cases you can use Algolia APIs/SDKs directly as well.