### PR TITLE
content: Refactor pages related to image processing

### DIFF
--- a/content/en/_common/methods/resource/processing-spec.md
+++ b/content/en/_common/methods/resource/processing-spec.md
@@ -2,35 +2,72 @@
 _comment: Do not remove front matter.
 ---
 
-## Process specification
+## Processing specification
 
-The process specification is a space-delimited, case-insensitive list of one or more of the following in any sequence:
+The processing specification is a space-delimited, case-insensitive list containing one or more of the following options in any sequence:
 
 action
-: Applicable to the [`Process`](/methods/resource/process) method only. Specify zero or one of `crop`, `fill`, `fit`, or `resize`. If you specify an action you must also provide dimensions.
-
-dimensions
-: Provide width _or_ height when using the [`Resize`](/methods/resource/resize) method, else provide both width _and_ height. See&nbsp;[details](/content-management/image-processing/#dimensions).
+: Specify one of `crop`, `fill`, `fit`, or `resize`. This is applicable to the [`Process`][] method and the [`images.Process`][] filter. If you specify an action, you must also provide dimensions.
 
 anchor
-: Use with the [`Crop`](/methods/resource/crop) and [`Fill`](/methods/resource/fill) methods. Specify zero or one of `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`. Default is `Smart`. See&nbsp;[details](/content-management/image-processing/#anchor).
-
-rotation
-: Typically specify zero or one of `r90`, `r180`, or `r270`. Also supports arbitrary rotation angles. See&nbsp;[details](/content-management/image-processing/#rotation).
-
-target format
-: Specify zero or one of `gif`, `jpeg`, `png`, `tiff`, or `webp`. See&nbsp;[details](/content-management/image-processing/#target-format).
-
-quality
-: Applicable to JPEG and WebP images. Optionally specify `qN` where `N` is an integer in the range [0, 100]. Default is `75`. See&nbsp;[details](/content-management/image-processing/#quality).
-
-hint
-: Applicable to WebP images and equivalent to the `-preset` flag for the [`cwebp`] encoder. Specify zero or one of `drawing`, `icon`, `photo`, `picture`, or `text`. Default is `photo`. See&nbsp;[details](/content-management/image-processing/#hint).
-
-[`cwebp`]: https://developers.google.com/speed/webp/docs/cwebp
+: The focal point of the crop box when cropping or filling an image. Valid options include `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`. This defaults to the [`anchor`][] parameter in your site configuration. The `Smart` option identifies the most interesting area of the image based on the smart cropping algorithm implemented in the [`smartcrop.js`][] library.
 
 background color
-: When converting a PNG or WebP with transparency to a format that does not support transparency, optionally specify a background color using a 3-digit or a 6-digit hexadecimal color code. Default is `#ffffff` (white). See&nbsp;[details](/content-management/image-processing/#background-color).
+: The background color of the resulting image. This applies when converting an image with transparency to a format that does not support it, such as when converting from PNG to JPEG, or when rotating an image by a non-orthogonal angle into a non-transparent format. In these cases, this color fills the empty space created as the image extents increase to fit the rotated corners. The value must be an RGB [hexadecimal color][], defaulting to the [`bgColor`][] parameter in your site configuration.
+
+compression
+: {{< new-in 0.153.5 />}}
+: The compression method used when encoding an image. Valid options include `lossless` or `lossy`. The `lossless` method is only applicable to WebP images. This defaults to the [`compression`][] parameter in your site configuration.
+
+dimensions
+: The dimensions of the resulting image, in pixels. The format is `WIDTHxHEIGHT` where `WIDTH` and `HEIGHT` are whole numbers. When resizing an image, you may specify only the width (such as `600x`) or only the height (such as `x400`) for proportional scaling. Specifying both width and height when resizing an image may result in non-proportional scaling. When cropping, fitting, or filling, you must provide both width and height such as `600x400`.
+
+format
+: The format of the resulting image. Valid options include `bmp`, `gif`, `jpeg`, `png`, `tiff`, or `webp`. This defaults to the format of the source image.
+
+hint
+: The encoding preset used when processing WebP images, equivalent to the `-preset` flag for the [`cwebp`][] encoder. Valid options include `drawing`, `icon`, `photo`, `picture`, or `text`. This defaults to the [`hint`][] parameter in your site configuration.
+
+  Value|Example
+  :--|:--
+  `drawing`|Hand or line drawing with high-contrast details
+  `icon`|Small colorful image
+  `photo`|Outdoor photograph with natural lighting
+  `picture`|Indoor photograph such as a portrait
+  `text`|Image that is primarily text
+
+quality
+: The quality of the resulting image, applicable to JPEG and WebP images when using  lossy [compression](#compression). The format is `qQUALITY` where `QUALITY` is a whole number between `1` and `100`, inclusive. This defaults to the [`quality`][] parameter in your site configuration.
 
 resampling filter
-: Typically specify zero or one of `Box`, `Lanczos`, `CatmullRom`, `MitchellNetravali`, `Linear`, or `NearestNeighbor`. Other resampling filters are available. See&nbsp;[details](/content-management/image-processing/#resampling-filter).
+: The filter used to calculate new pixels when resizing, fitting, or filling an image. Common options include `box`, `lanczos`, `catmullRom`, `mitchellNetravali`, `linear`, or `nearestNeighbor`. This defaults to the [`resampleFilter`][] parameter in your site configuration.
+
+  Filter|Description
+  :--|:--
+  `box`|Simple and fast averaging filter appropriate for downscaling
+  `lanczos`|High-quality resampling filter for photographic images yielding sharp results
+  `catmullRom`|Sharp cubic filter that is faster than the Lanczos filter while providing similar results
+  `mitchellNetravali`|Cubic filter that produces smoother results with less ringing artifacts than CatmullRom
+  `linear`|Bilinear resampling filter, produces smooth output, faster than cubic filters
+  `nearestNeighbor`|Fastest resampling filter, no antialiasing
+
+  Refer to the [source documentation][] for a complete list of available resampling filters. If you wish to improve image quality at the expense of performance, you may wish to experiment with the alternative filters.
+
+rotation
+: The number of whole degrees to rotate an image counter-clockwise. The format is `rDEGREES` where `DEGREES` is a whole number. Hugo performs rotation before any other transformations, so your target dimensions and any anchor point should refer to the image orientation after rotation. Use `r90`, `r180`, or `r270` for orthogonal rotations, or arbitrary angles such as `r45`. To rotate clockwise, use a negative number such as `r-45`. To automatically rotate an image based on its EXIF orientation tag, use the [`images.AutoOrient`][] filter instead of manual rotation.
+
+  Rotating by non-orthogonal values increases the image extents to fit the rotated corners; the resulting empty space is transparent for formats supporting alpha channels, or filled with a background color. This background color defaults to the [`bgColor`][] parameter in your site configuration unless you include a [background color](#background-color)
+
+[`anchor`]: /configuration/imaging/#processing-options
+[`bgcolor`]: /configuration/imaging/#processing-options
+[`compression`]: /configuration/imaging/#processing-options
+[`cwebp`]: https://developers.google.com/speed/webp/docs/cwebp
+[`hint`]: /configuration/imaging/#processing-options
+[`images.AutoOrient`]: /functions/images/autoorient/
+[`images.Process`]: /functions/images/process/
+[`Process`]: /methods/resource/process
+[`quality`]: /configuration/imaging/#processing-options
+[`resampleFilter`]: /configuration/imaging/#processing-options
+[`smartcrop.js`]: https://github.com/jwagner/smartcrop.js
+[hexadecimal color]: https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color
+[source documentation]: https://github.com/disintegration/imaging#image-resizing

--- a/content/en/configuration/imaging.md
+++ b/content/en/configuration/imaging.md
@@ -14,27 +14,49 @@ These are the default settings for processing images:
 [imaging]
 anchor = 'Smart'
 bgColor = '#ffffff'
+compression = 'lossy'
 hint = 'photo'
 quality = 75
 resampleFilter = 'box'
 {{< /code-toggle >}}
 
 anchor
-: (`string`) When using the [`Crop`] or [`Fill`] method, the anchor determines the placement of the crop box. One of `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`. Default is `Smart`.
+: (`string`) The focal point of the crop box when cropping or filling an image. Valid options include `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`. The default is `Smart`, which identifies the most interesting area of the image based on the smart cropping algorithm implemented in the [`smartcrop.js`][] library.
 
 bgColor
-: (`string`) The background color of the resulting image. Applicable when converting from a format that supports transparency to a format that does not support transparency, for example, when converting from PNG to JPEG. Expressed as an RGB [hexadecimal] value. Default is `#ffffff`.
+: (string) The background color of the resulting image. This applies when converting an image with transparency to a format that does not support it, such as when converting from PNG to JPEG, or when rotating an image by a non-orthogonal angle into a non-transparent format. In these cases, this color fills the empty space created as the image extents increase to fit the rotated corners. The value must be an RGB [hexadecimal color][]. Default is `#ffffff`.
 
-[hexadecimal]: https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color
+compression
+: {{< new-in 0.153.5 />}}
+: (`string`) The compression method used when encoding an image. Valid options include `lossless` or `lossy`. The `lossless` method is only applicable to WebP images. Default is `lossy`.
 
 hint
-: (`string`) Applicable to WebP images, this option corresponds to a set of predefined encoding parameters. One of `drawing`, `icon`, `photo`, `picture`, or `text`. Default is `photo`. See&nbsp;[details](/content-management/image-processing/#hint).
+: (`string`) The encoding preset used when processing WebP images, equivalent to the `-preset` flag for the [`cwebp`][] encoder. Valid options include `drawing`, `icon`, `photo`, `picture`, or `text`. Default is `photo`.
+
+  Value|Example
+  :--|:--
+  `drawing`|Hand or line drawing with high-contrast details
+  `icon`|Small colorful image
+  `photo`|Outdoor photograph with natural lighting
+  `picture`|Indoor photograph such as a portrait
+  `text`|Image that is primarily text
 
 quality
-: (`int`) Applicable to JPEG and WebP images, this value determines the quality of the converted image. Higher values produce better quality images, while lower values produce smaller files. Set this value to a whole number between `1` and `100`, inclusive. Default is `75`.
+: (`int`) The quality of the resulting image, applicable to JPEG and WebP images when using  lossy [compression](#compression). The format is `qQUALITY` where `QUALITY` is a whole number between `1` and `100`, inclusive. Default is `75`.
 
 resampleFilter
-: (`string`) The resampling filter used when resizing an image. Default is `box`. See&nbsp;[details](/content-management/image-processing/#resampling-filter)
+: (`string`) The filter used to calculate new pixels when when resizing, fitting, or filling an image. Common options include `box`, `lanczos`, `catmullRom`, `mitchellNetravali`, `linear`, or `nearestNeighbor`. Default is `box`.
+
+  Filter|Description
+  :--|:--
+  `box`|Simple and fast averaging filter appropriate for downscaling
+  `lanczos`|High-quality resampling filter for photographic images yielding sharp results
+  `catmullRom`|Sharp cubic filter that is faster than the Lanczos filter while providing similar results
+  `mitchellNetravali`|Cubic filter that produces smoother results with less ringing artifacts than CatmullRom
+  `linear`|Bilinear resampling filter, produces smooth output, faster than cubic filters
+  `nearestNeighbor`|Fastest resampling filter, no antialiasing
+
+  Refer to the [source documentation][] for a complete list of available resampling filters. If you wish to improve image quality at the expense of performance, you may wish to experiment with the alternative filters.
 
 ## EXIF data
 
@@ -65,5 +87,7 @@ includeFields
 >
 > To control tag availability, change the `excludeFields` or `includeFields` settings as described above.
 
-[`Crop`]: /methods/resource/crop/
-[`Fill`]: /methods/resource/fill/
+[`smartcrop.js`]: https://github.com/jwagner/smartcrop.js
+[`cwebp`]: https://developers.google.com/speed/webp/docs/cwebp
+[hexadecimal color]: https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color
+[source documentation]: https://github.com/disintegration/imaging#image-resizing

--- a/content/en/configuration/related-content.md
+++ b/content/en/configuration/related-content.md
@@ -46,7 +46,7 @@ weight
 : (`int`) An integer weight that indicates how important this parameter is relative to the other parameters. It can be `0`, which has the effect of turning this index off, or even negative. Test with different values to see what fits your content best. Default is `0`.
 
 cardinalityThreshold
-: (`int`) If between 1 and 100, this is a percentage. All keywords that are used in more than this percentage of documents are removed. For example, setting this to `60` will remove all keywords that are used in more than 60% of the documents in the index. If `0`, no keyword is removed from the index. Default is `0`.
+: (`int`) If between `1` and `100`, this is a percentage. All keywords that are used in more than this percentage of documents are removed. For example, setting this to `60` will remove all keywords that are used in more than 60% of the documents in the index. If `0`, no keyword is removed from the index. Default is `0`.
 
 pattern
 : (`string`) This is currently only relevant for dates. When listing related content, we may want to list content that is also close in time. Setting "2006" (default value for date indexes) as the pattern for a date index will add weight to pages published in the same year. For busier blogs, "200601" (year and month) may be a better default.

--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -1,15 +1,17 @@
 ---
 title: Image processing
-description: Resize, crop, rotate, filter, and convert images.
+description: Process, transform, and analyze images.
 categories: []
 keywords: []
 ---
 
-## Image resources
+Hugo provides methods to transform and analyze images during the build process. The results are cached to ensure subsequent builds remain fast.
 
-To process an image you must access the file as a page resource, global resource, or remote resource.
+## Resources
 
-### Page resource
+To process an image you must capture the file as a page resource, a global resource, or a remote resource.
+
+### Page
 
 {{% glossary-term "page resource" %}}
 
@@ -21,13 +23,13 @@ content/
         └── sunset.jpg    <-- page resource
 ```
 
-To access an image as a page resource:
+To capture an image as a page resource:
 
 ```go-html-template
 {{ $image := .Resources.Get "sunset.jpg" }}
 ```
 
-### Global resource
+### Global
 
 {{% glossary-term "global resource" %}}
 
@@ -37,34 +39,34 @@ assets/
     └── sunset.jpg    <-- global resource
 ```
 
-To access an image as a global resource:
+To capture an image as a global resource:
 
 ```go-html-template
 {{ $image := resources.Get "images/sunset.jpg" }}
 ```
 
-### Remote resource
+### Remote
 
 {{% glossary-term "remote resource" %}}
 
-To access an image as a remote resource:
+To capture an image as a remote resource:
 
 ```go-html-template
 {{ $image := resources.GetRemote "https://gohugo.io/img/hugo-logo.png" }}
 ```
 
-## Image rendering
+## Rendering
 
-Once you have accessed an image as a resource, render it in your templates using the `Permalink`, `RelPermalink`, `Width`, and `Height` properties.
+Once you have captured an image as a resource, render it in your templates using the [`Permalink`][], [`RelPermalink`][], [`Width`][], and [`Height`][] methods.
 
-Example 1: Throws an error if the resource is not found.
+Example 1: Throw an error if the resource is not found.
 
 ```go-html-template
 {{ $image := .Resources.GetMatch "sunset.jpg" }}
 <img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}">
 ```
 
-Example 2: Skips image rendering if the resource is not found.
+Example 2: Skip image rendering if the resource is not found.
 
 ```go-html-template
 {{ $image := .Resources.GetMatch "sunset.jpg" }}
@@ -81,7 +83,7 @@ Example 3: A more concise way to skip image rendering if the resource is not fou
 {{ end }}
 ```
 
-Example 4: Skips rendering if there's problem accessing a remote resource.
+Example 4: Skip rendering if there's problem accessing a remote resource.
 
 ```go-html-template
 {{ $url := "https://gohugo.io/img/hugo-logo.png" }}
@@ -96,350 +98,78 @@ Example 4: Skips rendering if there's problem accessing a remote resource.
 {{ end }}
 ```
 
-## Image processing methods
+## Processing
 
-The `image` resource implements the  [`Process`],  [`Resize`], [`Fit`], [`Fill`], [`Crop`], [`Filter`], [`Colors`] and [`Exif`] methods.
-
-> [!note]
-> Metadata (EXIF, IPTC, XMP, etc.) is not preserved during image transformation. Use the `Exif` method with the _original_ image to extract EXIF metadata from JPEG, PNG, TIFF, and WebP images.
-
-### Process
-
-> [!note]
-> The `Process` method is also available as a filter, which is more effective if you need to apply multiple filters to an image. See [Process filter](/functions/images/process).
-
-Process processes the image with the given specification. The specification can contain an optional action, one of `resize`, `crop`, `fit` or `fill`. This means that you can use this method instead of [`Resize`], [`Fit`], [`Fill`], or [`Crop`].
-
-See [Options](#image-processing-options) for available options.
-
-You can also use this method apply image processing that does not need any scaling, e.g. format conversions:
+To transform an image, apply a processing method to the image resource. Hugo generates the processed image on demand, caches the result, and returns a new resource object.
 
 ```go-html-template
-{{/* Convert the image from JPG to PNG. */}}
-{{ $png := $jpg.Process "png" }}
-```
-
-Some more examples:
-
-```go-html-template
-{{/* Rotate the image 90 degrees counter-clockwise. */}}
-{{ $image := $image.Process "r90" }}
-
-{{/* Scaling actions. */}}
-{{ $image := $image.Process "resize 600x" }}
-{{ $image := $image.Process "crop 600x400" }}
-{{ $image := $image.Process "fit 600x400" }}
-{{ $image := $image.Process "fill 600x400" }}
-```
-
-### Resize
-
-Resize an image to the given width and/or height.
-
-If you specify both width and height, the resulting image will be disproportionally scaled unless the original image has the same aspect ratio.
-
-```go-html-template
-{{/* Resize to a width of 600px and preserve aspect ratio */}}
-{{ $image := $image.Resize "600x" }}
-
-{{/* Resize to a height of 400px and preserve aspect ratio */}}
-{{ $image := $image.Resize "x400" }}
-
-{{/* Resize to a width of 600px and a height of 400px */}}
-{{ $image := $image.Resize "600x400" }}
-```
-
-### Fit
-
-Downscale an image to fit the given dimensions while maintaining aspect ratio. You must provide both width and height.
-
-```go-html-template
-{{ $image := $image.Fit "600x400" }}
-```
-
-### Fill
-
-Crop and resize an image to match the given dimensions. You must provide both width and height. Use the [`anchor`] option to change the crop box anchor point.
-
-```go-html-template
-{{ $image := $image.Fill "600x400" }}
-```
-
-### Crop
-
-Crop an image to match the given dimensions without resizing. You must provide both width and height. Use the [`anchor`] option to change the crop box anchor point.
-
-```go-html-template
-{{ $image := $image.Crop "600x400" }}
-```
-
-### Filter
-
-Apply one or more [filters] to an image.
-
-```go-html-template
-{{ $image := $image.Filter (images.GaussianBlur 6) (images.Pixelate 8) }}
-```
-
-Write this in a more functional style using pipes. Hugo applies the filters in the order given.
-
-```go-html-template
-{{ $image := $image | images.Filter (images.GaussianBlur 6) (images.Pixelate 8) }}
-```
-
-Sometimes it can be useful to create the filter chain once and then reuse it.
-
-```go-html-template
-{{ $filters := slice  (images.GaussianBlur 6) (images.Pixelate 8) }}
-{{ $image1 := $image1.Filter $filters }}
-{{ $image2 := $image2.Filter $filters }}
-```
-
-### Colors
-
-`.Colors` returns a slice of hex strings with the dominant colors in the image using a simple histogram method.
-
-```go-html-template
-{{ $colors := $image.Colors }}
-```
-
-This method is fast, but if you also scale down your images, it would be good for performance to extract the colors from the scaled down image.
-
-### EXIF
-
-Provides an [EXIF] object containing image metadata.
-
-You may access EXIF data in JPEG, PNG, TIFF, and WebP images. To prevent errors when processing images without EXIF data, wrap the access in a [`with`] statement.
-
-```go-html-template
-{{ with $image.Exif }}
-  Date: {{ .Date }}
-  Lat/Long: {{ .Lat }}/{{ .Long }}
-  Tags:
-  {{ range $k, $v := .Tags }}
-    TAG: {{ $k }}: {{ $v }}
-  {{ end }}
-{{ end }}
-```
-
-You may also access EXIF fields individually, using the [`lang.FormatNumber`] function to format the fields as needed.
-
-```go-html-template
-{{ with $image.Exif }}
-  <ul>
-    {{ with .Date }}<li>Date: {{ .Format "January 02, 2006" }}</li>{{ end }}
-    {{ with .Tags.ApertureValue }}<li>Aperture: {{ lang.FormatNumber 2 . }}</li>{{ end }}
-    {{ with .Tags.BrightnessValue }}<li>Brightness: {{ lang.FormatNumber 2 . }}</li>{{ end }}
-    {{ with .Tags.ExposureTime }}<li>Exposure Time: {{ . }}</li>{{ end }}
-    {{ with .Tags.FNumber }}<li>F Number: {{ . }}</li>{{ end }}
-    {{ with .Tags.FocalLength }}<li>Focal Length: {{ . }}</li>{{ end }}
-    {{ with .Tags.ISOSpeedRatings }}<li>ISO Speed Ratings: {{ . }}</li>{{ end }}
-    {{ with .Tags.LensModel }}<li>Lens Model: {{ . }}</li>{{ end }}
-  </ul>
-{{ end }}
-```
-
-#### EXIF methods
-
-Date
-: (`time.Time`) Returns the image creation date/time. Format with the [`time.Format`]function.
-
-Lat
-: (`float64`) Returns the GPS latitude in degrees.
-
-Long
-: (`float64`) Returns the GPS longitude in degrees.
-
-Tags
-: (`exif.Tags`) Returns a collection of the available EXIF tags for this image. You may include or exclude specific tags from this collection in the [site configuration].
-
-## Image processing options
-
-The [`Resize`], [`Fit`], [`Fill`], and [`Crop`] methods accept a space-delimited, case-insensitive list of options. The order of the options within the list is irrelevant.
-
-### Dimensions
-
-With the [`Resize`] method you must specify width, height, or both. The [`Fit`], [`Fill`], and [`Crop`] methods require both width and height. All dimensions are in pixels.
-
-```go-html-template
-{{ $image := $image.Resize "600x" }}
-{{ $image := $image.Resize "x400" }}
-{{ $image := $image.Resize "600x400" }}
-{{ $image := $image.Fit "600x400" }}
-{{ $image := $image.Fill "600x400" }}
-{{ $image := $image.Crop "600x400" }}
-```
-
-### Rotation
-
-Rotates an image counter-clockwise by the given angle. Hugo performs rotation _before_ scaling. For example, if the original image is 600x400 and you wish to rotate the image 90 degrees counter-clockwise while scaling it by 50%:
-
-```go-html-template
-{{ $image = $image.Resize "200x r90" }}
-```
-
-In the example above, the width represents the desired width _after_ rotation.
-
-To rotate an image without scaling, use the dimensions of the original image:
-
-```go-html-template
-{{ with .Resources.GetMatch "sunset.jpg" }}
-  {{ with .Resize (printf "%dx%d r90" .Height .Width) }}
+{{ with .Resources.Get "sunset.jpg" }}
+  {{ with .Resize "400x" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}">
   {{ end }}
 {{ end }}
 ```
 
-In the example above, on the second line, we have reversed width and height to reflect the desired dimensions _after_ rotation.
+> [!note]
+> Metadata (EXIF, IPTC, XMP, etc.) is not preserved during image transformation. Use the `Exif` method with the original image to extract EXIF metadata from JPEG, PNG, TIFF, and WebP images.
 
-### Anchor
+Each method serves a specific transformation or metadata requirement:
 
-When using the [`Crop`] or [`Fill`] method, the _anchor_ determines the placement of the crop box. You may specify `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`.
-
-The default value is `Smart`, which uses [Smartcrop] image analysis to determine the optimal placement of the crop box. You may override the default value in the [site configuration].
-
-For example, if you have a 400x200 image with a bird in the upper left quadrant, you can create a 200x100 thumbnail containing the bird:
-
-```go-html-template
-{{ $image.Crop "200x100 TopLeft" }}
-```
-
-If you apply [rotation](#rotation) when using the [`Crop`] or [`Fill`] method, specify the anchor relative to the rotated image.
-
-### Target format
-
-By default, Hugo encodes the image in the source format. You may convert the image to another format by specifying `bmp`, `gif`, `jpeg`, `jpg`, `png`, `tif`, `tiff`, or `webp`.
-
-```go-html-template
-{{ $image.Resize "600x webp" }}
-```
-
-To convert an image without scaling, use the dimensions of the original image:
-
-```go-html-template
-{{ with .Resources.GetMatch "sunset.jpg" }}
-  {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
-    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}">
-  {{ end }}
-{{ end }}
-```
-
-### Quality
-
-Applicable to JPEG and WebP images, the `q` value determines the quality of the converted image. Higher values produce better quality images, while lower values produce smaller files. Set this value to a whole number between 1 and 100, inclusive.
-
-The default value is 75. You may override the default value in the [site configuration].
-
-```go-html-template
-{{ $image.Resize "600x webp q50" }}
-```
-
-### Hint
-
-Applicable to WebP images, this option corresponds to a set of predefined encoding parameters, and is equivalent to the `-preset` flag for the [`cwebp`] encoder.
-
-Value|Example
+Method|Description
 :--|:--
-`drawing`|Hand or line drawing with high-contrast details
-`icon`|Small colorful image
-`photo`|Outdoor photograph with natural lighting
-`picture`|Indoor photograph such as a portrait
-`text`|Image that is primarily text
+[`Colors`]|Returns a slice of the most dominant colors using a simple histogram method
+[`Crop`]|Returns a new image resource cropped according to the given processing specification
+[`Exif`]|Applicable to JPEG, PNG, TIFF, and WebP images, returns an object containing image metadata
+[`Fill`]|Returns a new image resource cropped and resized according to the given processing specification
+[`Filter`]|Applies one or more image filters to the given image resource
+[`Fit`]|Returns a new image resource downscaled to fit according to the given processing specification
+[`Process`]|Returns a new image resource processed according to the given processing specification
+[`Resize`]|Returns a new image resource resized according to the given processing specification
 
-The default value is `photo`. You may override the default value in the [site configuration].
+Select a method from the table above for syntax and usage examples.
 
-```go-html-template
-{{ $image.Resize "600x webp picture" }}
+## Performance
+
+### Caching
+
+Hugo processes images on demand and returns a new resource object. To ensure subsequent builds remain fast, Hugo caches the results in the directory specified in the [file cache] section of your site configuration.
+
+If you host your site with Netlify, include the following in your site configuration to persist the image cache between builds:
+
+```toml
+[caches]
+  [caches.images]
+    dir = ':cacheDir/images'
 ```
 
-### Background color
+### Garbage collection
 
-When converting an image from a format that supports transparency (e.g., PNG) to a format that does _not_ support transparency (e.g., JPEG), you may specify the background color of the resulting image.
+If you change image processing methods, or rename/remove images, the cache will eventually contain unused files. To remove them and reclaim disk space, run Hugo's garbage collection:
 
-Use either a 3-digit or 6-digit hexadecimal color code (e.g., `#00f` or `#0000ff`).
-
-The default value is `#ffffff` (white). You may override the default value in the [site configuration].
-
-```go-html-template
-{{ $image.Resize "600x jpg #b31280" }}
+```text
+hugo --gc
 ```
 
-### Resampling filter
+### Resource usage
 
-You may specify the resampling filter used when resizing an image. Commonly used resampling filters include:
+The time and memory required to process an image increase with the image's dimensions. For example, a `4032x2268` image requires significantly more memory and processing time than a `1920x1080` image.
 
-Filter|Description
-:--|:--
-`Box`|Simple and fast averaging filter appropriate for downscaling
-`Lanczos`|High-quality resampling filter for photographic images yielding sharp results
-`CatmullRom`|Sharp cubic filter that is faster than the Lanczos filter while providing similar results
-`MitchellNetravali`|Cubic filter that produces smoother results with less ringing artifacts than CatmullRom
-`Linear`|Bilinear resampling filter, produces smooth output, faster than cubic filters
-`NearestNeighbor`|Fastest resampling filter, no antialiasing
-
-The default value is `Box`. You may override the default value in the [site configuration].
-
-```go-html-template
-{{ $image.Resize "600x400 Lanczos" }}
-```
-
-See [github.com/disintegration/imaging] for the complete list of resampling filters. If you wish to improve image quality at the expense of performance, you may wish to experiment with the alternative filters.
-
-## Image processing examples
-
-_The photo of the sunset used in the examples below is Copyright [Bjørn Erik Pedersen](https://bep.is) (Creative Commons Attribution-Share Alike 4.0 International license)_
-
-{{< imgproc path="sunset.jpg" spec="resize 480x" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="fill 120x150 left" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="fill 120x150 right" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="fit 120x120" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="crop 240x240 center" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="resize 360x q10" alt="A sunset" />}}
+If your source images are much larger than the maximum size you intend to publish, consider scaling them down before the build to optimize performance.
 
 ## Configuration
 
 See [configure imaging](/configuration/imaging).
 
-## Smart cropping of images
-
-By default, Hugo uses the [Smartcrop] library when cropping images with the `Crop` or `Fill` methods. You can set the anchor point manually, but in most cases the `Smart` option will make a good choice.
-
-Examples using the sunset image from above:
-
-{{< imgproc path="sunset.jpg" spec="fill 200x200 smart" alt="A sunset" />}}
-
-{{< imgproc path="sunset.jpg" spec="crop 200x200 smart" alt="A sunset" />}}
-
-## Image processing performance consideration
-
-Hugo caches processed images in the `resources` directory. If you include this directory in source control, Hugo will not have to regenerate the images on [CI/CD](g) platforms. This results in faster builds.
-
-If you change image processing methods or options, or if you rename or remove images, the `resources` directory will contain unused images. To remove the unused images, perform garbage collection with:
-
-```sh
-hugo --gc
-```
-
-[`anchor`]: /content-management/image-processing#anchor
-[`Colors`]: #colors
-[`Crop`]: #crop
-[`cwebp`]: https://developers.google.com/speed/webp/docs/cwebp
-[`Exif`]: #exif
-[`Fill`]: #fill
-[`Filter`]: #filter
-[`Fit`]: #fit
-[`lang.FormatNumber`]: /functions/lang/formatnumber/
-[`Process`]: #process
-[`Resize`]: #resize
-[`time.Format`]: /functions/time/format/
-[`with`]: /functions/go-template/with/
-[EXIF]: https://en.wikipedia.org/wiki/Exif
-[filters]: /functions/images/filter/#image-filters
-[github.com/disintegration/imaging]: https://github.com/disintegration/imaging#image-resizing
-[site configuration]: /configuration/imaging/
-[Smartcrop]: https://github.com/muesli/smartcrop#smartcrop
+[`Colors`]: /methods/resource/colors/
+[`Crop`]: /methods/resource/crop/
+[`Exif`]: /methods/resource/exif/
+[`Fill`]: /methods/resource/fill/
+[`Filter`]: /methods/resource/filter/
+[`Fit`]: /methods/resource/fit/
+[`Height`]: /methods/resource/height/
+[`Permalink`]: /methods/resource/permalink/
+[`Process`]: /methods/resource/process/
+[`RelPermalink`]: /methods/resource/relpermalink/
+[`Resize`]: /methods/resource/resize/
+[`Width`]: /methods/resource/width/
+[file cache]: /configuration/caches/

--- a/content/en/functions/images/Process.md
+++ b/content/en/functions/images/Process.md
@@ -1,98 +1,36 @@
 ---
 title: images.Process
-description: Returns an image filter that processes the given image using the given specification.
+description: Returns an image filter that processes an image according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     aliases: []
     returnType: images.filter
-    signatures: [images.Process SPEC]
+    signatures: [images.Process SPECIFICATION]
 ---
 
-This filter has the same options as the [`Process`] method on a `Resource` object, but using it as a filter may be more effective if you need to apply multiple filters to an image.
-
-[`Process`]: /methods/resource/process/
-
-The process specification is a space-delimited, case-insensitive list of one or more of the following in any sequence:
-
-action
-: Specify zero or one of `crop`, `fill`, `fit`, or `resize`. If you specify an action you must also provide dimensions. See&nbsp;[details](content-management/image-processing/#image-processing-methods).
+Returns an image filter that processes an image according to the given [processing specification][]. This versatile filter supports the full range of image transformations, including resizing, cropping, rotation, and format conversion, all within a single specification string. Use this as an argument to the [`Filter`][] method or the [`images.Filter`][] function.
 
 ```go-html-template
-{{ $filter := images.Process "resize 300x" }}
+{{ with resources.Get "images/original.jpg" }}
+  {{ $filter := images.Process "crop 200x200 TopRight webp q50" }}
+  {{ with .Filter $filter }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+{{ end }}
 ```
 
-dimensions
-: Required if you specify an action. Provide width _or_ height when using `resize`, else provide both width _and_ height. See&nbsp;[details](/content-management/image-processing/#dimensions).
+In the example above, `"crop 200x200 TopRight webp q50"` is the _processing specification_.
 
-```go-html-template
-{{ $filter := images.Process "crop 200x200" }}
-```
-
-anchor
-: Use with the `crop` or `fill` action. Specify zero or one of `TopLeft`, `Top`, `TopRight`, `Left`, `Center`, `Right`, `BottomLeft`, `Bottom`, `BottomRight`, or `Smart`. Default is `Smart`. See&nbsp;[details](/content-management/image-processing/#anchor).
-
-```go-html-template
-{{ $filter := images.Process "crop 200x200 center" }}
-```
-
-rotation
-: Typically specify zero or one of `r90`, `r180`, or `r270`. Also supports arbitrary rotation angles. See&nbsp;[details](/content-management/image-processing/#rotation).
-
-```go-html-template
-{{ $filter := images.Process "r90" }}
-{{ $filter := images.Process "crop 200x200 center r90" }}
-```
-
-target format
-: Specify zero or one of `gif`, `jpeg`, `png`, `tiff`, or `webp`. See&nbsp;[details](/content-management/image-processing/#target-format).
-
-```go-html-template
-{{ $filter := images.Process "webp" }}
-{{ $filter := images.Process "crop 200x200 center r90 webp" }}
-```
-
-quality
-: Applicable to JPEG and WebP images. Optionally specify `qN` where `N` is an integer in the range [0, 100]. Default is `75`. See&nbsp;[details](/content-management/image-processing/#quality).
-
-```go-html-template
-{{ $filter := images.Process "q50" }}
-{{ $filter := images.Process "crop 200x200 center r90 webp q50" }}
-```
-
-hint
-: Applicable to WebP images and equivalent to the `-preset` flag for the [`cwebp`] encoder. Specify zero or one of `drawing`, `icon`, `photo`, `picture`, or `text`. Default is `photo`. See&nbsp;[details](/content-management/image-processing/#hint).
-
-[`cwebp`]: https://developers.google.com/speed/webp/docs/cwebp
-
-```go-html-template
-{{ $filter := images.Process "webp" "icon" }}
-{{ $filter := images.Process "crop 200x200 center r90 webp q50 icon" }}
-```
-
-background color
-: When converting a PNG or WebP with transparency to a format that does not support transparency, optionally specify a background color using a 3-digit or a 6-digit hexadecimal color code. Default is `#ffffff` (white). See&nbsp;[details](/content-management/image-processing/#background-color).
-
-```go-html-template
-{{ $filter := images.Process "jpeg #000" }}
-{{ $filter := images.Process "crop 200x200 center r90 q50 jpeg #000" }}
-```
-
-resampling filter
-: Typically specify zero or one of `Box`, `Lanczos`, `CatmullRom`, `MitchellNetravali`, `Linear`, or `NearestNeighbor`. Other resampling filters are available. See&nbsp;[details](/content-management/image-processing/#resampling-filter).
-
-```go-html-template
-{{ $filter := images.Process "resize 300x lanczos" }}
-{{ $filter := images.Process "resize 300x r90 q50 jpeg #000 lanczos" }}
-```
+{{% include "/_common/methods/resource/processing-spec.md" %}}
 
 ## Usage
 
 Create a filter:
 
 ```go-html-template
-{{ $filter := images.Process "resize 256x q40 webp" }}
+{{ $filter := images.Process "crop 200x200 TopRight webp q50" }}
 ```
 
 {{% include "/_common/functions/images/apply-image-filter.md" %}}
@@ -103,6 +41,10 @@ Create a filter:
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="resize 256x q40 webp"
+  filterArgs="crop 200x200 TopRight webp q50"
   example=true
 >}}
+
+[`Filter`]: /methods/resource/filter/
+[`images.Filter`]: /functions/images/filter
+[processing specification]: #processing-specification

--- a/content/en/methods/resource/Crop.md
+++ b/content/en/methods/resource/Crop.md
@@ -1,25 +1,27 @@
 ---
 title: Crop
-description: Applicable to images, returns an image resource cropped to the given dimensions without resizing.
+description: Applicable to images, returns a new image resource cropped according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     returnType: images.ImageResource
-    signatures: [RESOURCE.Crop SPEC]
+    signatures: [RESOURCE.Crop SPECIFICATION]
 ---
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-Crop an image to match the given dimensions without resizing. You must provide both width and height.
+Crop an image according to the given [processing specification][]. When cropping, you must provide both width and height (such as `200x200`) within the specification. This method does not perform any resizing; it simply extracts a region of the image based on the dimensions and the [anchor](#anchor) provided, if any.
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Crop "200x200" }}
+  {{ with .Crop "200x200 TopRight" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
 ```
+
+In the example above, `"200x200 TopRight"` is the _processing specification_.
 
 {{% include "/_common/methods/resource/processing-spec.md" %}}
 
@@ -27,7 +29,7 @@ Crop an image to match the given dimensions without resizing. You must provide b
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Crop "200x200 topright webp q85 lanczos" }}
+  {{ with .Crop "200x200 TopRight" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
@@ -37,6 +39,8 @@ Crop an image to match the given dimensions without resizing. You must provide b
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="crop 200x200 topright webp q85 lanczos"
+  filterArgs="crop 200x200 TopRight"
   example=true
 >}}
+
+[processing specification]: #processing-specification

--- a/content/en/methods/resource/Exif.md
+++ b/content/en/methods/resource/Exif.md
@@ -1,6 +1,6 @@
 ---
 title: Exif
-description: Applicable to JPEG, PNG, TIFF, and WebP images, returns an EXIF object containing image metadata.
+description: Applicable to JPEG, PNG, TIFF, and WebP images, returns an object containing image metadata.
 categories: []
 keywords: []
 params:

--- a/content/en/methods/resource/Fill.md
+++ b/content/en/methods/resource/Fill.md
@@ -1,25 +1,27 @@
 ---
 title: Fill
-description: Applicable to images, returns an image resource cropped and resized to the given dimensions.
+description: Applicable to images, returns a new image resource cropped and resized according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     returnType: images.ImageResource
-    signatures: [RESOURCE.Fill SPEC]
+    signatures: [RESOURCE.Fill SPECIFICATION]
 ---
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-Crop and resize an image to match the given dimensions. You must provide both width and height.
+Crop and resize an image according to the given [processing specification][]. You must provide both width and height (such as `500x200`) within the specification. Unlike [`Resize`][], which may stretch the image, `Fill` maintains the original aspect ratio by cropping the image to the target ratio before resizing. The operation uses the [anchor](#anchor) and [resampling filter](#resampling-filter) provided, if any.
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Fill "200x200" }}
+  {{ with .Fill "500x200 TopRight lanczos" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
 ```
+
+In the example above, `"500x200 TopRight lanczos"` is the _processing specification_.
 
 {{% include "/_common/methods/resource/processing-spec.md" %}}
 
@@ -27,7 +29,7 @@ Crop and resize an image to match the given dimensions. You must provide both wi
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Fill "200x200 top webp q85 lanczos" }}
+  {{ with .Fill "500x200 TopRight lanczos webp q85" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
@@ -37,6 +39,9 @@ Crop and resize an image to match the given dimensions. You must provide both wi
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="fill 200x200 top webp q85 lanczos"
+  filterArgs="fill 500x200 TopRight lanczos webp q85"
   example=true
 >}}
+
+[`Resize`]: /methods/resource/resize/
+[processing specification]: #processing-specification

--- a/content/en/methods/resource/Fit.md
+++ b/content/en/methods/resource/Fit.md
@@ -1,25 +1,27 @@
 ---
 title: Fit
-description: Applicable to images, returns an image resource downscaled to fit the given dimensions while maintaining aspect ratio.
+description: Applicable to images, returns a new image resource downscaled to fit according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     returnType: images.ImageResource
-    signatures: [RESOURCE.Fit SPEC]
+    signatures: [RESOURCE.Fit SPECIFICATION]
 ---
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-Downscale an image to fit the given dimensions while maintaining aspect ratio. You must provide both width and height.
+Downscale an image to fit according to the given [processing specification][] while maintaining the aspect ratio. You must provide both width and height (such as `600x400`) within the specification. Unlike [`Fill`][] or [`Resize`][], this method will never upscale an image; if the source image is smaller than the target dimensions, it remains its original size. The operation uses the [resampling filter](#resampling-filter) provided, if any.
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Fit "200x200" }}
+  {{ with .Fit "300x175 lanczos" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
 ```
+
+In the example above, `"300x175 lanczos"` is the _processing specification_.
 
 {{% include "/_common/methods/resource/processing-spec.md" %}}
 
@@ -27,7 +29,7 @@ Downscale an image to fit the given dimensions while maintaining aspect ratio. Y
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Fit "300x175 webp q85 lanczos" }}
+  {{ with .Fit "300x175 lanczos" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
@@ -37,6 +39,10 @@ Downscale an image to fit the given dimensions while maintaining aspect ratio. Y
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="fit 300x175 webp q85 lanczos"
+  filterArgs="fit 300x175 lanczos"
   example=true
 >}}
+
+[`Resize`]: /methods/resource/resize/
+[`Fill`]: /methods/resource/fill/
+[processing specification]: #processing-specification

--- a/content/en/methods/resource/Process.md
+++ b/content/en/methods/resource/Process.md
@@ -1,25 +1,27 @@
 ---
 title: Process
-description: Applicable to images, returns an image resource processed with the given specification.
+description: Applicable to images, returns a new image resource processed according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     returnType: images.ImageResource
-    signatures: [RESOURCE.Process SPEC]
+    signatures: [RESOURCE.Process SPECIFICATION]
 ---
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-Process an image with the given specification. The specification can contain an optional action, one of `crop`, `fill`, `fit`, or `resize`. This means that you can use this method instead of [`Crop`], [`Fill`], [`Fit`], or [`Resize`].
+Process an image according to the given [processing specification][]. This versatile method supports the full range of image transformations, including resizing, cropping, rotation, and format conversion, all within a single specification string.
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Process "crop 200x200" }}
+  {{ with .Process "crop 200x200 TopRight webp q50" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
 ```
+
+In the example above, `"crop 200x200 TopRight webp q50"` is the _processing specification_.
 
 You can also use this method to apply simple transformations such as rotation and conversion:
 
@@ -39,7 +41,7 @@ The `Process` method is also available as a filter, which is more effective if y
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Process "crop 200x200 topright webp q85 lanczos" }}
+  {{ with .Process "crop 200x200 TopRight webp q50" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
@@ -49,12 +51,9 @@ The `Process` method is also available as a filter, which is more effective if y
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="crop 200x200 topright webp q85 lanczos"
+  filterArgs="crop 200x200 TopRight webp q50"
   example=true
 >}}
 
-[`Crop`]: /methods/resource/crop/
-[`Fill`]: /methods/resource/fill/
-[`Fit`]: /methods/resource/fit/
-[`Resize`]: /methods/resource/resize/
 [`images.Process`]: /functions/images/process/
+[processing specification]: #processing-specification

--- a/content/en/methods/resource/Resize.md
+++ b/content/en/methods/resource/Resize.md
@@ -1,27 +1,27 @@
 ---
 title: Resize
-description: Applicable to images, returns an image resource resized to the given width and/or height.
+description: Applicable to images, returns a new image resource resized according to the given processing specification.
 categories: []
 keywords: []
 params:
   functions_and_methods:
     returnType: images.ImageResource
-    signatures: [RESOURCE.Resize SPEC]
+    signatures: [RESOURCE.Resize SPECIFICATION]
 ---
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-Resize an image to the given width and/or height.
-
-If you specify both width and height, the resulting image will be disproportionally scaled unless the original image has the same aspect ratio.
+Resize an image according to the given [processing specification][]. You may specify only the width (such as `300x`) or only the height (`such as x150`) for proportional scaling. If you specify both width and height (such as `300x150`), the resulting image will be scaled to those exact dimensions; if the aspect ratio differs from the original, the image will be non-proportionally scaled (stretched or squashed). The operation uses the [resampling filter](#resampling-filter) provided, if any.
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Resize "300x" }}
+  {{ with .Resize "300x lanczos" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
 ```
+
+In the example above, `"300x lanczos"` is the _processing specification_.
 
 {{% include "/_common/methods/resource/processing-spec.md" %}}
 
@@ -29,7 +29,7 @@ If you specify both width and height, the resulting image will be disproportiona
 
 ```go-html-template
 {{ with resources.Get "images/original.jpg" }}
-  {{ with .Resize "300x webp q85 lanczos" }}
+  {{ with .Resize "300x lanczos" }}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
   {{ end }}
 {{ end }}
@@ -39,6 +39,8 @@ If you specify both width and height, the resulting image will be disproportiona
   src="images/examples/zion-national-park.jpg"
   alt="Zion National Park"
   filter="Process"
-  filterArgs="resize 300x webp q85 lanczos"
+  filterArgs="resize 300x lanczos"
   example=true
 >}}
+
+[processing specification]: #processing-specification


### PR DESCRIPTION
DRY this up and document the `compression` option added in [v0.153.5](https://github.com/gohugoio/hugo/releases/tag/v0.153.5).

- [x] [site config](https://deploy-preview-3331--gohugoio.netlify.app/configuration/imaging/#compression)
- [x] [`RESOURCE.Crop`](https://deploy-preview-3331--gohugoio.netlify.app/methods/resource/crop/#compression)
- [x] [`RESOURCE.Fill`](https://deploy-preview-3331--gohugoio.netlify.app/methods/resource/fill/#compression)
- [x] [`RESOURCE.Fit`](https://deploy-preview-3331--gohugoio.netlify.app/methods/resource/fit/#compression)
- [x] [`RESOURCE.Resize`](https://deploy-preview-3331--gohugoio.netlify.app/methods/resource/resize/#compression)
- [x] [`RESOURCE.Process`](https://deploy-preview-3331--gohugoio.netlify.app/methods/resource/process/#compression) 
- [x] [`images.Process`](https://deploy-preview-3331--gohugoio.netlify.app/functions/images/process/#compression)
- [x] [Image processing](https://deploy-preview-3331--gohugoio.netlify.app/content-management/image-processing) (most of this is redundant now that we have pages for the various resource methods)
