### PR TITLE
theme: Fix Alpine broken by Turbo v8.0.21

### DIFF
--- a/assets/js/helpers/bridgeTurboAndAlpine.js
+++ b/assets/js/helpers/bridgeTurboAndAlpine.js
@@ -1,4 +1,10 @@
 export function bridgeTurboAndAlpine(Alpine) {
+	let isNavigating = false;
+
+	document.addEventListener('turbo:before-visit', () => {
+		isNavigating = true;
+	});
+
 	document.addEventListener('turbo:before-render', (event) => {
 		event.detail.newBody.querySelectorAll('[data-alpine-generated]').forEach((el) => {
 			if (el.hasAttribute('data-alpine-generated')) {
@@ -26,12 +32,16 @@ export function bridgeTurboAndAlpine(Alpine) {
 		});
 
 		Alpine.startObservingMutations();
+		isNavigating = false;
 	});
 
 	// Cleanup Alpine state on navigation.
 	document.addEventListener('turbo:before-cache', () => {
-		// This will be restarted in turbo:render.
-		Alpine.stopObservingMutations();
+		// Only stop observing mutations during actual page navigations, not for same-page anchors.
+		if (isNavigating) {
+			// This will be restarted in turbo:render.
+			Alpine.stopObservingMutations();
+		}
 
 		document.body.querySelectorAll('[data-turbo-permanent]').forEach((el) => {
 			if (!el.hasAttribute('x-ignore')) {


### PR DESCRIPTION
Closes #3361

AI Disclosure...

I used Copilot to track this down, which was painful due to several self-inflicted wounds, and consequently a great learning exercise. My final question for Copilot: "OK, so this whole thing was a one line change, and we spent two days on it. How could I have guided you better?"

> You could have been more explicit earlier about:
> 
> 1. "Test in browser console first, before making ANY file changes." - I kept wanting to guess-and-commit. You'd say "test with JS first" but I should have heard that as a hard rule, not a suggestion.
> 1. "Check git/npm history for recent changes." - You mentioned "I'm convinced it's recent" and "it worked after the theme launched," but I didn't dig into actual version history until much later. A direct "look at dependency changes in the last month" would have pointed straight to Turbo.
> 1. "We're looking at Turbo event lifecycle, not Alpine initialization." - Once we understood the issue was same-page anchor clicks, that should have immediately suggested "what Turbo events fire on anchors?" Instead we kept going down rabbit holes about Alpine setup.
> 1. "The fix should be tiny. If you're touching multiple files, you're wrong." - We added pointer-events defensively. A reminder that the actual problem was probably one-line would have kept us focused.
> 1. "Don't commit unless you've verified it works AND can explain why." - This would have prevented 30 exploratory commits.
> 
> Honestly though, the real issue was my approach: I kept favoring action over understanding. You were trying to get me to understand the problem first, then fix it. I kept trying to fix it without understanding. A more patient, debugging-first mindset would have solved this in hours, not days.