### PR TITLE
theme: Run ncu -u to update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@awmottaz/prettier-plugin-void-html": "~1.8.0",
-    "@tailwindcss/cli": "~4.1.0",
-    "@tailwindcss/typography": "~0.5.16",
-    "prettier": "~3.5.3",
+    "@awmottaz/prettier-plugin-void-html": "~2.0.0",
+    "@tailwindcss/cli": "~4.1.18",
+    "@tailwindcss/typography": "~0.5.19",
+    "prettier": "~3.7.4",
     "prettier-plugin-go-template": "~0.0.15",
-    "tailwindcss": "~4.1.0"
+    "tailwindcss": "~4.1.18"
   },
   "dependencies": {
-    "@alpinejs/focus": "~3.14.9",
-    "@alpinejs/persist": "~3.14.9",
-    "@hotwired/turbo": "~8.0.13",
-    "alpinejs": "~3.14.9"
+    "@alpinejs/focus": "~3.15.3",
+    "@alpinejs/persist": "~3.15.3",
+    "@hotwired/turbo": "~8.0.20",
+    "alpinejs": "~3.15.3"
   }
 }


### PR DESCRIPTION
Given the use of the `~` prefix, I see only AlpineJS of the runtime modules that's really being upgrade by this.