### PR TITLE
misc: Address build warnings

### DIFF
--- a/content/en/_common/render-hooks/pageinner.md
+++ b/content/en/_common/render-hooks/pageinner.md
@@ -4,8 +4,6 @@ _comment: Do not remove front matter.
 
 ## PageInner details
 
-{{< new-in 0.125.0 />}}
-
 The primary use case for `PageInner` is to resolve links and [page resources](g) relative to an included `Page`. For example, create an "include" shortcode to compose a page from multiple content files, while preserving a global context for footnotes and the table of contents:
 
 ```go-html-template {file="layouts/_shortcodes/include.html" copy=true}

--- a/content/en/configuration/sitemap.md
+++ b/content/en/configuration/sitemap.md
@@ -14,7 +14,6 @@ changefreq
 : (`string`) How frequently a page is likely to change. Valid values are `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, and `never`. With the default value of `""` Hugo will omit this field from the sitemap. See&nbsp;[details](https://www.sitemaps.org/protocol.html#changefreqdef).
 
 disable
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to disable page inclusion. Default is `false`. Set to `true` in front matter to exclude the page.
 
 filename

--- a/content/en/functions/strings/Diff/index.md
+++ b/content/en/functions/strings/Diff/index.md
@@ -9,8 +9,6 @@ params:
     signatures: [strings.Diff OLDNAME OLD NEWNAME NEW]
 ---
 
-{{< new-in 0.125.0 />}}
-
 Use `strings.Diff` to compare two strings and render a highlighted diff:
 
 ```go-html-template

--- a/content/en/methods/page/Sitemap.md
+++ b/content/en/methods/page/Sitemap.md
@@ -23,8 +23,6 @@ Access to the `Sitemap` method on a `Page` object is restricted to [sitemap temp
 
 ### Disable
 
-{{< new-in 0.125.0 />}}
-
 (`bool`) Whether to disable page inclusion. Default is `false`. Set to `true` in front matter to exclude the page.
 
 ```go-html-template

--- a/content/en/methods/resource/Colors.md
+++ b/content/en/methods/resource/Colors.md
@@ -19,13 +19,9 @@ Each color is an object with the following methods:
 
 ### ColorHex
 
-{{< new-in 0.125.0 />}}
-
 (`string`) Returns the [hexadecimal color] value, prefixed with a hash sign.
 
 ### Luminance
-
-{{< new-in 0.125.0 />}}
 
 (`float64`) Returns the [relative luminance] of the color in the sRGB colorspace in the range [0, 1]. A value of `0` represents the darkest black, while a value of `1` represents the lightest white.
 

--- a/content/en/methods/taxonomy/Page.md
+++ b/content/en/methods/taxonomy/Page.md
@@ -9,8 +9,6 @@ params:
     signatures: [TAXONOMY.Page]
 ---
 
-{{< new-in 0.125.0 />}}
-
 This `TAXONOMY` method returns nil if the taxonomy has no terms, so you must code defensively:
 
 ```go-html-template

--- a/content/en/render-hooks/code-blocks.md
+++ b/content/en/render-hooks/code-blocks.md
@@ -59,7 +59,6 @@ Page
 : (`page`) A reference to the current page.
 
 PageInner
-: {{< new-in 0.125.0 />}}
 : (`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
 
 Position

--- a/content/en/render-hooks/headings.md
+++ b/content/en/render-hooks/headings.md
@@ -28,7 +28,6 @@ Page
 : (`page`) A reference to the current page.
 
 PageInner
-: {{< new-in 0.125.0 />}}
 : (`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
 
 PlainText

--- a/content/en/render-hooks/images.md
+++ b/content/en/render-hooks/images.md
@@ -45,7 +45,6 @@ Page
 : (`page`) A reference to the current page.
 
 PageInner
-: {{< new-in 0.125.0 />}}
 : (`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
 
 PlainText

--- a/content/en/render-hooks/links.md
+++ b/content/en/render-hooks/links.md
@@ -29,7 +29,6 @@ Page
 : (`page`) A reference to the current page.
 
 PageInner
-: {{< new-in 0.125.0 />}}
 : (`page`) A reference to a page nested via the [`RenderShortcodes`] method. [See details](#pageinner-details).
 
 PlainText

--- a/content/en/shortcodes/youtube.md
+++ b/content/en/shortcodes/youtube.md
@@ -33,38 +33,30 @@ id
 : (`string`) The video `id`. Optional if the `id` is the first and only positional argument.
 
 allowFullScreen
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether the `iframe` element can activate full screen mode. Default is `true`.
 
 autoplay
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to automatically play the video. Forces `mute` to `true`. Default is `false`.
 
 class
 : (`string`) The `class` attribute of the wrapping `div` element. When specified, removes the `style` attributes from the `iframe` element and its wrapping `div` element.
 
 controls
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to display the video controls. Default is `true`.
 
 end
-: {{< new-in 0.125.0 />}}
 : (`int`) The time, measured in seconds from the start of the video, when the player should stop playing the video.
 
 loading
-: {{< new-in 0.125.0 />}}
 : (`string`) The loading attribute of the `iframe` element, either `eager` or `lazy`. Default is `eager`.
 
 loop
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to indefinitely repeat the video. Ignores the `start` and `end` arguments after the first play. Default is `false`.
 
 mute
-: {{< new-in 0.125.0 />}}
 : (`bool`) Whether to mute the video. Always `true` when `autoplay` is `true`. Default is `false`.
 
 start
-: {{< new-in 0.125.0 />}}
 : (`int`) The time, measured in seconds from the start of the video, when the player should start playing the video.
 
 title

--- a/hugo.toml
+++ b/hugo.toml
@@ -87,9 +87,10 @@ disableAliases = true
     source = "assets"
     target = "assets"
   [[module.mounts]]
-    lang   = 'en'
     source = 'content/en'
     target = 'content'
+    [module.mounts.sites.matrix]
+      languages = ['en']
   [[module.mounts]]
     disableWatch = true
     source       = "hugo_stats.json"


### PR DESCRIPTION
Remove outdated new-in badges, and use a sites matrix instead of the lang parameter for the content mount.