### PR TITLE
"layouts/_markup/heading.html" is a typo

### DIFF
--- a/content/en/templates/types.md
+++ b/content/en/templates/types.md
@@ -347,7 +347,7 @@ A _render hook_ template overrides the conversion of Markdown to HTML.
 
 For example, the _render hook_ template below adds an anchor link to the right of each heading.
 
-```go-html-template {file="layouts/_markup/heading.html"}
+```go-html-template {file="layouts/_markup/render-heading.html"}
 <h{{ .Level }} id="{{ .Anchor }}" {{- with .Attributes.class }} class="{{ . }}" {{- end }}>
   {{ .Text }}
   <a href="#{{ .Anchor }}">#</a>


### PR DESCRIPTION
Render hooks are prefixed with "render", corrected to "layouts/_markup/render-heading.html"