### PR TITLE
theme: Move initColorScheme() to head

### DIFF
--- a/assets/js/body-start.js
+++ b/assets/js/body-start.js
@@ -1,6 +1,0 @@
-import { initColorScheme } from './alpinejs/stores/index';
-
-(function () {
-	// This allows us to initialize the color scheme before AlpineJS etc. is loaded.
-	initColorScheme();
-})();

--- a/assets/js/head-early.js
+++ b/assets/js/head-early.js
@@ -1,6 +1,10 @@
 import { scrollToActive } from 'js/helpers/index';
+import { initColorScheme } from './alpinejs/stores/index';
 
 (function () {
+	// This allows us to initialize the color scheme before AlpineJS etc. is loaded.
+	initColorScheme();
+
 	// Now we know that the browser has JS enabled.
 	document.documentElement.classList.remove('no-js');
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,14 +8,6 @@ import focus from '@alpinejs/focus';
 
 var debug = 0 ? console.log.bind(console, '[index]') : function () {};
 
-// Turbolinks init.
-(function () {
-	document.addEventListener('turbo:render', function (e) {
-		// This is also called right after the body start. This is added to prevent flicker on navigation.
-		initColorScheme();
-	});
-})();
-
 // Set up and start Alpine.
 (function () {
 	// Register AlpineJS plugins.

--- a/layouts/_partials/layouts/hooks/body-start.html
+++ b/layouts/_partials/layouts/hooks/body-start.html
@@ -1,3 +1,0 @@
-{{ with resources.Get "js/body-start.js" | js.Build (dict "minify" true) }}
-  {{ partial "helpers/linkjs.html" (dict "r" . "attributes" (dict "" "")) }}
-{{ end }}


### PR DESCRIPTION
Also remove the initColorScheme() in `turbo:render` which is not needed after we moved the `dark` class from body to documentElement.
