### PR TITLE
content: update archetype lookup order to match actual behavior

### DIFF
--- a/content/en/content-management/archetypes.md
+++ b/content/en/content-management/archetypes.md
@@ -53,11 +53,16 @@ hugo new content posts/my-first-post.md
 The archetype lookup order is:
 
 1. `archetypes/posts.md`
-1. `archetypes/default.md`
 1. `themes/my-theme/archetypes/posts.md`
+1. `archetypes/default.md`
 1. `themes/my-theme/archetypes/default.md`
 
 If none of these exists, Hugo uses a built-in default archetype.
+
+> [!note]
+> Hugo has a [theme components] feature. This means that if the project has its `theme` set as a composite, the second and fourth items will use Hugo's lookup rules and check all themes specified in the composite before moving further down the list.
+>
+> If you're running Hugo without a theme, second and fourth items are skipped.
 
 ## Functions and context
 
@@ -184,3 +189,5 @@ To create an article using the tutorials archetype:
 ```sh
 hugo new content --kind tutorials articles/something.md
 ```
+
+[theme components]: /hugo-modules/theme-components/


### PR DESCRIPTION
Fixes #724

Archetype lookup order docs do not match current behavior ([code](https://github.com/gohugoio/hugo/blob/v0.151.2/create/content.go#L256-L260))

Resurrection of https://github.com/gohugoio/hugoDocs/pull/725 by @mdhender (@mdhender I've added you as co-author, if that is ok with you, if not  please let me know I will remove it)

Reproduction repo https://github.com/imomaliev/hugo-archetype-lookup-order

**Summary**:

```
.
├── README.md
├── archetypes
│   ├── default.md
│   └── posts.md
├── hugo.toml
└── themes
    └── theme
        ├── archetypes
        │   ├── articles.md
        │   ├── default.md
        │   └── posts.md
        ├── assets
        │   ├── css
        │   │   └── main.css
        │   └── js
        │       └── main.js
        ├── content
        │   ├── _index.md
        │   └── posts
        │       ├── _index.md
        │       ├── post-1.md
        │       ├── post-2.md
        │       └── post-3
        │           ├── bryce-canyon.jpg
        │           └── index.md
        ├── hugo.toml
        ├── layouts
        │   ├── _partials
        │   │   ├── footer.html
        │   │   ├── head
        │   │   │   ├── css.html
        │   │   │   └── js.html
        │   │   ├── head.html
        │   │   ├── header.html
        │   │   ├── menu.html
        │   │   └── terms.html
        │   ├── baseof.html
        │   ├── home.html
        │   ├── page.html
        │   ├── section.html
        │   ├── taxonomy.html
        │   └── term.html
        └── static
            └── favicon.ico
```

```console
$ hugo new posts/post-1.md
$ hugo new articles/article-1.md
```

Expected content to be created:

```
Post: This is site post
Article: This is site default
```

Actual:

```
Post: This is site post
Article: This is theme article
```