### PR TITLE
Update new-templatesystem-overview.md to change section.html to list.html

### DIFF
--- a/content/en/templates/new-templatesystem-overview.md
+++ b/content/en/templates/new-templatesystem-overview.md
@@ -61,7 +61,7 @@ layouts
 ├── baseof.term.html
 ├── home.html
 ├── page.html
-├── section.html
+├── list.html
 ├── taxonomy.html
 ├── term.html
 ├── term.mylayout.en.rss.xml


### PR DESCRIPTION
From my understanding of the changes to v0.146.0 section.html is still functional but list.html is preferred? I updated the example to reflect this change. If I misunderstood than please close off this PR. Thanks guys.

---

Btw, I love hugo and appreciate all the dev work you guys put into it, thanks bep and team.