### PR TITLE
content: Identify esbuild as the foundation for build functions

### DIFF
--- a/content/en/functions/css/Build.md
+++ b/content/en/functions/css/Build.md
@@ -12,6 +12,9 @@ params:
 
 {{< new-in 0.158.0 />}}
 
+> [!note]
+> The `css.Build` function is backed by the [`evanw/esbuild`][] package, providing a mature, high-performance foundation for bundling, transformation, and minification.
+
 Use the `css.Build` function to:
 
 - Recursively replace `@import` statements in CSS files with the content of the imported files
@@ -90,7 +93,7 @@ To minify the generated CSS code, use the [`minify`](#minify) option as describe
 
 ## Options
 
-The `css.Build` function takes an optional map of options based on the underlying [`esbuild`] package. Use these options to fine-tune bundling, minification, and browser compatibility.
+The `css.Build` function takes an optional map of options to fine-tune bundling, minification, and browser compatibility.
 
 externals
 : (`[]string`) A slice of path patterns to exclude from bundling. The `@import` statements for these patterns remain as-is in the generated CSS code. See&nbsp;[details][esb_external].
@@ -203,17 +206,6 @@ Using the options above, Hugo does the following:
 - Publishes the generated CSS code to `css/styles.css`
 - In production, adds an SRI hash and inserts a file hash into the filename
 
-[`esbuild`]: https://github.com/evanw/esbuild
-[`publishDir`]: /configuration/all/#publishdir
-[browserlist]: https://browsersl.ist
-[esb_external]: https://esbuild.github.io/api/#external
-[esb_loader]: https://esbuild.github.io/api/#loader
-[esb_mainfields]: https://esbuild.github.io/api/#main-fields
-[esb_minify]: https://esbuild.github.io/api/#minify
-[esb_sourcemap]: https://esbuild.github.io/api/#sourcemap
-[esb_sourcesContent]: https://esbuild.github.io/api/#sources-content
-[esb_target]: https://esbuild.github.io/api/#target
-
 ## Common patterns
 
 The examples below cover the most frequent use cases for referencing resources within your project or within Node packages. These patterns apply to both `@import` statements and the `url()` functional notation used for images and fonts.
@@ -254,3 +246,14 @@ To reference a specific file within a Node package, provide the path starting wi
 ```css {file="/assets/css/main.css"}
 @import "bootstrap/dist/css/bootstrap-grid.css";
 ```
+
+[`evanw/esbuild`]: https://github.com/evanw/esbuild
+[`publishDir`]: /configuration/all/#publishdir
+[browserlist]: https://browsersl.ist
+[esb_external]: https://esbuild.github.io/api/#external
+[esb_loader]: https://esbuild.github.io/api/#loader
+[esb_mainfields]: https://esbuild.github.io/api/#main-fields
+[esb_minify]: https://esbuild.github.io/api/#minify
+[esb_sourcemap]: https://esbuild.github.io/api/#sourcemap
+[esb_sourcesContent]: https://esbuild.github.io/api/#sources-content
+[esb_target]: https://esbuild.github.io/api/#target

--- a/content/en/functions/js/Batch.md
+++ b/content/en/functions/js/Batch.md
@@ -11,6 +11,9 @@ params:
 ---
 
 > [!note]
+> The `js.Batch` function is backed by the [`evanw/esbuild`][] package, providing a mature, high-performance foundation for bundling, transformation, and minification.
+
+> [!note]
 > For a runnable example of this feature, see [this test and demo repo](https://github.com/bep/hugojsbatchdemo/).
 
 The Batch `ID` is used to create the base directory for this batch. Forward slashes are allowed. `js.Batch` returns an object with an API with this structure:
@@ -287,22 +290,23 @@ import './lib1.js';
 console.log('entrypoints-workaround.js');
 ```
 
+[ESBuild]: https://github.com/evanw/esbuild
+[JavaScript import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
+[OptionsSetter]: #optionssetter
+[SetOptions]: #optionssetter
 [`Resource`]: /methods/resource/
 [`Resources.Mount`]: /methods/page/resources/#mount
 [`Resources`]: /methods/page/resources/
+[`evanw/esbuild`]: https://github.com/evanw/esbuild
 [`templates.Defer`]: /functions/templates/defer/
 [build options]: #build-options
 [code splitting]: https://esbuild.github.io/api/#splitting
 [config]: #config
-[ESBuild]: https://github.com/evanw/esbuild
 [group]: #group
 [instance]: #instance
-[JavaScript import]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [js.Batch Demo Repo]: https://github.com/bep/hugojsbatchdemo/
-[OptionsSetter]: #optionssetter
 [params options]: #params-options
 [runner]: #runner
-[script]: #script
 [script options]: #script-options
-[SetOptions]: #optionssetter
+[script]: #script
 [with]: /functions/go-template/with/

--- a/content/en/functions/js/Build.md
+++ b/content/en/functions/js/Build.md
@@ -10,7 +10,10 @@ params:
     signatures: ['js.Build [OPTIONS] RESOURCE']
 ---
 
-The `js.Build` function uses the [evanw/esbuild] package to:
+> [!note]
+> The `js.Build` function is backed by the [`evanw/esbuild`][] package, providing a mature, high-performance foundation for bundling, transformation, and minification.
+
+Use the `js.Build` function to:
 
 - Bundle
 - Transpile (TypeScript and JSX)
@@ -74,7 +77,7 @@ For other files (e.g. `JSON`, `CSS`) you need to use the relative path including
 import * as data from 'my/module/data.json';
 ```
 
-Any imports in a file outside `assets` or that does not resolve to a component inside `assets` will be resolved by [ESBuild](https://esbuild.github.io/) with the **project directory** as the resolve directory (used as the starting point when looking for `node_modules` etc.). Also see [hugo mod npm pack](/commands/hugo_mod_npm_pack/). If you have any imported npm dependencies in your project, you need to make sure to run `npm install` before you run `hugo build`.
+Any imports in a file outside `assets` or that does not resolve to a component inside `assets` will be resolved by [esbuild](https://esbuild.github.io/) with the **project directory** as the resolve directory (used as the starting point when looking for `node_modules` etc.). Also see [hugo mod npm pack](/commands/hugo_mod_npm_pack/). If you have any imported npm dependencies in your project, you need to make sure to run `npm install` before you run `hugo build`.
 
 Also note the new `params` option that can be passed from template to your JS files, e.g.:
 
@@ -118,4 +121,4 @@ Or with options:
 <script src="{{ $built.RelPermalink }}" defer></script>
 ```
 
-[evanw/esbuild]: https://github.com/evanw/esbuild
+[`evanw/esbuild`]: https://github.com/evanw/esbuild


### PR DESCRIPTION
Closes #3448

See <https://deploy-preview-3452--gohugoio.netlify.app/functions/css/build/>.

If this is acceptable I will update the `js.Build` and `js.Batch` pages as well.

