### PR TITLE
Remove related content full configuration requirement

### DIFF
--- a/content/en/configuration/related-content.md
+++ b/content/en/configuration/related-content.md
@@ -17,9 +17,6 @@ This is the default configuration:
 
 {{< code-toggle config=related />}}
 
-> [!note]
-> Adding a `related` section to your site configuration requires you to provide a full configuration. You cannot override individual default values without specifying all related settings.
-
 ## Top-level options
 
 threshold


### PR DESCRIPTION
Remove the requirement to provide full configuration, as it no longer seems applicable, given the minimal configuration included in the Example section.