### PR TITLE
fix: allow dotfiles in page artifacts

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -149,7 +149,7 @@ Step 4
           with:
             path: ${{ runner.temp }}/hugo_cache
             key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-        - name: Create Pages artifact (keep .well-known)
+        - name: Create Pages artifact
         run: |
           tar \
             --dereference --hard-dereference \


### PR DESCRIPTION
### 🐛 Problem

e.g. Files under `/static/.well-known/` were not served on GitHub Pages, even though:

- they exist in the repository (static/.well-known)
- Hugo correctly copies them to public/.well-known
- the site builds correctly locally

### 🔍 Root cause

The workflow used `actions/upload-pages-artifact@v4`, which internally excludes all dotfiles and dot-directories:
```
--exclude=".[^/]*"
```

As a result, `public/.well-known` was never included in the Pages artifact and therefore not deployed.

### ✅ Solution

The workflow was patched to create and upload the Pages artifact without excluding dotfiles, ensuring that `.well-known` is included in the deployed output.

No changes were required to Hugo configuration or project structure.