### PR TITLE
content: Fix accidental removal

### DIFF
--- a/content/en/templates/new-templatesystem-overview.md
+++ b/content/en/templates/new-templatesystem-overview.md
@@ -16,7 +16,7 @@ We have aimed to maintain as much backward compatibility as possible by mapping 
 
 | Description   | Action required |
 | ------------- | ------------- |
-| The `_default` folder is removed. | Move all files in `layouts` up to the `layouts/` root.|
+| The `_default` folder is removed. | Move all files in `layouts/_default` up to the `layouts/` root.|
 | The `layouts/partials` folder is renamed to `layouts/_partials`.  | Rename the folder.  |
 | The `layouts/shortcodes` folder is renamed to `layouts/_shortcodes`.  | Rename the folder.  |
 | Any folder in `layouts` that does not start with `_` represents the root of a [Page path]. In [Hugo v0.146.0], this can be nested as deeply as needed, and `_shortcodes` and `_markup` folders can be placed at any level in the tree.| No action required.|
@@ -24,7 +24,7 @@ We have aimed to maintain as much backward compatibility as possible by mapping 
 |A template named `taxonomy.html` used to be a candidate for both Page kind `term` and `taxonomy`, now it's only considered for `taxonomy`.|Create both `taxonomy.html` and `term.html` or create a more general layout, e.g. `list.html`.|
 | For base templates (e.g., `baseof.html`), in previous Hugo versions, you could prepend one identifier (layout, type, or kind) with a hyphen in front of the baseof keyword.|Move that identifier after the first "dot," e.g., rename`list-baseof.html` to `baseof.list.html`.|
 | We have added a new `all` "catch-all" layout. This means that if you have, e.g., `layouts/all.html` and that is the only template, that layout will be used for all HTML page rendering.||
-| We have removed the concept of `_internal` Hugo templates.[^internal]|Replace constructs similar to `{{ partial "opengraph.html" . }}` with `{{ partial "opengraph.html" . }}`.|
+| We have removed the concept of `_internal` Hugo templates.[^internal]|Replace constructs similar to `{{ template "_internal/opengraph.html" . }}` with `{{ partial "opengraph.html" . }}`.|
 | The identifiers that can be used in a template filename are one of the [Page kinds] (`home`, `page`, `section`, `taxonomy`, or `term`), one of the standard layouts (`list`, `single`, or `all`), a custom layout (as defined in the `layout` front matter field), a language (e.g., `en`), an output format (e.g., `html`, `rss`), and a suffix representing the media type. E.g., `all.en.html` and `home.rss.xml`.||
 | The above means that there's no such thing as an `index.html` template for the home page anymore. | Rename `index.html` to `home.html`.|
 


### PR DESCRIPTION
It seems to me that some kind of search and replace command was used for https://github.com/gohugoio/hugoDocs/commit/0015e7a9bed15133e33f75e407b23a93289baf0b. In the course of that some content in `content/en/templates/new-templatesystem-overview.md` has been accidentally removed.

This PR is restoring that content.

However, there might be more content that has been affected by the search and replace command in this file and in other files as well. Therefore, please review the above mentioned commit.