### PR TITLE
content: Improve urls.PathEscape/PathUnescape examples

### DIFF
--- a/content/en/functions/urls/PathEscape.md
+++ b/content/en/functions/urls/PathEscape.md
@@ -1,6 +1,6 @@
 ---
 title: urls.PathEscape 
-description: Returns the given string, replacing all percent-encoded sequences with the corresponding unescaped characters.
+description: Returns the given string, applying percent-encoding to special characters and reserved delimiters so it can be safely used as a segment within a URL path.
 categories: []
 keywords: []
 params:
@@ -14,7 +14,9 @@ params:
 The `urls.PathEscape` function does the inverse transformation of [`urls.PathUnescape`][].
 
 ```go-html-template
-{{ urls.PathEscape "A/b/c?d=é&f=g+h" }} → A%2Fb%2Fc%3Fd=%C3%A9&f=g+h
+{{ urls.PathEscape "my café" }} → my%20caf%C3%A9
 ```
+
+Use this function to escape a string so that it can be safely used as an individual segment within a URL path.
 
 [`urls.PathUnescape`]: /functions/urls/PathUnescape/

--- a/content/en/functions/urls/PathUnescape.md
+++ b/content/en/functions/urls/PathUnescape.md
@@ -1,6 +1,6 @@
 ---
 title: urls.PathUnescape 
-description: Returns the given string, applying percent-encoding to special characters and reserved delimiters so it can be safely used as a segment within a URL path.
+description: Returns the given string, replacing all percent-encoded sequences with the corresponding unescaped characters.
 categories: []
 keywords: []
 params:
@@ -16,5 +16,7 @@ The `urls.PathUnescape` function does the inverse transformation of [`urls.PathE
 ```go-html-template
 {{ urls.PathUnescape "A%2Fb%2Fc%3Fd=%C3%A9&f=g+h" }} → A/b/c?d=é&f=g+h
 ```
+
+Use this function to decode an individual segment within a URL path.
 
 [`urls.PathEscape`]: /functions/urls/PathEscape/


### PR DESCRIPTION
These functions are to be used with segments, not the entire path.