### PR TITLE
Add Commentix to the list of commercial commenting systems

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -41,6 +41,7 @@ Disqus has its own [internal template](/templates/embedded/#disqus) available, t
 
 Commercial commenting systems:
 
+- [Commentix](https://www.commentix.com/)
 - [Emote](https://emote.com/)
 - [Graph Comment](https://graphcomment.com/)
 - [Hyvor Talk](https://talk.hyvor.com/)


### PR DESCRIPTION
This PR adds [Commentix](https://www.commentix.com/) to the list of commercial commenting systems on [this page](https://gohugo.io/content-management/comments/) in the documentation.