### PR TITLE
Deployment docs: bump dependencies to their latest versions

### DIFF
--- a/content/en/host-and-deploy/host-on-aws-amplify/index.md
+++ b/content/en/host-and-deploy/host-on-aws-amplify/index.md
@@ -40,9 +40,9 @@ Step 2
   env:
     variables:
       # Application versions
-      DART_SASS_VERSION: 1.97.1
+      DART_SASS_VERSION: 1.97.2
       GO_VERSION: 1.25.5
-      HUGO_VERSION: 0.154.2
+      HUGO_VERSION: 0.154.4
       # Time zone
       TZ: Europe/Oslo
       # Cache

--- a/content/en/host-and-deploy/host-on-cloudflare/index.md
+++ b/content/en/host-and-deploy/host-on-cloudflare/index.md
@@ -51,9 +51,9 @@ Step 2
 
   main() {
 
-    DART_SASS_VERSION=1.97.1
+    DART_SASS_VERSION=1.97.2
     GO_VERSION=1.25.5
-    HUGO_VERSION=0.154.2
+    HUGO_VERSION=0.154.4
     NODE_VERSION=24.12.0
 
     export TZ=Europe/Oslo

--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -77,24 +77,24 @@ Step 4
     build:
       runs-on: ubuntu-latest
       env:
-        DART_SASS_VERSION: 1.97.1
+        DART_SASS_VERSION: 1.97.2
         GO_VERSION: 1.25.5
-        HUGO_VERSION: 0.154.2
+        HUGO_VERSION: 0.154.4
         NODE_VERSION: 24.12.0
         TZ: Europe/Oslo
       steps:
         - name: Checkout
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
           with:
             submodules: recursive
             fetch-depth: 0
         - name: Setup Go
-          uses: actions/setup-go@v5
+          uses: actions/setup-go@v6
           with:
             go-version: ${{ env.GO_VERSION }}
             cache: false
         - name: Setup Node.js
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6
           with:
             node-version: ${{ env.NODE_VERSION }}
         - name: Setup Pages
@@ -130,7 +130,7 @@ Step 4
             git config core.quotepath false
         - name: Cache restore
           id: cache-restore
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v5
           with:
             path: ${{ runner.temp }}/hugo_cache
             key: hugo-${{ github.run_id }}
@@ -145,12 +145,12 @@ Step 4
               --cacheDir "${{ runner.temp }}/hugo_cache"
         - name: Cache save
           id: cache-save
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v5
           with:
             path: ${{ runner.temp }}/hugo_cache
             key: ${{ steps.cache-restore.outputs.cache-primary-key }}
         - name: Upload artifact
-          uses: actions/upload-pages-artifact@v3
+          uses: actions/upload-pages-artifact@v4
           with:
             path: ./public
     deploy:

--- a/content/en/host-and-deploy/host-on-gitlab-pages.md
+++ b/content/en/host-and-deploy/host-on-gitlab-pages.md
@@ -24,8 +24,8 @@ Define your [CI/CD](g) jobs by creating a `.gitlab-ci.yml` file in the root of y
 ```yaml {file=".gitlab-ci.yml" copy=true}
 variables:
   # Application versions
-  DART_SASS_VERSION: 1.97.1
-  HUGO_VERSION: 0.154.2
+  DART_SASS_VERSION: 1.97.2
+  HUGO_VERSION: 0.154.4
   NODE_VERSION: 24.12.0
   # Git
   GIT_DEPTH: 0

--- a/content/en/host-and-deploy/host-on-netlify/index.md
+++ b/content/en/host-and-deploy/host-on-netlify/index.md
@@ -30,9 +30,9 @@ Step 1
 
   ```text {file="netlify.toml" copy=true}
   [build.environment]
-  DART_SASS_VERSION = "1.97.1"
+  DART_SASS_VERSION = "1.97.2"
   GO_VERSION = "1.25.5"
-  HUGO_VERSION = "0.154.2"
+  HUGO_VERSION = "0.154.4"
   NODE_VERSION = "24.12.0"
   TZ = "Europe/Oslo"
 
@@ -48,9 +48,9 @@ Step 1
 
   ```text {file="netlify.toml" copy=true}
   [build.environment]
-  DART_SASS_VERSION = "1.97.1"
+  DART_SASS_VERSION = "1.97.2"
   GO_VERSION = "1.25.5"
-  HUGO_VERSION = "0.154.2"
+  HUGO_VERSION = "0.154.4"
   NODE_VERSION = "24.12.0"
   TZ = "Europe/Oslo"
 

--- a/content/en/host-and-deploy/host-on-render/index.md
+++ b/content/en/host-and-deploy/host-on-render/index.md
@@ -35,11 +35,11 @@ Step 1
       staticPublishPath: public
       envVars:
         - key: DART_SASS_VERSION
-          value: 1.97.1
+          value: 1.97.2
         - key: GO_VERSION
           value: 1.25.5
         - key: HUGO_VERSION
-          value: 0.154.2
+          value: 0.154.4
         - key: NODE_VERSION
           value: 24.12.0
         - key: TZ

--- a/content/en/host-and-deploy/host-on-vercel/index.md
+++ b/content/en/host-and-deploy/host-on-vercel/index.md
@@ -47,9 +47,9 @@ Step 2
 
   main() {
 
-    DART_SASS_VERSION=1.97.1
+    DART_SASS_VERSION=1.97.2
     GO_VERSION=1.25.5
-    HUGO_VERSION=0.154.2
+    HUGO_VERSION=0.154.4
     NODE_VERSION=24.12.0
 
     export TZ=Europe/Oslo


### PR DESCRIPTION
This PR bumps dependencies in deployment docs to their latest versions.