### PR TITLE
Add a note about 404 redirection not working locally in hugo server

### DIFF
--- a/content/en/templates/404.md
+++ b/content/en/templates/404.md
@@ -30,6 +30,8 @@ layouts/
 └── 404.fr.html
 ```
 
+When running your site locally, `hugo server` will not automatically load your custom `404.html` file, but you can test the appearance of your custom "not found" page by navigating your browser to `/404.html`.
+
 Your production server redirects the browser to the 404 page when a page is not found. Capabilities and configuration vary by host.
 
 Host|Capabilities and configuration


### PR DESCRIPTION
This used to be documented (6b626fac61e43894a4c560073ee27ef33e8e6a37) but got lost in the seven years since.

Since a user would reasonably expect the built-in first-party local server to support all Hugo features, I think it is important to point out that this is not the case for 404 page support. The lack of this note wasted me some time today having to read through blog posts and old issues to find out it's unsupported.

This note can be removed should gohugoio/hugo#874 ever be implemented.