### PR TITLE
Regular web server hosting and GUI SFTP client deployment

### DIFF
--- a/content/en/_common/installation/02-prerequisites.md
+++ b/content/en/_common/installation/02-prerequisites.md
@@ -12,7 +12,7 @@ Git is required to:
 - Use the [Hugo Modules] feature
 - Install a theme as a Git submodule
 - Access [commit information] from a local Git repository
-- Host your site with services such as [CloudCannon], [Cloudflare Pages], [GitHub Pages], [GitLab Pages], and [Netlify]
+- Host your site on [a regular web server], or with services such as [CloudCannon], [Cloudflare Pages], [GitHub Pages], [GitLab Pages], and [Netlify]
 
 Go is required to:
 
@@ -27,6 +27,7 @@ Please refer to the relevant documentation for installation instructions:
 - [Go][go install]
 - [Dart Sass][dart sass install]
 
+[a regular web server]: /host-and-deploy/host-on-a-regular-web-server
 [cloudcannon]: https://cloudcannon.com/
 [cloudflare pages]: https://pages.cloudflare.com/
 [dart sass install]: /functions/css/sass/#dart-sass

--- a/content/en/getting-started/usage.md
+++ b/content/en/getting-started/usage.md
@@ -142,7 +142,7 @@ public/
 
 In a simple hosting environment, where you typically `ftp`, `rsync`, or `scp` your files to the root of a virtual host, the contents of the `public` directory are all that you need.
 
-Most of our users deploy their sites using a [CI/CD](g) workflow, where a push[^1] to their GitHub or GitLab repository triggers a build and deployment. Popular providers include [AWS Amplify], [CloudCannon], [Cloudflare Pages], [GitHub Pages], [GitLab Pages], and [Netlify].
+Most of our users deploy their sites on [a regular web server], or using a [CI/CD](g) workflow, where a push[^1] to their GitHub or GitLab repository triggers a build and deployment. Popular providers include [AWS Amplify], [CloudCannon], [Cloudflare Pages], [GitHub Pages], [GitLab Pages], and [Netlify].
 
 Learn more in the [host and deploy] section.
 
@@ -153,6 +153,7 @@ Learn more in the [host and deploy] section.
 [`hugo server`]: /commands/hugo_server/
 [`hugo`]: /commands/hugo/
 [`publishDir`]: /configuration/all/#publishdir
+[a regular web server]: /host-and-deploy/host-on-a-regular-web-server
 [AWS Amplify]: https://aws.amazon.com/amplify/
 [build options]: /content-management/build-options/
 [CloudCannon]: https://cloudcannon.com/

--- a/content/en/host-and-deploy/deploy-with-drag-and-drop-application.md
+++ b/content/en/host-and-deploy/deploy-with-drag-and-drop-application.md
@@ -1,0 +1,36 @@
+---
+title: Deploy with a drag and drop file transfer application
+description: Deploy your site with any (S)FTP client, like Cyberduck, WinSCP, or FileZilla.
+categories: []
+keywords: []
+aliases: []
+---
+
+## Assumptions
+
+- A web host running a web server. This could be a shared hosting environment or a VPS.
+- A file transfer application such as [Cyberduck], [WinSCP], or [FileZilla].
+- Access to your web host with any of the protocols supported by the above application, such as SFTP.
+- A functional static website built with Hugo.
+
+## Getting started
+
+Connect to your web server using Cyberduck, WinSCP, FileZilla, or any file transfer application of your choosing, and the connection instructions from your hosting provider.
+
+Copy the contents of the `public` folder of your Hugo web site to the root of your web server (usually, a folder called `www` or `public_html`,) or any subfolder you would like your site to be available at.
+
+## Folder synchronisation
+
+As you update your web site, you might want to synchronise the local and online folders, instead of uploading everything each time.
+
+In Cyberduck, this is achieved with the [_File → Synchronize_][Cyberduck-sync] command.
+
+In WinSCP, this is achieved with the [_Commands → Synchronize_][WinSCP-sync] command.
+
+FileZilla doesn’t offer such a feature.
+
+[Cyberduck]: https://cyberduck.io
+[WinSCP]: https://winscp.net/
+[FileZilla]: https://filezilla-project.org
+[Cyberduck-sync]: https://docs.cyberduck.io/cyberduck/sync/
+[WinSCP-sync]: https://winscp.net/eng/docs/task_synchronize_full

--- a/content/en/host-and-deploy/host-on-a-regular-web-server.md
+++ b/content/en/host-and-deploy/host-on-a-regular-web-server.md
@@ -1,0 +1,11 @@
+---
+title: Host on a regular web server
+description: Host your site with any regular web hosting provider.
+categories: []
+keywords: []
+aliases: []
+---
+
+A web server is the most common way to serve a web site. There are thousands of web hosting providers that will provide hosting for your web site, whether it is a shared hosting environment or a VPS.
+
+Once you have registered with a hosting provider, you can deploy your Hugo site with a [drag and drop file transfer application](/host-and-deploy/deploy-with-drag-and-drop-application).


### PR DESCRIPTION
This was prompted by seeing a beginner post about deciding on Hugo for their blog and apprehensively (with good reason) getting ready to learn git to deploy it on GitHub pages. So I went to the Host and Deploy section of the Hugo docs, and I was surprised to find out there is nothing there whatsoever for non-nerds. Moreover, I read the GitHub Pages instructions, to see what that person would have to learn and do if they went this way, and the overengineering of it made me cry blood. And I work in DevOps. (To be clear, I don’t believe it’s the fault of the people who wrote that documentation. Rather, it’s a failing of our whole profession, plus a case of https://xkcd.com/2501/.)

For a system that’s supposed to be (and is) “easy to host because it’s just a bunch of static files,” that’s a bit of a pity.

So I added two pages, one about deploying with a GUI SFTP app, and one about hosting on any regular web hosting provider. I also added the regular web server wherever the nerdier methods are mentioned.

I did my best, but didn’t spend a lot of time on this, so there’s room for improvement. (I’m also not yet a Hugo user, although I plan to be. It just requires a good deal of yak shaving first.) I’m happy to integrate feedback. But I think it’s important to show people that they can also “just” (I’ve been careful not to use this word, or “simple” or “easy”) sign up for regular hosting and upload their site with drag and drop.