### PR TITLE
docs: Clarify output of 'hugo new site' command

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -60,6 +60,7 @@ View your site at the URL displayed in your terminal. Press `Ctrl + C` to stop H
 ### Explanation of commands
 
 Create the [directory structure] for your project in the `quickstart` directory.
+This command creates a new directory named `quickstart` containing several subdirectories and a default configuration file (`hugo.toml`).
 
 ```text
 hugo new site quickstart


### PR DESCRIPTION
This PR clarifies the output of the `hugo new site` command in the Quick Start guide, as part of improving beginner-friendliness.

It adds a sentence explaining that the command creates a new directory and what that directory contains (subfolders and a config file).