### PR TITLE
content: Hide snap installation instructions

### DIFF
--- a/content/en/installation/linux.md
+++ b/content/en/installation/linux.md
@@ -12,6 +12,7 @@ weight: 20
 
 {{% include "/_common/installation/03-prebuilt-binaries.md" %}}
 
+<!--
 ## Package managers
 
 ### Snap
@@ -57,6 +58,7 @@ sudo snap disconnect hugo:ssh-keys
 ```
 
 {{% include "/_common/installation/homebrew.md" %}}
+-->
 
 ## Repository packages
 


### PR DESCRIPTION
We will restore after resolution of https://github.com/gohugoio/hugo/issues/14320