### PR TITLE
content: Wrap calls to eturl shortcode in angle brackets

### DIFF
--- a/content/en/_common/render-hooks/pageinner.md
+++ b/content/en/_common/render-hooks/pageinner.md
@@ -43,5 +43,5 @@ As a practical example, Hugo's embedded link and image render hooks use the `Pag
 
 [`RenderShortcodes`]: /methods/page/rendershortcodes/
 [Markdown notation]: /content-management/shortcodes/#notation
-[Embedded link render hook]: {{% eturl render-link %}}
-[Embedded image render hook]: {{% eturl render-image %}}
+[Embedded link render hook]: <{{% eturl render-link %}}>
+[Embedded image render hook]: <{{% eturl render-image %}}>

--- a/content/en/configuration/all.md
+++ b/content/en/configuration/all.md
@@ -350,9 +350,9 @@ Some configuration settings, such as menus and custom parameters, can be defined
 [Chicago Manual of Style]: https://www.chicagomanualofstyle.org/home.html
 [default front matter configuration]: /configuration/front-matter/
 [duration]: https://pkg.go.dev/time#Duration
-[embedded alias template]: {{% eturl alias %}}
-[embedded Open Graph template]: {{% eturl opengraph %}}
-[embedded RSS template]: {{% eturl rss %}}
+[embedded alias template]: <{{% eturl alias %}}>
+[embedded Open Graph template]: <{{% eturl opengraph %}}>
+[embedded RSS template]: <{{% eturl rss %}}>
 [IANA Time Zone Database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [module mounts]: /configuration/module/#mounts
 [os.UserCacheDir]: https://pkg.go.dev/os#UserCacheDir

--- a/content/en/configuration/languages.md
+++ b/content/en/configuration/languages.md
@@ -185,9 +185,9 @@ public
 [`Language.LanguageName`]: /methods/site/language/#languagename
 [`Language.Weight`]: /methods/site/language/#weight
 [`Title`]: /methods/site/title/
-[embedded alias template]: {{% eturl alias %}}
-[embedded OpenGraph template]: {{% eturl opengraph %}}
-[embedded RSS template]: {{% eturl rss %}}
+[embedded alias template]: <{{% eturl alias %}}>
+[embedded OpenGraph template]: <{{% eturl opengraph %}}>
+[embedded RSS template]: <{{% eturl rss %}}>
 [RFC 5646]: https://datatracker.ietf.org/doc/html/rfc5646#section-2.1
 [RFC 5646 § 2.2.7]: https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.7
 [translating by file name]: /content-management/multilingual/#translation-by-file-name

--- a/content/en/content-management/diagrams.md
+++ b/content/en/content-management/diagrams.md
@@ -256,5 +256,5 @@ Created from <https://arthursonzogni.com/Diagon/#Tree>
 ```
 
 [code block render hook]: /render-hooks/code-blocks/
-[embedded code block render hook]: {{% eturl render-codeblock-goat %}}
+[embedded code block render hook]: <{{% eturl render-codeblock-goat %}}>
 [GoAT]: https://github.com/bep/goat

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -322,18 +322,18 @@ To override the default time zone, set the [`timeZone`](/configuration/all/#time
 [`lastmod`]: /methods/page/date/
 [`layout`]: /methods/page/layout/
 [`linktitle`]: /methods/page/linktitle/
-[`opengraph.html`]: {{% eturl opengraph %}}
+[`opengraph.html`]: <{{% eturl opengraph %}}>
 [`Param`]: /methods/page/param/
 [`Params`]: /methods/page/params/
 [`publishdate`]: /methods/page/publishdate/
 [`readingtime`]: /methods/page/readingtime/
-[`schema.html`]: {{% eturl schema %}}
+[`schema.html`]: <{{% eturl schema %}}>
 [`sitemap`]: /methods/page/sitemap/
 [`slug`]: /methods/page/slug/
 [`Summary`]: /methods/page/summary/
 [`title`]: /methods/page/title/
 [`translationkey`]: /methods/page/translationkey/
-[`twitter_cards.html`]: {{% eturl twitter_cards %}}
+[`twitter_cards.html`]: <{{% eturl twitter_cards %}}>
 [`type`]: /methods/page/type/
 [`weight`]: /methods/page/weight/
 [`wordcount`]: /methods/page/wordcount/

--- a/content/en/content-management/urls.md
+++ b/content/en/content-management/urls.md
@@ -263,4 +263,4 @@ Page
 [`baseURL`]: /configuration/all/#baseurl
 [removed in a future release]: https://github.com/gohugoio/hugo/issues/4733
 [reserved characters]: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-[source code]: {{% eturl alias %}}
+[source code]: <{{% eturl alias %}}>

--- a/content/en/contribute/documentation.md
+++ b/content/en/contribute/documentation.md
@@ -399,7 +399,7 @@ Use the embedded template URL (`eturl`) shortcode to insert an absolute URL to t
 ```text
 This is a link to the [embedded alias template].
 
-[embedded alias template]: {{%/* eturl alias */%}}
+[embedded alias template]: <{{%/* eturl alias */%}}>
 ```
 
 ### glossary-term

--- a/content/en/functions/diagrams/Goat.md
+++ b/content/en/functions/diagrams/Goat.md
@@ -111,5 +111,5 @@ svg.foo {
 ```
 
 [code block render hook]: /render-hooks/code-blocks/
-[embedded code block render hook]: {{% eturl render-codeblock-goat %}}
+[embedded code block render hook]: <{{% eturl render-codeblock-goat %}}>
 [GoAT]: https://github.com/bep/goat

--- a/content/en/render-hooks/code-blocks.md
+++ b/content/en/render-hooks/code-blocks.md
@@ -119,7 +119,7 @@ Hugo includes an [embedded code block render hook] to render [GoAT diagrams].
 [Chroma]: https://github.com/alecthomas/chroma/
 [code fence]: https://spec.commonmark.org/current/#code-fence
 [diagrams]: /content-management/diagrams/#mermaid-diagrams
-[embedded code block render hook]: {{% eturl render-codeblock-goat %}}
+[embedded code block render hook]: <{{% eturl render-codeblock-goat %}}>
 [GoAT diagrams]: /content-management/diagrams/#goat-diagrams-ascii
 [highlighting options]: /functions/transform/highlight/#options
 [info string]: https://spec.commonmark.org/current/#info-string

--- a/content/en/render-hooks/images.md
+++ b/content/en/render-hooks/images.md
@@ -133,5 +133,5 @@ Note that the embedded image render hook does not perform image processing. Its 
 [`RenderShortcodes`]: /methods/page/rendershortcodes
 [CommonMark specification]: https://spec.commonmark.org/current/
 [duplication of shared page resources]: /configuration/markup/#duplicateresourcefiles
-[embedded image render hook]: {{% eturl render-image %}}
+[embedded image render hook]: <{{% eturl render-image %}}>
 [Markdown attributes]: /content-management/markdown-attributes/

--- a/content/en/render-hooks/links.md
+++ b/content/en/render-hooks/links.md
@@ -104,4 +104,4 @@ target = 'assets'
 [`RenderShortcodes`]: /methods/page/rendershortcodes
 [CommonMark specification]: https://spec.commonmark.org/current/
 [duplication of shared page resources]: /configuration/markup/#duplicateresourcefiles
-[embedded link render hook]: {{% eturl render-link %}}
+[embedded link render hook]: <{{% eturl render-link %}}>

--- a/content/en/shortcodes/details.md
+++ b/content/en/shortcodes/details.md
@@ -71,4 +71,4 @@ details > summary > * { }
 details > :not(summary) { }
 ```
 
-[source code]: {{% eturl details %}}
+[source code]: <{{% eturl details %}}>

--- a/content/en/shortcodes/figure.md
+++ b/content/en/shortcodes/figure.md
@@ -106,4 +106,4 @@ source = 'static'
 target = 'assets'
 {{< /code-toggle >}}
 
-[source code]: {{% eturl figure %}}
+[source code]: <{{% eturl figure %}}>

--- a/content/en/shortcodes/highlight.md
+++ b/content/en/shortcodes/highlight.md
@@ -103,5 +103,5 @@ Pass the options when calling the shortcode. You can set their default values in
 [content format]: /content-management/formats/
 [highlighting styles]: /quick-reference/syntax-highlighting-styles/
 [site configuration]: /configuration/markup/#highlight
-[source code]: {{% eturl highlight %}}
+[source code]: <{{% eturl highlight %}}>
 [supported languages]: /content-management/syntax-highlighting/#languages

--- a/content/en/shortcodes/instagram.md
+++ b/content/en/shortcodes/instagram.md
@@ -39,4 +39,4 @@ disable
 simple
 : (`bool`) Whether to enable simple mode for image card generation. If `true`, Hugo creates a static card without JavaScript. This mode only supports image cards, and the image is fetched directly from Instagram's servers. Default is `false`.
 
-[source code]: {{% eturl instagram %}}
+[source code]: <{{% eturl instagram %}}>

--- a/content/en/shortcodes/param.md
+++ b/content/en/shortcodes/param.md
@@ -35,4 +35,4 @@ Access nested values by [chaining](g) the [identifiers](g):
 {{%/* param my.nested.param */%}}
 ```
 
-[source code]: {{% eturl param %}}
+[source code]: <{{% eturl param %}}>

--- a/content/en/shortcodes/qr.md
+++ b/content/en/shortcodes/qr.md
@@ -103,5 +103,5 @@ title
 [`publishDir`]: /configuration/all/#publishdir
 [QR code]: https://en.wikipedia.org/wiki/QR_code
 [related documentation]: /functions/images/qr/
-[source code]: {{% eturl qr %}}
+[source code]: <{{% eturl qr %}}>
 [vCard]: <https://en.wikipedia.org/wiki/VCard>

--- a/content/en/shortcodes/ref.md
+++ b/content/en/shortcodes/ref.md
@@ -62,4 +62,4 @@ Rendered:
 [duplication of shared page resources]: /configuration/markup/#duplicateresourcefiles
 [embedded link render hook]: /render-hooks/links/#embedded
 [Markdown notation]: /content-management/shortcodes/#notation
-[source code]: {{% eturl relref %}}
+[source code]: <{{% eturl relref %}}>

--- a/content/en/shortcodes/relref.md
+++ b/content/en/shortcodes/relref.md
@@ -62,4 +62,4 @@ Rendered:
 [duplication of shared page resources]: /configuration/markup/#duplicateresourcefiles
 [embedded link render hook]: /render-hooks/links/#embedded
 [Markdown notation]: /content-management/shortcodes/#notation
-[source code]: {{% eturl relref %}}
+[source code]: <{{% eturl relref %}}>

--- a/content/en/shortcodes/vimeo.md
+++ b/content/en/shortcodes/vimeo.md
@@ -67,7 +67,7 @@ enableDNT
 simple
 : (`bool`) Whether to enable simple mode. If `true`, the video thumbnail is fetched from Vimeo and overlaid with a play button. Clicking the thumbnail opens the video in a new Vimeo tab. Default is `false`.
 
-The source code for the simple version of the shortcode is available [here].
+The source code for the simple version of the shortcode is available [in this file].
 
-[here]: {{% eturl vimeo_simple %}}
-[source code]: {{% eturl vimeo %}}
+[in this file]: <{{% eturl vimeo_simple %}}>
+[source code]: <{{% eturl vimeo %}}>

--- a/content/en/shortcodes/x.md
+++ b/content/en/shortcodes/x.md
@@ -44,11 +44,11 @@ enableDNT
 simple
 : (`bool`) Whether to enable simple mode. If `true`, Hugo builds a static version of the of the post without JavaScript. Default is `false`.
 
-The source code for the simple version of the shortcode is available [here].
+The source code for the simple version of the shortcode is available [in this file].
 
 If you enable simple mode you may want to disable the hardcoded inline styles by setting `disableInlineCSS` to `true` in your site configuration. The default value for this setting is `false`.
 
 {{< code-toggle config=services.x />}}
 
-[here]: {{% eturl x_simple %}}
-[source code]: {{% eturl x %}}
+[in this file]: <{{% eturl x_simple %}}>
+[source code]: <{{% eturl x %}}>

--- a/content/en/templates/embedded.md
+++ b/content/en/templates/embedded.md
@@ -12,7 +12,7 @@ aliases: [/templates/internal]
 ## Disqus
 
 > [!note]
-> To override Hugo's embedded Disqus template, copy the [source code]({{% eturl disqus %}}) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
+> To override Hugo's embedded Disqus template, copy the [source code](<{{% eturl disqus %}}>) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
 >
 > `{{ partial "disqus.html" . }}`
 
@@ -57,7 +57,7 @@ disable
 ## Google Analytics
 
 > [!note]
-> To override Hugo's embedded Google Analytics template, copy the [source code]({{% eturl google_analytics %}}) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
+> To override Hugo's embedded Google Analytics template, copy the [source code](<{{% eturl google_analytics %}}>) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
 >
 > `{{ partial "google_analytics.html" . }}`
 
@@ -95,7 +95,7 @@ respectDoNotTrack
 ## Open Graph
 
 > [!note]
-> To override Hugo's embedded Open Graph template, copy the [source code]({{% eturl opengraph %}}) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
+> To override Hugo's embedded Open Graph template, copy the [source code](<{{% eturl opengraph %}}>) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
 >
 > `{{ partial "opengraph.html" . }}`
 
@@ -154,7 +154,7 @@ See&nbsp;[details](/templates/pagination/).
 ## Schema
 
 > [!note]
-> To override Hugo's embedded Schema template, copy the [source code]({{% eturl schema %}}) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
+> To override Hugo's embedded Schema template, copy the [source code](<{{% eturl schema %}}>) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
 >
 > `{{ partial "schema.html" . }}`
 
@@ -169,7 +169,7 @@ To include the embedded template:
 ## X (Twitter) Cards
 
 > [!note]
-> To override Hugo's embedded Twitter Cards template, copy the [source code]({{% eturl twitter_cards %}}) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
+> To override Hugo's embedded Twitter Cards template, copy the [source code](<{{% eturl twitter_cards %}}>) to a file with the same name in the `layouts/_partials` directory, then call it from your templates using the [`partial`] function:
 >
 > `{{ partial "twitter_cards.html" . }}`
 

--- a/content/en/templates/pagination.md
+++ b/content/en/templates/pagination.md
@@ -237,4 +237,4 @@ public/
 [`Paginator`]: /methods/page/paginator/
 [`partial`]: /functions/partials/include/
 [grouping methods]: /quick-reference/page-collections/#group
-[source code]: {{% eturl pagination %}}
+[source code]: <{{% eturl pagination %}}>

--- a/content/en/templates/robots.md
+++ b/content/en/templates/robots.md
@@ -48,5 +48,5 @@ This template creates a robots.txt file with a `Disallow` directive for each pag
 >
 > Remember that Hugo copies everything in the static director to the root of `publishDir` (typically `public`) when you build your site.
 
-[embedded template]: {{% eturl robots %}}
+[embedded template]: <{{% eturl robots %}}>
 [site configuration]: /configuration/

--- a/content/en/templates/rss.md
+++ b/content/en/templates/rss.md
@@ -72,4 +72,4 @@ layouts/
 
 RSS templates receive the `.Page` and `.Site` objects in context.
 
-[embedded RSS template]: {{% eturl rss %}}
+[embedded RSS template]: <{{% eturl rss %}}>

--- a/content/en/templates/sitemap.md
+++ b/content/en/templates/sitemap.md
@@ -49,6 +49,6 @@ disableKinds = ['sitemap']
 {{</ code-toggle >}}
 
 [`publishDir`]: /configuration/all/#publishdir
-[embedded sitemap template]: {{% eturl sitemap %}}
-[embedded sitemapindex template]: {{% eturl sitemapindex %}}
+[embedded sitemap template]: <{{% eturl sitemap %}}>
+[embedded sitemapindex template]: <{{% eturl sitemapindex %}}>
 [sitemap protocol]: https://www.sitemaps.org/protocol.html


### PR DESCRIPTION
This change fixes false positives reported by markdownlint rule MD052 when the shortcode is used as a link reference.