### PR TITLE
Adding instructions for Codeberg Page + Forgejo Actions with custom domains

### DIFF
--- a/content/en/host-and-deploy/host-on-codeberg-pages.md
+++ b/content/en/host-and-deploy/host-on-codeberg-pages.md
@@ -265,6 +265,7 @@ Nevertheless, it's worth noticing that in the example `.forgejo/workflows/hugo.y
           path: public/
           include-hidden-files: true # Prevents excluding .domains from uploading
 ```
+
 It is important to modify the workflow file accordingly if you are using a custom domain.
 
 

--- a/content/en/host-and-deploy/host-on-codeberg-pages.md
+++ b/content/en/host-and-deploy/host-on-codeberg-pages.md
@@ -156,23 +156,7 @@ jobs:
           git commit --allow-empty --message "Codeberg build for ${GITHUB_SHA}" && \
           git push origin pages
 ```
-Note that if you are using a custom domain, you should make sure that `.domains` file is included in the uploaded artifacts. Therefore, you should place it under `static` directory of your source branch, and a small modification should be made in the `Checkout the target branch and clean it up` section:
 
-```yaml {copy=true}
-      - name: Checkout the target branch, backup .domains and clean it up
-              run: |
-                git checkout pages || git switch --orphan pages && \
-               [ -f .domains ] && cp .domains /tmp/.domains || true && \
-                rm -Rfv $(ls -A | egrep -v '^(\.git|LICENSE)$')
-```
-And make sure to add another step between "download generated files" and "publish the website":
-
-```yaml {copy=true}
-      - name: Restore .domains
-        run: |
-            echo "Restoring .domains from backup"
-            cp /tmp/.domains .domains
-```
 The second file implements a more complex scenario: having your website sources in one repository and the resulting static website in another repository (in this case, `pages`). If you want Codeberg to make your website available at the root of your pages subdomain (`https://<YourUsername>.codeberg.page/`), you have to push that website to the default branch of your repository named `pages`.
 
 Since this action involves more than one repository, it will require a bit more preparation:
@@ -264,7 +248,6 @@ jobs:
 ```
 
 Once you commit one of the two files to your website source repository, you should see your first automated build firing up pretty soon. You can also trigger it manually by navigating to the **Actions** section of your repository web page, choosing **hugo.yaml** on the left and clicking on **Run workflow**.
-
 
 ## Other resources
 

--- a/content/en/host-and-deploy/host-on-codeberg-pages.md
+++ b/content/en/host-and-deploy/host-on-codeberg-pages.md
@@ -156,7 +156,23 @@ jobs:
           git commit --allow-empty --message "Codeberg build for ${GITHUB_SHA}" && \
           git push origin pages
 ```
+Note that if you are using a custom domain, you should make sure that `.domains` file is included in the uploaded artifacts. Therefore, you should place it under `static` directory of your source branch, and a small modification should be made in the `Checkout the target branch and clean it up` section:
 
+```yaml {copy=true}
+      - name: Checkout the target branch, backup .domains and clean it up
+              run: |
+                git checkout pages || git switch --orphan pages && \
+               [ -f .domains ] && cp .domains /tmp/.domains || true && \
+                rm -Rfv $(ls -A | egrep -v '^(\.git|LICENSE)$')
+```
+And make sure to add another step between "download generated files" and "publish the website":
+
+```yaml {copy=true}
+      - name: Restore .domains
+        run: |
+            echo "Restoring .domains from backup"
+            cp /tmp/.domains .domains
+```
 The second file implements a more complex scenario: having your website sources in one repository and the resulting static website in another repository (in this case, `pages`). If you want Codeberg to make your website available at the root of your pages subdomain (`https://<YourUsername>.codeberg.page/`), you have to push that website to the default branch of your repository named `pages`.
 
 Since this action involves more than one repository, it will require a bit more preparation:
@@ -248,6 +264,7 @@ jobs:
 ```
 
 Once you commit one of the two files to your website source repository, you should see your first automated build firing up pretty soon. You can also trigger it manually by navigating to the **Actions** section of your repository web page, choosing **hugo.yaml** on the left and clicking on **Run workflow**.
+
 
 ## Other resources
 

--- a/content/en/host-and-deploy/host-on-codeberg-pages.md
+++ b/content/en/host-and-deploy/host-on-codeberg-pages.md
@@ -249,6 +249,25 @@ jobs:
 
 Once you commit one of the two files to your website source repository, you should see your first automated build firing up pretty soon. You can also trigger it manually by navigating to the **Actions** section of your repository web page, choosing **hugo.yaml** on the left and clicking on **Run workflow**.
 
+### Using custom domain with Forgejo Actions
+
+Codeberg Pages utilizes `.domains` file to identify allowed domains for a specific branch. It's necessary to ensure that the `.domains` file is located in the root directory of output repository or branch instead of root directory of source files.
+
+The ideal practice is putting your `.domains` file in `static` folder, and it will be preserved without modification in `public` folder, which will be the root directory of the output repository or branch.
+
+Nevertheless, it's worth noticing that in the example `.forgejo/workflows/hugo.yaml`, the action `upload-artifact@v3` , has been used to upload `public` folder to the target branch for deploy. And by default, [upload-artifact@v3 and @v4 exclude all dot files from uploading unless you explicitly prevents it from doing so](https://github.com/actions/upload-artifact/issues/602):
+
+```yaml {file=".forgejo/workflows/hugo.yaml" copy=true}
+      - name: Upload generated files
+        uses: https://code.forgejo.org/actions/upload-artifact@v3
+        with:
+          name: Generated files
+          path: public/
+          include-hidden-files: true # Prevents excluding .domains from uploading
+```
+It is important to modify the workflow file accordingly if you are using a custom domain.
+
+
 ## Other resources
 
 - [Codeberg Pages](https://codeberg.page/)


### PR DESCRIPTION
Greetings,

Thank you for your maintenance for all the time!

When I'm trying to use the default Forgejo Action's `hugo.yaml` to deploy my Hugo site to Codeberg Pages, I noticed that upload-artifacts@v3 action will exclude any dot files from uploading, therefore, it will exclude the necessary `.domains` file from uploading to target branch. Indicating that dot files should be included in `hugo.yaml` should fix that, and I also added instructions to make `.domains` file to be preserved in `public` directory by adding it to `static`.

Hopefully this will be of a little help!