### PR TITLE
added instructions on custom domain for Codeberg Pages and Forgejo Actions

### DIFF
--- a/content/en/host-and-deploy/host-on-codeberg-pages.md
+++ b/content/en/host-and-deploy/host-on-codeberg-pages.md
@@ -156,7 +156,23 @@ jobs:
           git commit --allow-empty --message "Codeberg build for ${GITHUB_SHA}" && \
           git push origin pages
 ```
+Note that if you are using a custom domain, you should make sure that `.domains` file is included in the uploaded artifacts. Therefore, you should place it under `static` directory of your source branch, and a small modification should be made in the `Checkout the target branch and clean it up` section:
 
+```yaml {copy=true}
+      - name: Checkout the target branch, backup .domains and clean it up
+              run: |
+                git checkout pages || git switch --orphan pages && \
+               [ -f .domains ] && cp .domains /tmp/.domains || true && \
+                rm -Rfv $(ls -A | egrep -v '^(\.git|LICENSE)$')
+```
+And make sure to add another step between "download generated files" and "publish the website":
+
+```yaml {copy=true}
+      - name: Restore .domains
+        run: |
+            echo "Restoring .domains from backup"
+            cp /tmp/.domains .domains
+```
 The second file implements a more complex scenario: having your website sources in one repository and the resulting static website in another repository (in this case, `pages`). If you want Codeberg to make your website available at the root of your pages subdomain (`https://<YourUsername>.codeberg.page/`), you have to push that website to the default branch of your repository named `pages`.
 
 Since this action involves more than one repository, it will require a bit more preparation:
@@ -248,6 +264,7 @@ jobs:
 ```
 
 Once you commit one of the two files to your website source repository, you should see your first automated build firing up pretty soon. You can also trigger it manually by navigating to the **Actions** section of your repository web page, choosing **hugo.yaml** on the left and clicking on **Run workflow**.
+
 
 ## Other resources
 


### PR DESCRIPTION
The document's sample `hugo.yaml` is only effective if the user set baseURL to `username.codeberg.page`. It's worth noticing that this config clears `.domains` file of the target branch, therefore, it would cause "misdirected request" if you use automated deployment following this Forgejo Actions config file. I added a small modification to make sure that `.domains` file will be present in the target branch when automated deploy is on following the instructions.
Thanks!