### PR TITLE
Hosting on Netlify, netlify.toml: fix GO_VERSION

### DIFF
--- a/content/en/functions/css/Sass.md
+++ b/content/en/functions/css/Sass.md
@@ -141,8 +141,8 @@ To install Dart Sass for your builds on GitLab Pages, the `.gitlab-ci.yml` file 
 
 ```yaml
 variables:
-  HUGO_VERSION: 0.144.2
-  DART_SASS_VERSION: 1.85.0
+  HUGO_VERSION: 0.147.1
+  DART_SASS_VERSION: 1.87.0
   GIT_DEPTH: 0
   GIT_STRATEGY: clone
   GIT_SUBMODULE_STRATEGY: recursive
@@ -175,8 +175,8 @@ To install Dart Sass for your builds on Netlify, the `netlify.toml` file should 
 
 ```toml
 [build.environment]
-HUGO_VERSION = "0.144.2"
-DART_SASS_VERSION = "1.85.0"
+HUGO_VERSION = "0.147.1"
+DART_SASS_VERSION = "1.87.0"
 NODE_VERSION = "22"
 TZ = "America/Los_Angeles"
 

--- a/content/en/functions/resources/FromString.md
+++ b/content/en/functions/resources/FromString.md
@@ -22,9 +22,9 @@ Let's say you need to publish a file named "site.json" in the root of your `publ
 
 ```json
 {
-  "build_date": "2025-01-16T19:14:41-08:00",
-  "hugo_version": "0.141.0",
-  "last_modified": "2025-01-16T19:14:46-08:00"
+  "build_date": "2025-05-03T19:14:41-08:00",
+  "hugo_version": "0.147.1",
+  "last_modified": "2025-05-03T19:14:46-08:00"
 }
 ```
 

--- a/content/en/host-and-deploy/host-on-aws-amplify/index.md
+++ b/content/en/host-and-deploy/host-on-aws-amplify/index.md
@@ -44,9 +44,9 @@ version: 1
 env:
   variables:
     # Application versions
-    DART_SASS_VERSION: 1.85.0
-    GO_VERSION: 1.23.3
-    HUGO_VERSION: 0.144.2
+    DART_SASS_VERSION: 1.87.0
+    GO_VERSION: 1.24.2
+    HUGO_VERSION: 0.147.1
     # Time zone
     TZ: America/Los_Angeles
     # Cache

--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -107,7 +107,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.147.1
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:

--- a/content/en/host-and-deploy/host-on-gitlab-pages.md
+++ b/content/en/host-and-deploy/host-on-gitlab-pages.md
@@ -27,7 +27,7 @@ variables:
   GIT_DEPTH: 0
   GIT_STRATEGY: clone
   GIT_SUBMODULE_STRATEGY: recursive
-  HUGO_VERSION: 0.146.7
+  HUGO_VERSION: 0.147.1
   NODE_VERSION: 22.x
   TZ: America/Los_Angeles
 image:

--- a/content/en/host-and-deploy/host-on-netlify/index.md
+++ b/content/en/host-and-deploy/host-on-netlify/index.md
@@ -113,8 +113,8 @@ Create a new file named netlify.toml in the root of your project directory. In i
 
 ```toml {file="netlify.toml"}
 [build.environment]
-GO_VERSION = "1.24"
-HUGO_VERSION = "0.146.7"
+GO_VERSION = "1.24.2"
+HUGO_VERSION = "0.147.1"
 NODE_VERSION = "22"
 TZ = "America/Los_Angeles"
 
@@ -128,8 +128,8 @@ If your site requires Dart Sass to transpile Sass to CSS, the configuration file
 ```toml {file="netlify.toml"}
 [build.environment]
 DART_SASS_VERSION = "1.87.0"
-GO_VERSION = "1.24"
-HUGO_VERSION = "0.146.7"
+GO_VERSION = "1.24.2"
+HUGO_VERSION = "0.147.1"
 NODE_VERSION = "22"
 TZ = "America/Los_Angeles"
 


### PR DESCRIPTION
The chapter on Netlify deployment lists a sample configuration file `netlify.toml` that helds these two lines:

https://github.com/gohugoio/hugoDocs/blob/8cc589c3a13d1aa04e67bf2aef16c3f1bb0d38d4/content/en/host-and-deploy/host-on-netlify/index.md?plain=1#L115-L116

The `GO_VERSION` given is invalid as seen from Netlify deploy logs:

```
10:13:22 PM: Installing Go version 1.24 (requested 1.24)
10:13:22 PM: Failed to install Go version '1.24'
10:13:22 PM: Continue with existing version '1.19.13'
```

This PR corrects this by setting `GO_VERSION` to `1.24.2`.

This PR also brings versions up to date in other deployment documents.