### PR TITLE
content: Fix example for `default`

### DIFF
--- a/content/en/functions/compare/Default.md
+++ b/content/en/functions/compare/Default.md
@@ -41,7 +41,7 @@ The `default` function returns the first argument if the second argument is not 
 {{ default 42 "" }} → 42
 {{ default 42 dict }} → 42
 {{ default 42 slice }} → 42
-{{ default 42 <nil> }} → 42
+{{ default 42 nil }} → 42
 ```
 
 [`or`]: /functions/go-template/or/


### PR DESCRIPTION
`{{ default 42 <nil> }}` is not valid syntax; it should be `{{ default 42 nil }}`.