### PR TITLE
Links to commonmark spec: update to latest version of the spec

### DIFF
--- a/content/en/contribute/documentation.md
+++ b/content/en/contribute/documentation.md
@@ -514,17 +514,17 @@ Visit the [documentation repository] and create a pull request (PR).
 
 A project maintainer will review your PR and may request changes. You may delete your branch after the maintainer merges your PR.
 
-[ATX]: https://spec.commonmark.org/0.30/#atx-headings
+[ATX]: https://spec.commonmark.org/current/#atx-headings
 [basic english]: https://simple.wikipedia.org/wiki/Basic_English
 [basic english]: https://simple.wikipedia.org/wiki/Basic_English
 [developer documentation style guide]: https://developers.google.com/style
 [documentation repository]: https://github.com/gohugoio/hugoDocs/
-[fenced code blocks]: https://spec.commonmark.org/0.30/#fenced-code-blocks
+[fenced code blocks]: https://spec.commonmark.org/current/#fenced-code-blocks
 [glossary]: /quick-reference/glossary/
-[indented code blocks]: https://spec.commonmark.org/0.30/#indented-code-blocks
+[indented code blocks]: https://spec.commonmark.org/current/#indented-code-blocks
 [issues]: https://github.com/gohugoio/hugoDocs/issues
-[list items]: https://spec.commonmark.org/0.30/#list-items
+[list items]: https://spec.commonmark.org/current/#list-items
 [project repository]: https://github.com/gohugoio/hugo
-[raw HTML]: https://spec.commonmark.org/0.30/#raw-html
+[raw HTML]: https://spec.commonmark.org/current/#raw-html
 [related content]: /content-management/related-content/
-[setext]: https://spec.commonmark.org/0.30/#setext-heading
+[setext]: https://spec.commonmark.org/current/#setext-heading

--- a/content/en/methods/page/Fragments.md
+++ b/content/en/methods/page/Fragments.md
@@ -102,8 +102,8 @@ Hugo renders this to:
 > When using the `Fragments` methods within a shortcode, call the shortcode using [standard notation]. If you use [Markdown notation] the rendered shortcode is included in the creation of the fragments map, resulting in a circular loop.
 
 [`TableOfContents`]: /methods/page/tableofcontents/
-[ATX]: https://spec.commonmark.org/0.30/#atx-headings
+[ATX]: https://spec.commonmark.org/current/#atx-headings
 [Markdown notation]: /content-management/shortcodes/#notation
-[setext]: https://spec.commonmark.org/0.30/#setext-headings
+[setext]: https://spec.commonmark.org/current/#setext-headings
 [standard notation]: /content-management/shortcodes/#notation
 [table of contents]: /methods/page/tableofcontents/

--- a/content/en/methods/page/TableOfContents.md
+++ b/content/en/methods/page/TableOfContents.md
@@ -12,8 +12,8 @@ aliases: [/content-management/toc/]
 
 The `TableOfContents` method on a `Page` object returns an ordered or unordered list of the Markdown [ATX] and [setext] headings within the page content.
 
-[atx]: https://spec.commonmark.org/0.30/#atx-headings
-[setext]: https://spec.commonmark.org/0.30/#setext-headings
+[atx]: https://spec.commonmark.org/current/#atx-headings
+[setext]: https://spec.commonmark.org/current/#setext-headings
 
 This template code:
 

--- a/content/en/methods/shortcode/Inner.md
+++ b/content/en/methods/shortcode/Inner.md
@@ -137,7 +137,7 @@ The difference between this and the previous example is subtle but required. Not
 [`strings.TrimSpace`]: /functions/strings/trimspace/
 [CommonMark]: https://spec.commonmark.org/current/
 [details]: /methods/page/renderstring/
-[indentation]: https://spec.commonmark.org/0.30/#indented-code-blocks
+[indentation]: https://spec.commonmark.org/current/#indented-code-blocks
 [Markdown notation]: /content-management/shortcodes/#notation
-[raw HTML blocks]: https://spec.commonmark.org/0.31.2/#html-blocks
+[raw HTML blocks]: https://spec.commonmark.org/current/#html-blocks
 [security model]: /about/security/

--- a/content/en/methods/shortcode/InnerDeindent.md
+++ b/content/en/methods/shortcode/InnerDeindent.md
@@ -94,5 +94,5 @@ Hugo renders the Markdown to:
 ```
 
 [commonmark]: https://commonmark.org/
-[indentation]: https://spec.commonmark.org/0.30/#indented-code-blocks
+[indentation]: https://spec.commonmark.org/current/#indented-code-blocks
 [`Inner`]: /methods/shortcode/inner/

--- a/content/en/render-hooks/code-blocks.md
+++ b/content/en/render-hooks/code-blocks.md
@@ -118,10 +118,10 @@ Hugo includes an [embedded code block render hook] to render [GoAT diagrams].
 
 [`RenderShortcodes`]: /methods/page/rendershortcodes
 [Chroma]: https://github.com/alecthomas/chroma/
-[code fence]: https://spec.commonmark.org/0.31.2/#code-fence
+[code fence]: https://spec.commonmark.org/current/#code-fence
 [diagrams]: /content-management/diagrams/#mermaid-diagrams
 [embedded code block render hook]: {{% eturl render-codeblock-goat %}}
 [GoAT diagrams]: /content-management/diagrams/#goat-diagrams-ascii
 [highlighting options]: /functions/transform/highlight/#options
-[info string]: https://spec.commonmark.org/0.31.2/#info-string
+[info string]: https://spec.commonmark.org/current/#info-string
 [Mermaid]: https://mermaid.js.org/


### PR DESCRIPTION
This PR updates several links to the commonmark spec so that they address the latest version of the spec.