### PR TITLE
theme: Generate QR code once per page

### DIFF
--- a/layouts/_partials/layouts/hooks/body-main-start.html
+++ b/layouts/_partials/layouts/hooks/body-main-start.html
@@ -1,8 +1,8 @@
 {{ if or .IsSection .IsPage }}
   <div class="hidden print:flex justify-between border-b-1 border-b-gray-400 mb-4">
     <p class="flex flex-col justify-end text-4xl mb-3">Hugo Documentation</p>
-    {{ with images.QR .Permalink (dict "scale" 3) }}
-      <img class="mb-2 -mr-2" src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="Link to {{ $.Permalink }}">
+    {{ with images.QR .Permalink (dict "targetDir" "images/qr") }}
+      <img class="mb-2 -mr-2" src="{{ .RelPermalink }}" width="{{ .Width | mul 0.75 | int }}" height="{{ .Height | mul 0.75 | int }}" alt="Link to {{ $.Permalink }}">
     {{ end }}
   </div>
 {{end }}


### PR DESCRIPTION
We currently generate two QR codes for each page, one in the header and another at the top the printed page. The content of the two codes is identical; the only difference is scale.

Instead of generating two images, make the same function call in both places so that the second call uses the cached instance.

All images are published to `public/images/qr/`.