### PR TITLE
Add EchoThread to comment systems list

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -47,6 +47,7 @@ Commercial commenting systems:
 - [Hyvor Talk](https://talk.hyvor.com/)
 - [IntenseDebate](https://intensedebate.com/)
 - [ReplyBox](https://getreplybox.com/)
+- [EchoThread](https://echothread.io/)
 
 Open-source commenting systems:
 


### PR DESCRIPTION
## Summary

- Add [EchoThread](https://echothread.io/) to the commercial commenting systems list on the Comments page.

EchoThread is a privacy-first commenting system with no tracking or third-party cookies. Its lightweight embed makes it a natural fit for Hugo sites where fast load times and minimal JavaScript overhead matter. See the [Hugo integration guide](https://echothread.io/docs/guides/hugo) for setup details.

## Test plan

- [ ] Verify the link renders correctly on the Comments page
- [ ] Confirm the entry is alphabetically placed among commercial systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)