### PR TITLE
Fix "disableKind" snippet to disable taxonomy system

### DIFF
--- a/content/en/configuration/taxonomies.md
+++ b/content/en/configuration/taxonomies.md
@@ -58,7 +58,7 @@ taxonomies:
 To disable the taxonomy system, use the [`disableKinds`] setting in the root of your site configuration to disable the `taxonomy` and `term` page [kinds](g).
 
 {{< code-toggle file=hugo >}}
-disableKinds = ['categories','tags']
+disableKinds = ['taxonomy','term']
 {{< /code-toggle >}}
 
 [`disableKinds`]: /configuration/all/#disablekinds


### PR DESCRIPTION
As "categories" and "tags" aren't [valid values for disableKinds](https://gohugo.io/configuration/all/#disablekinds), this is likely a typo?