### PR TITLE
Make "Hugo" link static

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -142,6 +142,10 @@ category = 'categories'
 
 ######## GLOBAL ITEMS TO BE SHARED WITH THE HUGO SITES ########
 [menus]
+    [[menus.hugo]]
+        identifier = 'Hugo'
+        name       = 'HUGO'
+        pageRef    = '/'
     [[menus.global]]
         identifier = 'news'
         name       = 'News'

--- a/layouts/_partials/layouts/header/header.html
+++ b/layouts/_partials/layouts/header/header.html
@@ -3,12 +3,12 @@
   class="print:hidden sticky top-0 z-50 bg-blue-950 flex flex-none flex-wrap items-center justify-between px-4 py-5 shadow-md shadow-slate-900/5 transition duration-500 sm:px-6 lg:px-8 dark:shadow-none"
   :class="$store.nav.scroll.atTop ? '': 'bg-blue-950/80'">
   <div class="relative flex basis-0 items-center mr-2 lg:mr-8">
-    {{ with site.Home }}
+    {{ range .Site.Menus.hugo }}
       <a
         class="text-white text-xl font-bold upper"
-        href="{{ .RelPermalink }}"
-        aria-label="{{ .LinkTitle }}"
-        >HUGO</a
+        href="{{ .URL }}"
+        aria-label="{{ $.LinkTitle }}"
+      >{{ .Name }}</a
       >
     {{ end }}
   </div>


### PR DESCRIPTION
First time using/contributing to Hugo, so I'm sorry if the etiquette or the code is off somehow. Willing to make changes.

---

Noticed that in the themes page clicking the top left Hugo link takes you to themes instead of the main docs homepage. It didn't quite make sense to me.

