### PR TITLE
Fix Relref examples

### DIFF
--- a/content/en/shortcodes/relref.md
+++ b/content/en/shortcodes/relref.md
@@ -30,13 +30,13 @@ The `relref` shortcode typically provides the destination for a Markdown link.
 The following examples show the rendered output for a page on the English version of the site:
 
 ```md
-[Link A]({{%/* ref "/books/book-1" */%}})
+[Link A]({{%/* relref "/books/book-1" */%}})
 
-[Link B]({{%/* ref path="/books/book-1" */%}})
+[Link B]({{%/* relref path="/books/book-1" */%}})
 
-[Link C]({{%/* ref path="/books/book-1" lang="de" */%}})
+[Link C]({{%/* relref path="/books/book-1" lang="de" */%}})
 
-[Link D]({{%/* ref path="/books/book-1" lang="de" outputFormat="json" */%}})
+[Link D]({{%/* relref path="/books/book-1" lang="de" outputFormat="json" */%}})
 ```
 
 Rendered:


### PR DESCRIPTION
Examples were incorrectly showing usage of `ref` instead of `relref`.

https://gohugo.io/shortcodes/relref/