### PR TITLE
Add Dart Sass installation to SourceHut CI workflow

### DIFF
--- a/content/en/functions/css/Sass.md
+++ b/content/en/functions/css/Sass.md
@@ -141,6 +141,7 @@ For examples of how to install Dart Sass in a production environment, see these 
 - [GitLab Pages][]
 - [Netlify][]
 - [Render][]
+- [SourceHut][]
 - [Vercel][]
 
 [`css.Quoted`]: /functions/css/quoted/
@@ -162,5 +163,6 @@ For examples of how to install Dart Sass in a production environment, see these 
 [SCSS]: https://sass-lang.com/documentation/syntax#scss
 [Snap package]: https://snapcraft.io/hugo
 [snapcraft.io]: https://snapcraft.io/dart-sass
+[SourceHut]: /host-and-deploy/host-on-sourcehut-pages/
 [v0.153.0]: https://github.com/gohugoio/hugo/releases/tag/v0.153.0
 [Vercel]: /host-and-deploy/host-on-vercel/


### PR DESCRIPTION
Fresh PR (previously #3319) with commits and changes made locally (not via GitHub web UI). 

Changes: 

1. Add installation steps for Dart Sass in SourceHut Build Manifest (CI/CD)
2. Add a link to the SourceHut deploy page from the Dart Sass page
3. Updated existing Markdown links to match the contribution guidelines (collapsed link references)
