### PR TITLE
npm: Use tilde ranges for versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@awmottaz/prettier-plugin-void-html": "^1.8.0",
-    "@tailwindcss/cli": "^4.1.0",
-    "@tailwindcss/typography": "^0.5.16",
-    "prettier": "^3.5.3",
-    "prettier-plugin-go-template": "^0.0.15",
-    "tailwindcss": "^4.1.0"
+    "@awmottaz/prettier-plugin-void-html": "~1.8.0",
+    "@tailwindcss/cli": "~4.1.0",
+    "@tailwindcss/typography": "~0.5.16",
+    "prettier": "~3.5.3",
+    "prettier-plugin-go-template": "~0.0.15",
+    "tailwindcss": "~4.1.0"
   },
   "dependencies": {
-    "@alpinejs/focus": "^3.14.9",
-    "@alpinejs/persist": "^3.14.9",
-    "@hotwired/turbo": "^8.0.13",
-    "alpinejs": "^3.14.9"
+    "@alpinejs/focus": "~3.14.9",
+    "@alpinejs/persist": "~3.14.9",
+    "@hotwired/turbo": "~8.0.13",
+    "alpinejs": "~3.14.9"
   }
 }


### PR DESCRIPTION
We don't want minor versions pulled in without some level of testing.

See https://github.com/npm/node-semver#tilde-ranges-123-12-1

```
~1.2.3 := >=1.2.3 <1.(2+1).0 := >=1.2.3 <1.3.0-0
```
