### PR TITLE
content: Add `--format` to hugo_new_theme.md

### DIFF
--- a/content/en/commands/hugo_new_theme.md
+++ b/content/en/commands/hugo_new_theme.md
@@ -21,6 +21,7 @@ hugo new theme [name] [flags]
 ### Options
 
 ```
+      --format string   preferred file format (toml, yaml or json) (default "toml")
   -h, --help   help for theme
 ```
 


### PR DESCRIPTION
`--format` is documented in -h, but is missing from the docs.

This PR brings the docs up to date.