### PR TITLE
theme: Modernize sans-serif font stack for cross-platform consistency

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -77,8 +77,9 @@
 
   /* Fonts. */
   --font-sans:
-    "Mulish", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    "Mulish", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 html {


### PR DESCRIPTION
Replaces generic ui-sans-serif and system-ui keywords with a specific list of preferred system fonts (similar to GitHub’s stack). This prevents visual inconsistencies across operating systems.

This specifically resolves an issue on Ubuntu where the default system font was overriding Noto Color Emoji, leading to broken or inconsistent emoticon rendering.

Before:

<img width="257" height="259" alt="image" src="https://github.com/user-attachments/assets/c3cefd60-5145-4824-b9ce-f101fa769a65" />

After:

<img width="257" height="264" alt="image" src="https://github.com/user-attachments/assets/3700f236-f036-4caa-b7a0-606f27a9ad6a" />
