### PR TITLE
Fix the spelling issue on the Host on Render description

### DIFF
--- a/content/en/host-and-deploy/host-on-render.md
+++ b/content/en/host-and-deploy/host-on-render.md
@@ -1,6 +1,6 @@
 ---
 title: Host on Render
-description: Host your on Render.
+description: Host your site on Render.
 categories: []
 keywords: []
 aliases: [/hosting-and-deployment/hosting-on-render/]


### PR DESCRIPTION
# What is this change?
- On the "Host and Deploy" section of the website, the Render description just says "Host your on Render". This has been changed to add the word "site" to be consistent with all the other sections


![image](https://github.com/user-attachments/assets/e88b46a5-aa40-4022-b4c3-25c0ab90857f)
