### PR TITLE
Fix Cloudflare deploy not_found_handling value

### DIFF
--- a/content/en/host-and-deploy/host-on-cloudflare/index.md
+++ b/content/en/host-and-deploy/host-on-cloudflare/index.md
@@ -35,7 +35,7 @@ Step 1
 
   [assets]
   directory = "./public"
-  not_found_handling = "404"
+  not_found_handling = "404-page"
   ```
 
 Step 2


### PR DESCRIPTION
not_found_handling value set to 404. This is invalid as valid options are "single-page-application", "404-page", "none"

```
10:49:25.411 | ⛅️ wrangler 4.33.1
-- | --
10:49:25.411 | ───────────────────
10:49:25.426 |  
10:49:25.565 | ✘ [ERROR] Processing wrangler.toml configuration:
10:49:25.565 |  
10:49:25.568 | - Expected "assets.not_found_handling" field to be one of ["single-page-application","404-page","none"] but got "404".
10:49:25.568


```