### PR TITLE
Clarify template file name identifiers and lookup rules

### DIFF
--- a/content/en/templates/lookup-order.md
+++ b/content/en/templates/lookup-order.md
@@ -36,6 +36,57 @@ Section
 > [!note]
 > Templates can live in either the project's or the themes' `layout` directories, and the most specific templates will be chosen. Hugo will interleave the lookups listed below, finding the most specific one either in the project or themes.
 
+## Template File Name Identifiers
+
+Starting with Hugo v0.146.0, template file name segments (identifiers separated by dots) must correspond to recognized Hugo parameters. These segments are parsed according to the lookup rules above.
+
+### Recognized Identifiers
+
+Hugo recognizes the following identifiers in template file names:
+
+- **Layout name**: The base name of the template (e.g., `single`, `list`, `index`)
+- **Output format**: Valid format names like `html`, `rss`, `json`, `xml`, `amp`
+- **Language code**: Valid language tags (e.g., `en`, `fr`, `de`)
+- **Page kind**: Values like `home`, `section`, `taxonomy`, `term`
+- **Type**: The content type (e.g., `post`, `page`)
+- **Section**: Section names for section-specific templates
+
+### Fallback Behavior
+
+If a template file name contains an **unrecognized identifier**, Hugo will fall back to a less specific template that matches the recognized segments.
+
+For example:
+
+| Template File Name | Recognized By Hugo | Fallback Behavior |
+|-------------------|-------------------|-------------------|
+| `single.html` | ✓ Standard match | Used as-is |
+| `single.json.html` | ✓ Valid output format | Used as-is |
+| `single.en.html` | ✓ Valid language code | Used as-is |
+| `single.blog.html` | ✗ "blog" unrecognized | Falls back to `single.html` |
+| `single.foo.html` | ✗ "foo" unrecognized | Falls back to `single.html` |
+| `single.green.json.html` | Partial - "green" unrecognized | May fall back to `single.json.html` |
+
+The same logic applies to partials:
+
+| Partial Call | File Name | Result |
+|-------------|-----------|--------|
+| `{{ partial "header.html" . }}` | `header.html` | ✓ Direct match |
+| `{{ partial "header.json" . }}` | `header.json` | ✓ Valid format |
+| `{{ partial "header.blog.html" . }}` | `header.blog.html` | ✗ Falls back to `header.html` |
+
+### Best Practices
+
+To avoid unexpected fallback behavior:
+
+1. **Use recognized identifiers only**: Stick to output formats, language codes, and valid Hugo parameters
+2. **Test custom naming conventions**: Verify that your template naming scheme produces the expected results
+3. **Prefer explicit targeting**: Use front matter (`type`, `layout`) to explicitly target templates rather than relying on complex file name patterns
+
+> [!tip]
+> If you need template variations based on custom criteria, use front matter parameters and conditional logic within your templates rather than encoding these variations in file names.
+
+For more details on the template system changes, see the [Hugo v0.146.0 release notes](https://github.com/gohugoio/hugo/releases/tag/v0.146.0).
+
 ## Target a template
 
 You cannot change the lookup order to target a content page, but you can change a content page to target a template. Specify `type`, `layout`, or both in front matter.

--- a/content/en/templates/new-templatesystem-overview.md
+++ b/content/en/templates/new-templatesystem-overview.md
@@ -53,6 +53,69 @@ For templates placed in a `layouts` folder partly or completely matching a [Page
 - `layouts/docs/baseof.html` will be used as the base template for the Page path `/docs` and below.
 - `layouts/tags/term.html` will be used for all `term` rendering in the `tags` taxonomy, except for the `blue` term, which will use `layouts/tags/blue/list.html`.
 
+## Template File Name Identifiers and Resolution
+
+Template file names in Hugo use dot-separated identifiers to specify various parameters. Understanding which identifiers are valid is crucial to avoid unexpected fallback behavior.
+
+### Valid Identifiers
+
+Only the following identifiers are recognized in template file names:
+
+- **Layout custom**: Custom layout names defined in front matter (e.g., `mylayout`)
+- **Page kinds**: `home`, `page`, `section`, `taxonomy`, `term`
+- **Standard layouts**: `list`, `single`, `all`
+- **Output format**: `html`, `rss`, `json`, `xml`, `amp`, etc.
+- **Language code**: Valid language tags like `en`, `fr`, `de`, `es`
+- **Media type suffix**: `.html`, `.xml`, `.json`, etc.
+
+### Fallback Behavior with Unrecognized Identifiers
+
+If a template file name contains an **unrecognized identifier** (any token not listed above), Hugo will fall back to a less specific template that matches only the recognized segments.
+
+> [!warning]
+> Using arbitrary or custom tokens in template file names (e.g., `home.foo.html`, `single.blog.html`, `term.green.html`) will cause Hugo to ignore those tokens and fall back to simpler templates. This can lead to unexpected template selection.
+
+#### Examples: Template File Name Resolution
+
+| Template File Name | Result | Explanation |
+|-------------------|--------|-------------|
+| `home.html` | ✓ Used as-is | All identifiers valid |
+| `home.en.html` | ✓ Used as-is | Valid language code |
+| `home.rss.xml` | ✓ Used as-is | Valid output format and suffix |
+| `term.mylayout.en.rss.xml` | ✓ Used as-is | All identifiers valid (matches example in folder structure) |
+| `home.foo.html` | ✗ Falls back to `home.html` | "foo" is unrecognized |
+| `single.blog.html` | ✗ Falls back to `single.html` | "blog" is unrecognized |
+| `taxonomy.green.html` | ✗ Falls back to `taxonomy.html` | "green" is unrecognized |
+| `section.custom.en.html` | Partial fallback | "custom" ignored, may use `section.en.html` |
+
+#### Examples: Partial File Name Resolution
+
+The same rules apply to partials:
+
+| Partial Call | File Name Available | File Used | Explanation |
+|-------------|---------------------|-----------|-------------|
+| `{{ partial "header.html" . }}` | `header.html` | `header.html` | Direct match |
+| `{{ partial "header.json" . }}` | `header.json` | `header.json` | Valid output format |
+| `{{ partial "header.html" . }}` | `header.blog.html` | `header.html` (fallback) | "blog" unrecognized, falls back |
+| `{{ partial "nav.html" . }}` | `nav.mobile.html` | `nav.html` (fallback) | "mobile" unrecognized, falls back |
+
+### Best Practices
+
+1. **Only use recognized identifiers**: Stick to documented Hugo parameters when naming templates
+2. **Avoid custom tokens**: Don't invent your own identifiers like "mobile," "dark," "v2," etc.
+3. **Use front matter for variations**: Instead of encoding variations in file names, use front matter parameters and conditional logic within templates
+4. **Test thoroughly**: After renaming templates, verify that Hugo selects the expected template for each page
+
+> [!tip]
+> If you need template variations based on custom criteria (e.g., page theme, layout version, device type), define these as front matter parameters and use conditional logic inside your templates rather than trying to encode them in file names.
+
+### Related Resources
+
+For more information on this behavior and its implementation, see:
+
+- [Hugo v0.146.0 release notes](https://github.com/gohugoio/hugo/releases/tag/v0.146.0)
+- [GitHub Issue #13248](https://github.com/gohugoio/hugo/issues/13248) - Discussion on template identifier behavior
+
 ## Example folder structure
 
 ```text


### PR DESCRIPTION
This update clarifies the rules Hugo applies when resolving template and partial file names with dot-separated identifiers.  
It explains which tokens are valid (like layout, page kind, output format, language) and warns about fallback behavior when arbitrary or unrecognized tokens are used.  
Concrete examples and best practices are included to help users avoid common pitfalls.  
This resolves confusion documented in issue #3248.
