### PR TITLE
content: Fix links to Pandoc

### DIFF
--- a/content/en/configuration/markup.md
+++ b/content/en/configuration/markup.md
@@ -337,5 +337,5 @@ ordered
 [superscript]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
 [AsciiDoc]: https://asciidoc.org/
 [Emacs Org Mode]: https://orgmode.org/
-[Pandoc]: https://www.pandoc.org/
+[Pandoc]: https://pandoc.org/
 [reStructuredText]: https://docutils.sourceforge.io/rst.html

--- a/content/en/methods/page/RenderString.md
+++ b/content/en/methods/page/RenderString.md
@@ -46,4 +46,4 @@ Render with [Pandoc]:
 ```
 
 [markup identifier]: /content-management/formats/#classification
-[pandoc]: https://www.pandoc.org/
+[pandoc]: https://pandoc.org/


### PR DESCRIPTION
The content of <https://www.pandoc.org/> looks the same as <https://djot.net/>. So I fixed these links to the official website of Pandoc (<https://pandoc.org/>).