### PR TITLE
Try to fix the intro to PAGE.Rotate

### DIFF
--- a/content/en/content-management/image-processing/index.md
+++ b/content/en/content-management/image-processing/index.md
@@ -176,4 +176,3 @@ See [configure imaging](/configuration/imaging).
 [`Resize`]: /methods/resource/resize/
 [`Width`]: /methods/resource/width/
 [file cache]: /configuration/caches/
-

--- a/content/en/methods/page/Rotate.md
+++ b/content/en/methods/page/Rotate.md
@@ -1,6 +1,6 @@
 ---
 title: Rotate
-description: Returns a collection of all pages sharing the same identity across the specified dimension, including the current page, sorted by the dimension's weight.
+description: Returns a collection of pages that vary along the specified dimension while sharing the current page's values for the other dimensions, including the current page, sorted by the dimension's weight.
 categories: []
 keywords: []
 params:
@@ -11,7 +11,7 @@ params:
 
 {{< new-in 0.153.0 />}}
 
-The `Rotate` method on a `Page` object returns a collection of all pages sharing the same identity across the specified [dimension](g), including the current page, sorted by the dimension's weight.
+The `Rotate` method on a `Page` object returns a collection of pages that vary along the specified [dimension](g), while holding the other dimensions constant. The result includes the current page and is sorted by the dimension's weight. For example, rotating along `language` returns all language variants that share the current page's version and role.
 
 The `DIMENSION` argument must be one of `language`, `version`, or `role`.
 


### PR DESCRIPTION
I have read the current version a few times, and I don't think it accurately describe what the method really does.
