### PR TITLE
content: Replace inline URLs with autolinks

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -77,7 +77,7 @@ config:
     full: true
     inline: true
     shortcut: true
-    url_inline: true
+    url_inline: false
   MD055:
     style: consistent
   MD056: true

--- a/content/en/hugo-modules/introduction.md
+++ b/content/en/hugo-modules/introduction.md
@@ -12,8 +12,8 @@ Modules are combinable in any arrangement, and external directories (including t
 
 Some example projects:
 
-[https://github.com/bep/docuapi](https://github.com/bep/docuapi)
+<https://github.com/bep/docuapi>
 : A theme that has been ported to Hugo Modules while testing this feature. It is a good example of a non-Hugo-project mounted into Hugo's directory structure. It even shows a JS Bundler implementation in regular Go templates.
 
-[https://github.com/bep/my-modular-site](https://github.com/bep/my-modular-site)
+<https://github.com/bep/my-modular-site>
 : A simple site used for testing.


### PR DESCRIPTION
See markdownlint MD054:
https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md

Replace this:
[https://example.org](https://example.org)

With this:
<https://example.org>