### PR TITLE
Fix typos in module configuration documentation

### DIFF
--- a/content/en/configuration/module.md
+++ b/content/en/configuration/module.md
@@ -30,13 +30,13 @@ auth
 : (`string`) Configures `GOAUTH` when running the Go command for module operations. This is a semicolon-separated list of authentication commands for go-import and HTTPS module mirror interactions. This is useful for private repositories. See `go help goauth` for more information.
 
 noProxy
-: (`string`) A comma-separated list of [glob patterns](g),s matching paths that should not use the [configured proxy server](#proxy).
+: (`string`) A comma-separated list of [glob patterns](g), matching paths that should not use the [configured proxy server](#proxy).
 
 noVendor
 : (`string`) A [glob pattern](g) matching module paths to skip when vendoring.
 
 private
-: (`string`) A comma-separated list of [glob patterns](g),s matching paths that should be treated as private.
+: (`string`) A comma-separated list of [glob patterns](g), matching paths that should be treated as private.
 
 proxy
 : (`string`) The proxy server to use to download remote modules. Default is `direct`, which means `git clone` and similar.


### PR DESCRIPTION
The `content/en/configuration/module.md` file contians two instances of the sentence:

> A comma-separated list of glob patterns,s matching paths that should ...

The `s,s` seems incorrect. This MR fixes that.