### PR TITLE
theme: Remove the print only QR code header

### DIFF
--- a/layouts/_partials/layouts/hooks/body-main-start.html
+++ b/layouts/_partials/layouts/hooks/body-main-start.html
@@ -1,8 +1,0 @@
-{{ if or .IsSection .IsPage }}
-  <div class="hidden print:flex justify-between border-b-1 border-b-gray-400 mb-4">
-    <p class="flex flex-col justify-end text-4xl mb-3">Hugo Documentation</p>
-    {{ with images.QR .Permalink (dict "scale" 3) }}
-      <img class="mb-2 -mr-2" src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="Link to {{ $.Permalink }}">
-    {{ end }}
-  </div>
-{{end }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -46,7 +46,6 @@
     <div class="flex w-full xl:w-6xl h-full flex-auto mx-auto">
       <main
         class="flex-1 mx-auto lg:mx-0 w-full max-w-3x lg:max-w-3x pt-8 lg:pt-14 pb-20 px-main print:pt-0">
-        {{ partial "layouts/hooks/body-main-start.html" . }}
         {{ block "main" . }}{{ end }}
       </main>
       {{ block "rightsidebar" . }}


### PR DESCRIPTION
I had a head scratching moment wondering where the qr codes directly below public/ came from.

I understand the motivation, but this produces a little too many files for this ... narrow feature.
