### PR TITLE
content: Fix missing link to latest release under Prebuilt Binaries

### DIFF
--- a/content/en/_common/installation/03-prebuilt-binaries.md
+++ b/content/en/_common/installation/03-prebuilt-binaries.md
@@ -15,3 +15,5 @@ Prebuilt binaries are available for a variety of operating systems and architect
 Please consult your operating system documentation if you need help setting file permissions or modifying your PATH environment variable.
 
 If you do not see a prebuilt binary for the desired edition, operating system, and architecture, install Hugo using one of the methods described below.
+
+[latest release]: https://github.com/gohugoio/hugo/releases/latest


### PR DESCRIPTION
Stumbled upon this dead link while getting started with Hugo @ https://gohugo.io/installation/macos/

<img width="1029" height="219" alt="dead" src="https://github.com/user-attachments/assets/8943d022-8900-43a5-b116-bb581bc5822a" />
