### PR TITLE
content: Update KaTeX link attributes to v0.16.25 (phase 2)

### DIFF
--- a/content/en/content-management/mathematics.md
+++ b/content/en/content-management/mathematics.md
@@ -10,7 +10,7 @@ keywords: []
 
 Mathematical equations and expressions written in [LaTeX][] are common in academic and scientific publications. Your browser typically renders this mathematical markup using an open-source JavaScript display engine such as [MathJax][] or [KaTeX][].
 
-For example, with this LaTeX markup:
+For example, this LaTeX markup:
 
 ```text
 \[
@@ -21,7 +21,7 @@ JS(\hat{y} || y) &= \frac{1}{2}(KL(y||\frac{y+\hat{y}}{2}) + KL(\hat{y}||\frac{y
 \]
 ```
 
-The MathJax display engine renders this:
+Is rendered to:
 
 \[
 \begin{aligned}
@@ -195,7 +195,7 @@ To use KaTeX instead of MathJax, replace the _partial_ template from [Step 2][] 
   src="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/contrib/auto-render.min.js"
   integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh"
   crossorigin="anonymous"
-    onload="renderMathInElement(document.body);">
+  onload="renderMathInElement(document.body);">
 </script>
 <script>
   document.addEventListener("DOMContentLoaded", function() {

--- a/content/en/functions/transform/ToMath.md
+++ b/content/en/functions/transform/ToMath.md
@@ -63,7 +63,13 @@ output
   With `html` and `htmlAndMathml` you must include the KaTeX style sheet within the `head` element of your base template.
 
   ```html
-  <link href="https://cdn.jsdelivr.net/npm/katex@0.16.23/dist/katex.min.css" rel="stylesheet">
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/katex.min.css"
+    integrity="sha384-WcoG4HRXMzYzfCgiyfrySxx90XSl2rxY5mnVY5TwtWE6KLrArNKn0T/mOgNL0Mmi"
+    crossorigin="anonymous"
+  >
+  ```
 
 strict
 : {{< new-in 0.147.6 />}}
@@ -132,7 +138,12 @@ Step 3
   <head>
     {{ $noop := .WordCount }}
     {{ if .Page.Store.Get "hasMath" }}
-      <link href="https://cdn.jsdelivr.net/npm/katex@0.16.23/dist/katex.min.css" rel="stylesheet">
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/katex.min.css"
+        integrity="sha384-WcoG4HRXMzYzfCgiyfrySxx90XSl2rxY5mnVY5TwtWE6KLrArNKn0T/mOgNL0Mmi"
+        crossorigin="anonymous"
+      >
     {{ end }}
   </head>
   ```

--- a/content/en/render-hooks/passthrough.md
+++ b/content/en/render-hooks/passthrough.md
@@ -104,7 +104,12 @@ Then, in your base template, conditionally include the KaTeX CSS within the head
 <head>
   {{ $noop := .WordCount }}
   {{ if .Page.Store.Get "hasMath" }}
-    <link href="https://cdn.jsdelivr.net/npm/katex@0.16.23/dist/katex.min.css" rel="stylesheet">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/katex.min.css"
+      integrity="sha384-WcoG4HRXMzYzfCgiyfrySxx90XSl2rxY5mnVY5TwtWE6KLrArNKn0T/mOgNL0Mmi"
+      crossorigin="anonymous"
+    >
   {{ end }}
 </head>
 ```

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -27,8 +27,11 @@
     {{ $noop := .WordCount }}
     {{ if .Page.Store.Get "hasMath" }}
       <link
-        href="https://cdn.jsdelivr.net/npm/katex@0.16.23/dist/katex.min.css"
-        rel="stylesheet">
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/katex.min.css"
+        integrity="sha384-WcoG4HRXMzYzfCgiyfrySxx90XSl2rxY5mnVY5TwtWE6KLrArNKn0T/mOgNL0Mmi"
+        crossorigin="anonymous"
+      >
     {{ end }}
     {{ partial "layouts/head/head.html" . }}
   </head>


### PR DESCRIPTION
Affects:

- content/en/content-management/mathematics.md
- content/en/functions/transform/ToMath.md
- content/en/render-hooks/passthrough.md
- layouts/baseof.html