### PR TITLE
content: Note that PATH segments must exclude project directory

### DIFF
--- a/content/en/functions/css/Sass.md
+++ b/content/en/functions/css/Sass.md
@@ -113,7 +113,7 @@ macOS|Homebrew|[brew.sh]|`brew install sass/sass/sass`
 Windows|Chocolatey|[chocolatey.org]|`choco install sass`
 Windows|Scoop|[scoop.sh]|`scoop install sass`
 
-You may also install [prebuilt binaries] for Linux, macOS, and Windows.
+You may also install [prebuilt binaries] for Linux, macOS, and Windows. You must install the prebuilt binary outside of your project directory and ensure its path is included in your system's PATH environment variable.
 
 Run `hugo env` to list the active transpilers.
 

--- a/content/en/functions/css/TailwindCSS.md
+++ b/content/en/functions/css/TailwindCSS.md
@@ -33,7 +33,8 @@ Install the Tailwind CSS CLI v4.0 or later:
 npm install --save-dev tailwindcss @tailwindcss/cli
 ```
 
-The TailwindCSS CLI is also available as a [standalone executable] if you want to use it without installing Node.js.
+The Tailwind CSS CLI is also available as a [standalone executable]. You must install it outside of your project directory and ensure its path is included in your system's `PATH` environment variable.
+
 
 [standalone executable]: https://github.com/tailwindlabs/tailwindcss/releases/latest
 

--- a/content/en/templates/embedded.md
+++ b/content/en/templates/embedded.md
@@ -149,7 +149,7 @@ If using YouTube this will produce a og:video tag like `<meta property="og:video
 
 ## Pagination
 
-See [details](/templates/pagination/).
+See&nbsp;[details](/templates/pagination/).
 
 ## Schema
 

--- a/content/en/templates/types.md
+++ b/content/en/templates/types.md
@@ -82,7 +82,7 @@ For example, the base template below calls the [`partial`] function to include p
 </html>
 ```
 
-The `block` construct above is used to define a set of root templates that are then customized by redefining the block templates within. See [details](/functions/go-template/block/)
+The `block` construct above is used to define a set of root templates that are then customized by redefining the block templates within. See&nbsp;[details](/functions/go-template/block/)
 
 ## Home
 


### PR DESCRIPTION
Applicable to Dart Sass prebuilt binaries and the Tailwind CSS standalone client.

Closes #3032