### PR TITLE
Revert the minimal analytics changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ node_modules/
 nohup.out
 package-lock.json
 trace.out
-assets/jsconfig.json
-

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -47,9 +47,6 @@ var debug = 0 ? console.log.bind(console, '[index]') : function () {};
 	bridgeTurboAndAlpine(Alpine);
 
 	{
-		// Minimal Analytics does not support SPA out of the box, so we need to manually track page views on Turbo navigation.
-		addEventListener('turbo:visit', () => window.track('page_view'));
-
 		let containerScrollTops = {};
 
 		// To preserve scroll position in scrolling elements on navigation add data-turbo-preserve-scroll-container="somename" to the scrolling container.

--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -1,0 +1,10 @@
+{
+ "compilerOptions": {
+  "baseUrl": ".",
+  "paths": {
+   "*": [
+    "*"
+   ]
+  }
+ }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/gohugoio/hugoDocs
 
 go 1.22.0
-
-require (
-	github.com/bep/hugo-mod-minimalanalytics v0.3.0 // indirect
-	github.com/jahilldev/minimal-analytics v0.0.0-20220825110705-ee335ed38334 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/bep/hugo-mod-minimalanalytics v0.3.0 h1:fctZN3nFOFrapX1dhPBszyCUKOGjEpBJmp1jBf3YkJE=
-github.com/bep/hugo-mod-minimalanalytics v0.3.0/go.mod h1:3QVkKqSikBRTI+hS3dm/zCAfGukd+opSfAwfjkyxqIw=
-github.com/jahilldev/minimal-analytics v0.0.0-20220825110705-ee335ed38334 h1:r8/jLqGw5uwSmgJ4eSGbxa1XBaSIkp3MY99GhY61NeE=
-github.com/jahilldev/minimal-analytics v0.0.0-20220825110705-ee335ed38334/go.mod h1:w4l2fXZWGxmcVQfLLBdTqUT6HpSIA9FhmUtVArJFLYw=
+github.com/gohugoio/gohugoioTheme v0.0.0-20250116152525-2d382cae7743 h1:gjoqq8+RnGwpuU/LQVYGGR/LsDplrfUjOabWwoROYsM=
+github.com/gohugoio/gohugoioTheme v0.0.0-20250116152525-2d382cae7743/go.mod h1:GOYeAPQJ/ok8z7oz1cjfcSlsFpXrmx6VkzQ5RpnyhZM=

--- a/hugo.toml
+++ b/hugo.toml
@@ -98,8 +98,6 @@ ignoreLogs = ['warning-frontmatter-params-overrides']
     disableWatch = true
     source       = "hugo_stats.json"
     target       = "assets/notwatching/hugo_stats.json"
-  [[module.imports]]
-    path = "github.com/bep/hugo-mod-minimalanalytics"
 
 [outputFormats]
   [outputFormats.redir]
@@ -122,11 +120,6 @@ ignoreLogs = ['warning-frontmatter-params-overrides']
 [params]
   description = "The world’s fastest framework for building websites"
   ghrepo      = "https://github.com/gohugoio/hugoDocs/"
-
-  [params.minimalanalytics]
-      # GA4 tracking ID
-      tracking_id = "G-MBZGKNMDWC"
-
   [params.render_hooks.link]
     errorLevel = 'warning' # ignore (default), warning, or error (fails the build)
   [params.social.mastodon]
@@ -154,6 +147,10 @@ ignoreLogs = ['warning-frontmatter-params-overrides']
       Referrer-Policy        = "no-referrer"
   [[server.headers]]
     for = "/**.{css,js}"
+
+[services]
+  [services.googleAnalytics]
+    ID = 'G-MBZGKNMDWC'
 
 [taxonomies]
   category = 'categories'

--- a/layouts/_partials/helpers/gtag.html
+++ b/layouts/_partials/helpers/gtag.html
@@ -1,0 +1,27 @@
+{{ with site.Config.Services.GoogleAnalytics.ID }}
+  <script
+    async
+    src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  {{ $site := site.BaseURL | replaceRE "^https?://(www\\.)?([^/]+).*" "$2" }}
+  gtag('config', '{{ . }}', {'anonymize_ip': true, 'dimension1': '{{ $site }}', 'dimension2': '{{ getenv "BRANCH" }}'});
+
+/**
+* Function that tracks a click on an outbound link in Analytics.
+* Setting the transport method to 'beacon' lets the hit be sent
+* using 'navigator.sendBeacon' in browser that support it.
+*/
+var trackOutboundLink = function(id, url) {
+  gtag('event', 'click', {
+    'event_category': 'outbound',
+    'event_label': id,
+    'transport_type': 'beacon'
+  });
+}
+
+</script>
+{{ end }}

--- a/layouts/_partials/layouts/head/head-js.html
+++ b/layouts/_partials/layouts/head/head-js.html
@@ -1,6 +1,3 @@
-{{ if or hugo.IsProduction (not hugo.IsDevelopment) }}
-  {{ partial "minimalanalytics.html" . }}
-{{ end }}
 {{ $githubInfo := partialCached "helpers/funcs/get-github-info.html" . "-" }}
 {{ $opts := dict "minify" true }}
 {{ with resources.Get "js/head-early.js" | js.Build $opts }}

--- a/layouts/_partials/layouts/head/head.html
+++ b/layouts/_partials/layouts/head/head.html
@@ -36,3 +36,6 @@
 {{ partial "schema.html" . }}
 {{ partial "twitter_cards.html" . }}
 
+{{ if hugo.IsProduction }}
+  {{ partial "helpers/gtag.html" . }}
+{{ end }}

--- a/layouts/_partials/layouts/home/sponsors.html
+++ b/layouts/_partials/layouts/home/sponsors.html
@@ -15,9 +15,13 @@
             {{ $url = printf "%s?%s%s" .link $query_params (querify "utm_source" (.utm_source | default $utmSource ) "utm_medium" (.utm_medium | default "banner") "utm_campaign" (.utm_campaign | default "hugosponsor") "utm_content" (.utm_content | default "gohugoio")) | safeURL }}
           {{ end }}
           {{ $logo := resources.Get .logo }}
+          {{ $gtagID := printf "Sponsor %s %s" .name $gtag | title }}
           <a
             href="{{ $url }}"
             title="{{ .title | default .name }}"
+            {{ if hugo.IsProduction }}
+              onclick="trackOutboundLink({{ printf "'%s', '%s'" $gtagID $url | safeJS }});"
+            {{ end }}
             class="group inline-block w-full h-full shadow-md dark:shadow-gray-600"
             {{ with .link_attr }}{{ . | safeHTMLAttr }}{{ end }}>
             <div


### PR DESCRIPTION
- **Revert "theme: Move tracking to turbo:load"**
- **Revert "theme: Move tracking to turbo:render"**
- **Revert "Move to minimalanalytics for GA tracking"**

The main issue that I don't have time to look into now is that https://github.com/jahilldev/minimal-analytics adds a set of document listeners (e.g. scroll) that doesn't work (survive) with Turbo on navigation.
