### PR TITLE
Correct command to create a new Hugo site

### DIFF
--- a/content/en/getting-started/quick-start.md
+++ b/content/en/getting-started/quick-start.md
@@ -47,7 +47,7 @@ hugo version
 Run these commands to create a Hugo project with the [Ananke][] theme. The next section provides an explanation of each command.
 
 ```text
-hugo new project quickstart
+hugo new site quickstart
 cd quickstart
 git init
 git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke


### PR DESCRIPTION
using: hugo new project [sitename] results in an error in the terminal as the correct command is hugo new site [sitename]