### PR TITLE
theme: Don't exclude current section from related content

### DIFF
--- a/content/en/functions/transform/CanHighlight.md
+++ b/content/en/functions/transform/CanHighlight.md
@@ -2,7 +2,7 @@
 title: transform.CanHighlight
 description: Reports whether the given code language is supported by the Chroma highlighter.
 categories: []
-keywords: []
+keywords: [highlight]
 params:
   functions_and_methods:
     aliases: []

--- a/content/en/functions/transform/HighlightCodeBlock.md
+++ b/content/en/functions/transform/HighlightCodeBlock.md
@@ -2,7 +2,7 @@
 title: transform.HighlightCodeBlock
 description: Highlights code received in context within a code block render hook.
 categories: []
-keywords: []
+keywords: [highlight]
 params:
   functions_and_methods:
     aliases: []

--- a/layouts/_partials/layouts/related.html
+++ b/layouts/_partials/layouts/related.html
@@ -1,6 +1,5 @@
 {{- $heading := "See also" }}
-{{- $related := site.Pages.Related . }}
-{{- $related = $related | complement .CurrentSection.Pages | first 7 }}
+{{- $related := site.Pages.Related . | first 7}}
 
 {{- with $related }}
   {{ $.Store.Set "hasRelated" true }}


### PR DESCRIPTION
Using [this page](https://deploy-preview-3185--gohugoio.netlify.app/functions/transform/highlight/) as an example, this change ensures that the "See also" block now displays all related content. With our current theme, we validate front matter keywords against a controlled list to guarantee that the related content is precisely targeted. In the past, the "See also" block sometimes included loosely related or even unrelated pages, which made it less critical to include everything. Now that the content is so relevant, we can confidently show all related pages to the user.


