### PR TITLE
content: Correct partial path in Tailwind CSS setup guide

### DIFF
--- a/content/en/functions/css/TailwindCSS.md
+++ b/content/en/functions/css/TailwindCSS.md
@@ -94,7 +94,7 @@ Step 5
   <head>
     ...
     {{ with (templates.Defer (dict "key" "global")) }}
-      {{ partial "css.html" . }}
+      {{ partial "head/css.html" . }}
     {{ end }}
     ...
   </head>


### PR DESCRIPTION
### Description

This PR corrects a path discrepancy in the css.TailwindCSS documentation.

### Issue
When a user creates a new theme using `hugo new theme [name]`, the CSS partial is generated at `layouts/partials/head/css.html`.

However, the documentation instructs the user to call the partial with:
```go-html-template
{{ partial "css.html" . }}
```
This leads to a "partial not found" error for anyone following the guide with a fresh theme.

### Solution
This change updates the code snippet in the documentation to use the correct path that aligns with the theme scaffolding:
```go-html-template
{{ partial "head/css.html" . }}
```

This small correction will help ensure a smoother setup experience preventing unnecessary friction.