### PR TITLE
content: Updates for v0.160.0

### DIFF
--- a/content/en/_common/installation/01-editions.md
+++ b/content/en/_common/installation/01-editions.md
@@ -12,7 +12,7 @@ Core features|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_ch
 Direct cloud deployment (2)|:x:|:heavy_check_mark:|:x:|:heavy_check_mark:
 LibSass support (3)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:
 
-(1)   {{< new-in v0.159.2 />}}
+(1) {{< new-in v0.159.2 />}}
 
 (2) Deploy your site directly to a Google Cloud Storage bucket, an AWS S3 bucket, or an Azure Storage container. See&nbsp;[details].
 

--- a/content/en/functions/css/Build.md
+++ b/content/en/functions/css/Build.md
@@ -172,6 +172,41 @@ targetPath
   {{ $r := resources.Get "css/main.css" | css.Build $opts }}
   ```
 
+vars
+: {{< new-in v0.160.0 />}}
+: (`map`) A map of key-value pairs used to generate CSS variables. The `css.Build` function injects these variables into the stylesheet when it encounters the `hugo:vars` internal identifier within an `@import` statement.
+
+  ```go-html-template
+  {{ $opts := dict "vars" (dict "primary-color" "blue" "font-size" "24px") }}
+  {{ $r := resources.Get "css/main.css" | css.Build $opts }}
+  ```
+
+  In the example above, using the identifier in your CSS allows you to access the values using standard CSS variable syntax.
+
+  ```css
+  @import 'hugo:vars';
+
+  .element {
+    color: var(--primary-color);
+    font-size: var(--font-size);
+  }
+  ```
+
+  The `vars` option is useful for setting CSS variables within your project configuration.
+
+  {{< code-toggle file=hugo >}}
+  [params.theme.style]
+  primary-color = 'blue'
+  font-size = '24px'
+  {{< /code-toggle >}}
+
+  ```go-html-template
+  {{ $opts := dict "vars" site.Params.theme.style }}
+  {{ $r := resources.Get "css/main.css" | css.Build $opts }}
+  ```
+
+  When passing a `vars` map to the css.Build function, you can use the [`css.Quoted`][] function to explicitly indicate that a value must be treated as a quoted string, most commonly for `font-family` names or the `content` property.
+
 ## Example
 
 The example below uses several of the [options](#options) described above to bundle, transform, and minify CSS code.
@@ -183,6 +218,7 @@ The example below uses several of the [options](#options) described above to bun
     "minify" (cond hugo.IsDevelopment false true)
     "sourceMap" (cond hugo.IsDevelopment "linked" "none")
     "target" (slice "chrome115" "edge115" "firefox116" "ios16.4" "opera101" "safari16.4")
+    "targetPath" "css/styles.css"
   }}
   {{ with . | css.Build $opts }}
     {{ if hugo.IsDevelopment }}
@@ -247,6 +283,7 @@ To reference a specific file within a Node package, provide the path starting wi
 @import "bootstrap/dist/css/bootstrap-grid.css";
 ```
 
+[`css.Quoted`]: /functions/css/quoted/
 [`evanw/esbuild`]: https://github.com/evanw/esbuild
 [`publishDir`]: /configuration/all/#publishdir
 [browserlist]: https://browsersl.ist

--- a/content/en/functions/css/Quoted.md
+++ b/content/en/functions/css/Quoted.md
@@ -13,13 +13,29 @@ params:
 <!-- Added in v0.111.0 -->
 
 > [!note]
-> This function is only applicable to the [`vars`] option passed to the [`css.Sass`] function.
+> This function is only applicable to the `vars` option passed to the [`css.Build`][] or [`css.Sass`][] functions.
 
 When passing a `vars` map to the `css.Sass` function, Hugo detects common typed CSS values such as `24px` or `#FF0000` using regular expression matching. If necessary, you can bypass automatic type inference by using the `css.Quoted` function to explicitly indicate that the value must be treated as a quoted string.
 
-For example:
+For the `css.Build` function, use `css.Quoted` to explicitly indicate that a value must be treated as a quoted string, most commonly for `font-family` names or the `content` property.
 
-```scss {file="assets/sass/main.scss"}
+In the example below, we use `css.Quoted` to ensure the values for the `content` property are injected as strings.
+
+```go-html-template
+{{ $vars := dict
+  "ol-li-after" ("6" | css.Quoted)
+  "ul-li-after" ("7" | css.Quoted)
+}}
+
+{{ $opts := dict "vars" $vars "transpiler" "dartsass" }}
+{{ with resources.Get "sass/main.scss" | css.Sass $opts }}
+  <link rel="stylesheet" href="{{ .RelPermalink }}">
+{{ end }}
+```
+
+Using the `hugo:vars` identifier in your stylesheet:
+
+```scss
 @use "hugo:vars" as h;
 
 ol li::after {
@@ -31,35 +47,9 @@ ul li::after {
 }
 ```
 
-```go-html-template {file="layouts/_partials/css.html"}
-{{ $vars := dict
-  "ol_li_after" ("6" | css.Quoted )
-  "ul_li_after" ("7" | css.Quoted )
-}}
+The resulting CSS contains quoted strings:
 
-{{ with resources.Get "sass/main.scss" }}
-  {{ $opts := dict
-    "enableSourceMap" hugo.IsDevelopment
-    "outputStyle" (cond hugo.IsDevelopment "expanded" "compressed")
-    "targetPath" "css/main.css"
-    "transpiler" "dartsass"
-    "vars" $vars
-  }}
-  {{ with . | toCSS $opts }}
-    {{ if hugo.IsDevelopment }}
-      <link rel="stylesheet" href="{{ .RelPermalink }}">
-    {{ else }}
-      {{ with . | fingerprint }}
-        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-```
-
-The Sass code is transpiled to:
-
-```css {file="public/css/main.css"}
+```css
 ol li::after {
   content: "6";
 }
@@ -69,5 +59,5 @@ ul li::after {
 }
 ```
 
-[`css.Sass`]: /functions/css/sass/
-[`vars`]: /functions/css/sass/#vars
+[`css.Build`]: /functions/css/build/#vars
+[`css.Sass`]: /functions/css/sass/#vars

--- a/content/en/functions/css/Sass.md
+++ b/content/en/functions/css/Sass.md
@@ -23,44 +23,110 @@ Sass has two forms of syntax: [SCSS][] and [indented][]. Hugo supports both.
 enableSourceMap
 : (`bool`) Whether to generate a source map. Default is `false`.
 
+  ```go-html-template
+  {{ $opts := dict "enableSourceMap" true }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
+
 includePaths
 : (`slice`) A slice of paths, relative to the project root, that the transpiler will use when resolving `@use` and `@import` statements.
+
+  ```go-html-template
+  {{ $opts := dict "includePaths" (slice "node_modules/bootstrap/scss") }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
 
 outputStyle
 : (`string`) The output style of the resulting CSS. With LibSass, one of `nested` (default), `expanded`, `compact`, or `compressed`. With Dart Sass, either `expanded` (default) or `compressed`.
 
+  ```go-html-template
+  {{ $opts := dict "outputStyle" "compressed" }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
+
 precision
 : (`int`) The precision of floating point math. Applicable to LibSass. Default is `8`.
 
+  ```go-html-template
+  {{ $opts := dict "precision" 10 }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
+
 silenceDeprecations
 : {{< new-in 0.139.0 />}}
-: (`slice`) A slice of deprecation IDs to silence. IDs are enclosed in brackets within Dart Sass warning messages (e.g., `import` in `WARN Dart Sass: DEPRECATED [import]`). Applicable to Dart Sass. Default is `false`.
+: (`slice`) A slice of deprecation IDs to silence. IDs are enclosed in brackets within Dart Sass warning messages (e.g., `import` in `WARN Dart Sass: DEPRECATED [import]`). Applicable to Dart Sass.
+
+  ```go-html-template
+  {{ $opts := dict "silenceDeprecations" (slice "import") }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
 
 silenceDependencyDeprecations
 : {{< new-in 0.146.0 />}}
-: (`bool`) Whether to silence deprecation warnings from dependencies, where a dependency is considered any file transitively imported through a load path. This does not apply to `@warn` or `@debug` rules.Default is `false`.
+: (`bool`) Whether to silence deprecation warnings from dependencies, where a dependency is considered any file transitively imported through a load path. This does not apply to `@warn` or `@debug` rules. Default is `false`.
+
+  ```go-html-template
+  {{ $opts := dict "silenceDependencyDeprecations" true }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
 
 sourceMapIncludeSources
 : (`bool`) Whether to embed sources in the generated source map. Applicable to Dart Sass. Default is `false`.
 
+  ```go-html-template
+  {{ $opts := dict "enableSourceMap" true "sourceMapIncludeSources" true }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
+
 targetPath
-: (`string`) The publish path for the transformed resource, relative to the[`publishDir`][]. If unset, the target path defaults to the asset's original path with a `.css` extension.
+: (`string`) The publish path for the transformed resource, relative to the [`publishDir`][]. If unset, the target path defaults to the asset's original path with a `.css` extension.
+
+  ```go-html-template
+  {{ $opts := dict "targetPath" "css/bundle.css" }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
 
 transpiler
 : (`string`) The transpiler to use, either `libsass` or `dartsass`. Hugo's extended and extended/deploy editions include the LibSass transpiler. To use the Dart Sass transpiler, see the [installation instructions](#dart-sass). Default is `libsass`.
+
+  ```go-html-template
+  {{ $opts := dict "transpiler" "dartsass" }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
 
   > [!warning]
   > The embedded LibSass transpiler was deprecated in [v0.153.0][] and will be removed in a future release. Use the Dart Sass transpiler instead.
 
 vars
-: (`map`) A map of key-value pairs that will be available in the `hugo:vars` namespace. Useful for [initializing Sass variables from Hugo templates](https://discourse.gohugo.io/t/42053/).
+: (`map`) A map of key-value pairs used to generate Sass variables. The `css.Sass` function injects these variables into the stylesheet when it encounters the `hugo:vars` internal identifier within a `@use` or `@import` statement.
+
+  ```go-html-template
+  {{ $opts := dict "vars" (dict "primary-color" "blue" "font-size" "24px") }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
+  ```
+
+   In the example above, using the identifier in your stylesheet allows you to access the values as Sass variables in the `hugo:vars` namespace:
 
   ```scss
-  // LibSass
-  @import "hugo:vars";
-
-  // Dart Sass
   @use "hugo:vars" as v;
+
+  .element {
+    color: v.$primary-color;
+    font-size: v.$font-size;
+  }
+  ```
+
+  The `vars` option is useful for setting Sass variables within your project configuration.
+
+  {{< code-toggle file=hugo >}}
+  [params.theme.style]
+  primary-color = 'blue'
+  font-size = '24px'
+  {{< /code-toggle >}}
+
+  ```go-html-template
+  {{ $opts := dict "vars" site.Params.theme.style }}
+  {{ $r := resources.Get "sass/main.scss" | css.Sass $opts }}
   ```
 
   When passing a `vars` map to the `css.Sass` function, Hugo detects common typed CSS values such as `24px` or `#FF0000` using regular expression matching. If necessary, you can bypass automatic type inference by using the [`css.Quoted`][] or [`css.Unquoted`][] function to explicitly indicate a value's type.
@@ -77,7 +143,7 @@ vars
     "vars" site.Params.styles
     "includePaths" (slice "node_modules/bootstrap/scss")
   }}
-  {{ with . | toCSS $opts }}
+  {{ with . | css.Sass $opts }}
     {{ if hugo.IsDevelopment }}
       <link rel="stylesheet" href="{{ .RelPermalink }}">
     {{ else }}

--- a/content/en/functions/css/Unquoted.md
+++ b/content/en/functions/css/Unquoted.md
@@ -13,61 +13,39 @@ params:
 <!-- Added in v0.111.0 -->
 
 > [!note]
-> This function is only applicable to the [`vars`] option passed to the [`css.Sass`] function.
+> This function is only applicable to the `vars` option passed to the [`css.Sass`][] function.
 
-When passing a `vars` map to the `css.Sass` function, Hugo detects common typed CSS values such as `24px` or `#FF0000` using regular expression matching. If necessary, you can bypass automatic type inference by using the `css.Unquoted` function to explicitly indicate that the value must not be treated as a quoted string.
+When passing a `vars` map to the `css.Sass` function, Hugo detects common typed CSS values such as `24px` or `#FF0000` using regular expression matching. If necessary, you can bypass automatic type inference by using the `css.Unquoted` function to explicitly indicate that the value must be treated as an unquoted string.
 
-For example:
+In the example below, we use `css.Unquoted` to ensure the value for the `font-family` property is injected without quotes.
 
-```scss {file="assets/sass/main.scss"}
-@use "hugo:vars" as h;
-
-h1 {
-  font-size: h.$font-size-h1;
-}
-
-h2 {
-  font-size: h.$font-size-h2;
-}
-```
-
-```go-html-template {file="layouts/_partials/css.html"}
+```go-html-template
 {{ $vars := dict
-  "font_size_h1" ("72px * 0.500" | css.Unquoted)
-  "font_size_h2" ("72px * 0.375" | css.Unquoted)
+  "font-main" ("sans-serif" | css.Unquoted)
 }}
 
-{{ with resources.Get "sass/main.scss" }}
-  {{ $opts := dict
-    "enableSourceMap" hugo.IsDevelopment
-    "outputStyle" (cond hugo.IsDevelopment "expanded" "compressed")
-    "targetPath" "css/main.css"
-    "transpiler" "dartsass"
-    "vars" $vars
-  }}
-  {{ with . | toCSS $opts }}
-    {{ if hugo.IsDevelopment }}
-      <link rel="stylesheet" href="{{ .RelPermalink }}">
-    {{ else }}
-      {{ with . | fingerprint }}
-        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
-      {{ end }}
-    {{ end }}
-  {{ end }}
+{{ $opts := dict "vars" $vars "transpiler" "dartsass" }}
+{{ with resources.Get "sass/main.scss" | css.Sass $opts }}
+  <link rel="stylesheet" href="{{ .RelPermalink }}">
 {{ end }}
 ```
 
-The Sass rules are transpiled to:
+Using the `hugo:vars` identifier in your stylesheet:
 
-```css {file="public/css/main.css"}
-h1 {
-  font-size: 36px;
-}
+```scss
+@use "hugo:vars" as h;
 
-h2 {
-  font-size: 27px;
+body {
+  font-family: h.$font-main;
 }
 ```
 
-[`css.Sass`]: /functions/css/sass/
-[`vars`]: /functions/css/sass/#vars
+The resulting CSS contains an unquoted string:
+
+```css
+body {
+  font-family: sans-serif;
+}
+```
+
+[`css.Sass`]: /functions/css/sass/#vars

--- a/content/en/render-hooks/headings.md
+++ b/content/en/render-hooks/headings.md
@@ -24,6 +24,10 @@ Attributes
 Level
 : (`int`) The heading level, 1 through 6.
 
+Ordinal
+: {{< new-in v0.160.0 />}}
+: (`int`) The zero-based ordinal of the heading on the page.
+
 Page
 : (`page`) A reference to the current page.
 
@@ -32,6 +36,10 @@ PageInner
 
 PlainText
 : (`string`) The heading text as plain text.
+
+Position
+: {{< new-in 0.160.0 />}}
+: (`string`) The position of the heading within the page content.
 
 Text
 : (`template.HTML`) The heading text.

--- a/content/en/render-hooks/images.md
+++ b/content/en/render-hooks/images.md
@@ -39,6 +39,7 @@ IsBlock
 : (`bool`) Reports whether a standalone image is not wrapped within a paragraph element.
 
 Ordinal
+: {{< new-in v0.160.0 />}}
 : (`int`) The zero-based ordinal of the image on the page.
 
 Page
@@ -49,6 +50,10 @@ PageInner
 
 PlainText
 : (`string`) The image description as plain text.
+
+Position
+: {{< new-in 0.160.0 />}}
+: (`string`) The position of the image within the page content.
 
 Text
 : (`template.HTML`) The image description.

--- a/content/en/render-hooks/links.md
+++ b/content/en/render-hooks/links.md
@@ -25,6 +25,10 @@ Link _render hook_ templates receive the following context:
 Destination
 : (`string`) The link destination.
 
+Ordinal
+: {{< new-in v0.160.0 />}}
+: (`int`) The zero-based ordinal of the link on the page.
+
 Page
 : (`page`) A reference to the current page.
 
@@ -33,6 +37,10 @@ PageInner
 
 PlainText
 : (`string`) The link description as plain text.
+
+Position
+: {{< new-in 0.160.0 />}}
+: (`string`) The position of the link within the page content.
 
 Text
 : (`template.HTML`) The link description.

--- a/data/docs.yaml
+++ b/data/docs.yaml
@@ -1038,7 +1038,6 @@ chroma:
     - zig
     Name: Zig
   styles:
-  - RPGLE
   - abap
   - algol
   - algol_nu
@@ -1091,6 +1090,7 @@ chroma:
   - rose-pine
   - rose-pine-dawn
   - rose-pine-moon
+  - rpgle
   - rrt
   - solarized-dark
   - solarized-dark256
@@ -2211,12 +2211,12 @@ tpl:
         Description: |-
           Append appends args up to the last one to the slice in the last argument.
           This construct allows template constructs like this:
-          
+
           	{{ $pages = $pages | append $p2 $p1 }}
-          
+
           Note that with 2 arguments where both are slices of the same type,
           the first slice will be appended to the second:
-          
+
           	{{ $pages = $pages | append .Site.RegularPages }}
         Examples: []
       Apply:
@@ -2237,11 +2237,11 @@ tpl:
         Description: |-
           Complement gives the elements in the last element of ls that are not in
           any of the others.
-          
+
           All elements of ls must be slices or arrays of comparable types.
-          
+
           The reasoning behind this rather clumsy API is so we can do this in the templates:
-          
+
           	{{ $c := .Pages | complement $last4 }}
         Examples:
         - - '{{ slice "a" "b" "c" "d" "e" "f" | complement (slice "b" "c") (slice "d" "e") }}'
@@ -2316,9 +2316,9 @@ tpl:
           Index returns the result of indexing its first argument by the following
           arguments. Thus "index x 1 2 3" is, in Go syntax, x[1][2][3]. Each
           indexed item must be a map, slice, or array.
-          
+
           Adapted from Go stdlib src/text/template/funcs.go.
-          
+
           We deviate from the stdlib mostly because of https://github.com/golang/go/issues/14751.
         Examples: []
       Intersect:
@@ -2368,7 +2368,7 @@ tpl:
         Description: |-
           Merge creates a copy of the final parameter in params and merges the preceding
           parameters into it in reverse order.
-          
+
           Currently only maps are supported. Key handling is case insensitive.
         Examples:
         - - '{{ dict "title" "Hugo Rocks!" | collections.Merge (dict "title" "Default Title" "description" "Yes, Hugo Rocks!") | sort }}'
@@ -2415,9 +2415,9 @@ tpl:
         - args
         Description: |-
           Seq creates a sequence of integers from args. It's named and used as GNU's seq.
-          
+
           Examples:
-          
+
           	3 => 1, 2, 3
           	1 2 4 => 1, 3
           	-3 => -1, -2, -3
@@ -2506,7 +2506,7 @@ tpl:
         - v2
         Description: |-
           Conditional can be used as a ternary operator.
-          
+
           It returns v1 if cond is true, else v2.
         Examples:
         - - '{{ cond (eq (add 2 2) 4) "2+2 is 4" "what?" | safeHTML }}'
@@ -2682,10 +2682,10 @@ tpl:
           Dump returns a object dump of val as a string.
           Note that not every value passed to Dump will print so nicely, but
           we'll improve on that.
-          
+
           We recommend using the "go" Chroma lexer to format the output
           nicely.
-          
+
           Also note that the output from Dump may change from Hugo version to the next,
           so don't depend on a specific output.
         Examples:
@@ -3107,7 +3107,7 @@ tpl:
         - v
         Description: |-
           Humanize returns the humanized form of v.
-          
+
           If v is either an integer or a string containing an integer
           value, the behavior is to add the appropriate ordinal.
         Examples:
@@ -3171,7 +3171,7 @@ tpl:
         Description: |-
           FormatAccounting returns the currency representation of number for the given currency and precision
           for the current language in accounting notation.
-          
+
           The return value is formatted with at least two decimal places.
         Examples:
         - - '{{ 512.5032 | lang.FormatAccounting 2 "NOK" }}'
@@ -3185,7 +3185,7 @@ tpl:
         Description: |-
           FormatCurrency returns the currency representation of number for the given currency and precision
           for the current language.
-          
+
           The return value is formatted with at least two decimal places.
         Examples:
         - - '{{ 512.5032 | lang.FormatCurrency 2 "USD" }}'
@@ -3793,16 +3793,16 @@ tpl:
           so if you organize your resources in sub-folders, you need to be explicit about it, e.g.:
           "images/*.png". To match any PNG image anywhere in the bundle you can do "**.png", and
           to match all PNG images below the images folder, use "images/**.jpg".
-          
+
           The matching is case insensitive.
-          
+
           Match matches by using the files name with path relative to the file system root
           with Unix style slashes (/) and no leading slash, e.g. "images/logo.png".
-          
+
           See https://github.com/gobwas/glob for the full rules set.
-          
+
           It looks for files in the assets file system.
-          
+
           See Match for a more complete explanation about the rules used.
         Examples: []
       Minify:
@@ -4148,7 +4148,7 @@ tpl:
           expression in content. Each element is a slice of strings holding the text
           of the leftmost match of the regular expression and the matches, if any, of
           its subexpressions.
-          
+
           By default all matches will be included. The number of matches can be
           limited with the optional limit parameter. A return value of nil indicates
           no match.
@@ -4521,7 +4521,7 @@ tpl:
         - s
         Description: |-
           Emojify returns a copy of s with all emoji codes replaced with actual emojis.
-          
+
           See http://www.emoji-cheat-sheet.com/
         Examples:
         - - '{{ "I :heart: Hugo" | emojify }}'


### PR DESCRIPTION
- [x] Add `Ordinal` and `Position` to render hook context for [headings][], [images][], and [links][]. See [#14664][].
- [x] Update docs.yaml. See [#14671][].
- [x] Add `vars` option to [`css.Build`][]. See [#14700][].

[#14700]: https://github.com/gohugoio/hugo/pull/14700
[#14664]: https://github.com/gohugoio/hugo/pull/14664
[#14671]: https://github.com/gohugoio/hugo/pull/14671
[headings]: https://deploy-preview-3450--gohugoio.netlify.app/render-hooks/headings/#context
[images]: https://deploy-preview-3450--gohugoio.netlify.app/render-hooks/images/#context
[links]: https://deploy-preview-3450--gohugoio.netlify.app/render-hooks/links/#context
[`css.Build`]: https://deploy-preview-3450--gohugoio.netlify.app/functions/css/build/#vars