### PR TITLE
theme: Pin npm dependencies and adjust Netlify build commands

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo --gc --minify"
+  command = "npm ls && hugo --gc --minify"
 
   [build.environment]
     HUGO_VERSION = "0.155.2"
@@ -10,16 +10,16 @@
   HUGO_ENABLEGITINFO = "true"
 
 [context.split1]
-  command = "hugo --gc --minify --enableGitInfo"
+  command = "npm ls && hugo --gc --minify --enableGitInfo"
 
   [context.split1.environment]
     HUGO_ENV = "production"
 
 [context.deploy-preview]
-  command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL --enableGitInfo"
+  command = "npm ls && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL --enableGitInfo"
 
 [context.branch-deploy]
-  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+  command = "npm ls && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.next.environment]
   HUGO_ENABLEGITINFO = "true"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "tailwindcss": "~4.1.18"
   },
   "dependencies": {
-    "@alpinejs/focus": "~3.15.3",
-    "@alpinejs/persist": "~3.15.3",
+    "@alpinejs/focus": "3.15.3",
+    "@alpinejs/persist": "3.15.3",
     "@hotwired/turbo": "8.0.20",
-    "alpinejs": "~3.15.3"
+    "alpinejs": "3.15.3"
   }
 }


### PR DESCRIPTION
Closes #3366

The Netlify build log now shows:

```text
10:13:29 AM: ├── @alpinejs/focus@3.15.3
10:13:29 AM: ├── @alpinejs/persist@3.15.3
10:13:29 AM: ├── @awmottaz/prettier-plugin-void-html@2.0.0
10:13:29 AM: ├── @hotwired/turbo@8.0.20
10:13:29 AM: ├── @tailwindcss/cli@4.1.18
10:13:29 AM: ├── @tailwindcss/typography@0.5.19
10:13:29 AM: ├── alpinejs@3.15.3
10:13:29 AM: ├── prettier-plugin-go-template@0.0.15
10:13:29 AM: ├── prettier@3.7.4
10:13:29 AM: └── tailwindcss@4.1.18
```