### PR TITLE
Update actions/upload-pages-artifact version

### DIFF
--- a/content/en/host-and-deploy/host-on-github-pages/index.md
+++ b/content/en/host-and-deploy/host-on-github-pages/index.md
@@ -150,7 +150,7 @@ Step 4
             path: ${{ runner.temp }}/hugo_cache
             key: ${{ steps.cache-restore.outputs.cache-primary-key }}
         - name: Upload artifact
-          uses: actions/upload-pages-artifact@v3
+          uses: actions/upload-pages-artifact@v5
           with:
             path: ./public
     deploy:


### PR DESCRIPTION
https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0

Resolves the remaining

> Node.js 20 actions are deprecated.

warning.

Relates to #3469