### PR TITLE
Improve Dart Sass Installation in Example Workflow

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -116,7 +116,23 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get latest release name
+          VERSION=$(gh api repos/sass/dart-sass/releases/latest --jq .tag_name)
+
+          # Build file and download URL
+          FILE="dart-sass-${VERSION}-linux-x64.tar.gz"
+          URL="https://github.com/sass/dart-sass/releases/download/${VERSION}/${FILE}"
+
+          # Download and extract
+          cd ${{ runner.temp }}
+          curl -L -o $FILE $URL
+          tar -xzf $FILE
+
+          # Install binaries
+          sudo mv dart-sass/* /usr/local/bin/
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The example workflow file for building a Hugo site on GitHub used snap to install dart-sass which is quite slow on a runner.  This replaces it with a quick script to pull the latest built binary from the repo's GitHub Release and manually installs it in /usr/local/bin/

In my testing it reduced this step from ~20 seconds to ~3 seconds.