### PR TITLE
Update Println.md

### DIFF
--- a/content/en/functions/fmt/Println.md
+++ b/content/en/functions/fmt/Println.md
@@ -13,4 +13,5 @@ aliases: [/functions/println]
 
 ```go-html-template
 {{ println "foo" }} → foo\n
+{{ println "foo" "bar" }} → foo bar\n
 ```


### PR DESCRIPTION
Add example showing `fmt.Println` automatically inserts spaces between operands, unlike `fmt.Print`.