### PR TITLE
Update `ToMath` example to include warning about the `hasMath`

### DIFF
--- a/content/en/functions/transform/ToMath.md
+++ b/content/en/functions/transform/ToMath.md
@@ -150,6 +150,9 @@ Step 3
 
   In the above, note the use of a [noop](g) statement to force content rendering before we check the value of `hasMath` with the `Store.Get` method.
 
+  > [!note]
+  > Conditionally including KaTeX CSS in this way only affects pages whose content has the configured delimiters. It does not necessarily affect all pages that display the rendered math. For example, if a page displays the `.Summary` of another page with math, this approach will not lead it to have the necessary CSS. For themes and websites where this is possible, consider including KaTeX CSS unconditionally.
+
 Step 4
 : Add some mathematical markup to your content, then test.
 


### PR DESCRIPTION
Following up on the discussion in https://github.com/gohugoio/hugo/issues/14455, update the documentation to include a warning about the issue I ran into. Specifically, the recommended approach of using `hasMath` + render-hook-time tagging of pages will fall through if other pages can display summaries (which would include the LaTeX but not correctly set `hasMath`).