### PR TITLE
content: Update minify config documentation

### DIFF
--- a/content/en/configuration/minify.md
+++ b/content/en/configuration/minify.md
@@ -10,6 +10,11 @@ This is the default configuration:
 
 {{< code-toggle config=minify />}}
 
-See the [tdewolff/minify] project page for details.
+See the [tdewolff/minify] project page for details, but note the following:
+
+- `css.inline` is for internal use. Changing this setting has no effect.
+- `css.keepCSS2` has been deprecated. Use `css.version` instead.
+- `html.keepConditionalComments` has been deprecated. Use `html.keepSpecialComments` instead.
+- `svg.inline` is for internal use. Changing this setting has no effect.
 
 [tdewolff/minify]: https://github.com/tdewolff/minify

--- a/data/docs.yaml
+++ b/data/docs.yaml
@@ -1490,8 +1490,9 @@ config:
     tdewolff:
       css:
         inline: false
-        keepCSS2: true
+        keepCSS2: false
         precision: 0
+        version: 0
       html:
         keepComments: false
         keepConditionalComments: false


### PR DESCRIPTION
Merge this change when the release that follows v0.149.0 is out.

Add this to the release notes:

> CSS minification now targets CSS3, removing certain optimizations that were specific to CSS2.

<https://deploy-preview-3197--gohugoio.netlify.app/configuration/minify/>