### PR TITLE
content: Add missing reference definitions

### DIFF
--- a/content/en/_common/installation/02-prerequisites.md
+++ b/content/en/_common/installation/02-prerequisites.md
@@ -29,6 +29,7 @@ Please refer to the relevant documentation for installation instructions:
 
 [cloudcannon]: https://cloudcannon.com/
 [cloudflare pages]: https://pages.cloudflare.com/
+[commit information]: /methods/page/GitInfo
 [dart sass install]: /functions/css/sass/#dart-sass
 [dart sass]: https://sass-lang.com/dart-sass
 [git install]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
@@ -37,4 +38,5 @@ Please refer to the relevant documentation for installation instructions:
 [gitlab pages]: https://docs.gitlab.com/ee/user/project/pages/
 [go install]: https://go.dev/doc/install
 [go]: https://go.dev/
+[hugo modules]: /hugo-modules/
 [netlify]: https://www.netlify.com/

--- a/content/en/functions/js/Batch.md
+++ b/content/en/functions/js/Batch.md
@@ -295,6 +295,8 @@ console.log('entrypoints-workaround.js');
 [code splitting]: https://esbuild.github.io/api/#splitting
 [config]: #config
 [ESBuild]: https://github.com/evanw/esbuild
+[group]: #group
+[instance]: #instance
 [JavaScript import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [js.Batch Demo Repo]: https://github.com/bep/hugojsbatchdemo/
 [OptionsSetter]: #optionssetter

--- a/content/en/templates/introduction.md
+++ b/content/en/templates/introduction.md
@@ -541,6 +541,7 @@ In the template example above, each of the keys is a valid identifier. For examp
 [`template`]: /functions/go-template/template/
 [`Title`]: /methods/page/title
 [`with`]: /functions/go-template/with/
+[current context]: #current-context
 [embedded templates]: /templates/embedded/
 [front matter fields]: /content-management/front-matter/#fields
 [front matter]: /content-management/front-matter/


### PR DESCRIPTION
Some shortcut references did not have their destinations defined at the end of their respective documentation files.

This PR adds those definitions (by making some assumptions on the actual destinations).
Please let me know if the destinations are not correct, and if I missed any of them (I ran a simple script to scrape the documentation folder to find these, and might or might not have missed some).

See Issue: #3273 