### PR TITLE
Update Step 7 description in index.md

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -70,7 +70,7 @@ touch .github/workflows/hugo.yaml
 > [!note]
 > The workflow below ensures Hugo's `cacheDir` is persistent, preserving modules, processed images, and [`resources.GetRemote`] data between builds.
 
-Copy and paste the YAML below into the file you created. Change the branch name and Hugo version as needed.
+Copy and paste the YAML below into the file you created. To ensure accuracy, do not use the Copy code icon (use your mouse/touchpad to select and paste the code). Change the branch name and Hugo version as needed.
 
 ```yaml {file=".github/workflows/hugo.yaml" copy=true}
 # Sample workflow for building and deploying a Hugo site to GitHub Pages


### PR DESCRIPTION
Updated the description of how to copy the YAML code to prevent workflow failures during deployment to GitHub Actions. It took me 9 attempts to get the code right, and selecting and copying finally did the trick, so I'd like to save others the time and frustration.

![Screen Shot 2025-05-22 at 12 20 45 AM](https://github.com/user-attachments/assets/49acb293-1e27-48f2-af13-48f2e35ead0a)