### PR TITLE
content: Updates for v0.161.0

### DIFF
--- a/content/en/_common/installation/01-editions.md
+++ b/content/en/_common/installation/01-editions.md
@@ -6,17 +6,21 @@ _comment: Do not remove front matter.
 
 Hugo is available in several editions. Use the standard edition unless you need additional features.
 
-Feature|standard|deploy (1)|extended|extended/deploy
+Feature|standard|deploy (1)|extended (2)|extended/deploy (3)
 :--|:-:|:-:|:-:|:-:
 Core features|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:
-Direct cloud deployment (2)|:x:|:heavy_check_mark:|:x:|:heavy_check_mark:
-LibSass support (3)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:
+Direct cloud deployment (4)|:x:|:heavy_check_mark:|:x:|:heavy_check_mark:
+LibSass support (5)|:x:|:x:|:heavy_check_mark:|:heavy_check_mark:
 
 (1) {{< new-in v0.159.2 />}}
 
-(2) Deploy your site directly to a Google Cloud Storage bucket, an AWS S3 bucket, or an Azure Storage container. See&nbsp;[details].
+(2) {{< deprecated-in v0.161.0 />}} Use the standard edition instead.
 
-(3) [Transpile Sass to CSS] via embedded LibSass. Note that embedded LibSass was deprecated in v0.153.0 and will be removed in a future release. Use the [Dart Sass] transpiler instead, which is compatible with any edition.
+(3) {{< deprecated-in v0.161.0 />}} Use the deploy edition instead.
+
+(4) Deploy your site directly to a Google Cloud Storage bucket, an AWS S3 bucket, or an Azure Storage container. See&nbsp;[details].
+
+(5) [Transpile Sass to CSS] via embedded LibSass. Note that embedded LibSass was deprecated in v0.153.0 and will be removed in a future release. Use the [Dart Sass] transpiler instead, which is compatible with any edition.
 
 [dart sass]: /functions/css/sass/#dart-sass
 [transpile sass to css]: /functions/css/sass/

--- a/content/en/_common/installation/04-build-from-source.md
+++ b/content/en/_common/installation/04-build-from-source.md
@@ -29,6 +29,8 @@ CGO_ENABLED=0 go install -tags withdeploy github.com/gohugoio/hugo@latest
 
 ### Extended edition
 
+{{< deprecated-in v0.161.0 />}} Build the standard edition instead.
+
 To build and install the extended edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
 
 ```sh
@@ -36,6 +38,8 @@ CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@latest
 ```
 
 ### Extended/deploy edition
+
+{{< deprecated-in v0.161.0 />}} Build the deploy edition instead.
 
 To build and install the extended/deploy edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
 

--- a/content/en/_common/installation/homebrew.md
+++ b/content/en/_common/installation/homebrew.md
@@ -4,7 +4,7 @@ _comment: Do not remove front matter.
 
 ### Homebrew
 
-[Homebrew] is a free and open-source package manager for macOS and Linux. To install the extended/deploy edition of Hugo:
+[Homebrew] is a free and open-source package manager for macOS and Linux. To install the deploy edition:
 
 ```sh
 brew install hugo

--- a/content/en/configuration/module.md
+++ b/content/en/configuration/module.md
@@ -73,6 +73,8 @@ This is the default configuration:
 
 You can omit any of the settings above.
 
+<!-- TODO: remove the "extended" bit somewhere around April 15, 2027 -->
+
 extended
 : (`bool`) Whether the extended edition of Hugo is required, satisfied by installing either the extended or extended/deploy edition.
 

--- a/content/en/contribute/development.md
+++ b/content/en/contribute/development.md
@@ -82,11 +82,15 @@ Step 5
 
   To build and install the extended edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
 
+  {{< deprecated-in v0.161.0 />}} Build and install the standard edition instead.
+
   ```sh
   CGO_ENABLED=1 go install -tags extended
   ```
 
   To build and install the extended/deploy edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
+
+  {{< deprecated-in v0.161.0 />}} Build and install the deploy edition instead.
 
   ```sh
   CGO_ENABLED=1 go install -tags extended,withdeploy

--- a/content/en/installation/macos.md
+++ b/content/en/installation/macos.md
@@ -18,7 +18,7 @@ weight: 10
 
 ### MacPorts
 
-[MacPorts] is a free and open-source package manager for macOS. To install the extended edition of Hugo:
+[MacPorts] is a free and open-source package manager for macOS. To install the standard edition:
 
 ```sh
 sudo port install hugo

--- a/content/en/installation/windows.md
+++ b/content/en/installation/windows.md
@@ -19,32 +19,26 @@ weight: 30
 
 ### Chocolatey
 
-[Chocolatey] is a free and open-source package manager for Windows. To install the extended edition of Hugo:
+[Chocolatey] is a free and open-source package manager for Windows. To install the standard edition:
 
 ```sh
-choco install hugo-extended
+choco install hugo
 ```
 
 ### Scoop
 
-[Scoop] is a free and open-source package manager for Windows. To install the extended edition of Hugo:
+[Scoop] is a free and open-source package manager for Windows. To install the standard edition:
 
 ```sh
-scoop install hugo-extended
+scoop install hugo
 ```
 
 ### Winget
 
-[Winget] is Microsoft's official free and open-source package manager for Windows. To install the extended edition of Hugo:
+[Winget] is Microsoft's official free and open-source package manager for Windows. To install the standard edition:
 
 ```sh
-winget install Hugo.Hugo.Extended
-```
-
-To uninstall the extended edition of Hugo:
-
-```sh
-winget uninstall --name "Hugo (Extended)"
+winget install Hugo.Hugo
 ```
 
 {{% include "/_common/installation/04-build-from-source.md" %}}


### PR DESCRIPTION
- [ ] Never auto-fallback to page resources in other roles/versions. See [#14753][]. I don't know enough about this to determine if we need adjust the documentation.
- [ ] Add a more flexible filename identifier scheme that also allows setting roles and versions. See [#14754][].
- [ ] Add slice-based permalinks config. See [#14759][].
- [ ] Deprecation of extended and extended/deploy editions. See [#14728][]. In the "Repository packages" and "Package managers" sections for each OS, replace the extended edition instructions with the standard edition instructions. Don't display both commands and don't display a deprecation badge. Including two commands for every installation method will be difficult to read and potentially overwhelming. In the "Editions" sections, display deprecation badges. In the "Build from source" sections, display deprecation badges and retain instructions for building the extended and extended/deploy editions.
  - [ ] BSD
    - [x] [Editions][bsd-editions]
    - [ ] [Repository packages][bsd-repository-packages]
    - [x] [Build from source][bsd-build-from-source]
  - [ ] Linux
    - [x] [Editions][linux-editions]
    - [x] [Package managers][linux-package-managers] (note that we have to change our snap recipe ~ 
    - [ ] [Repository packages][linux-repository-packages]
    - [x] [Build from source][linux-build-from-source]
  - [x] macOS
    - [x] [Editions][macos-editions]
    - [x] [Package managers][macos-package-managers]
    - [x] [Build from source][macos-build-from-source]
  - [x] Windows
    - [x] [Editions][windows-editions]
    - [x] [Package managers][windows-package-managers]
    - [x] [Build from source][windows-build-from-source]
  - [x] Instructions in the [contribute/development][contribute/development] section.


[contribute/development]: https://deploy-preview-3475--gohugoio.netlify.app/contribute/development/#step-5
[bsd-editions]: https://deploy-preview-3475--gohugoio.netlify.app/installation/bsd/#editions
[bsd-repository-packages]: https://deploy-preview-3475--gohugoio.netlify.app/installation/bsd/#repository-packages
[bsd-build-from-source]: https://deploy-preview-3475--gohugoio.netlify.app/installation/bsd/#build-from-source

[linux-editions]: https://deploy-preview-3475--gohugoio.netlify.app/installation/linux/#editions
[linux-package-managers]: https://deploy-preview-3475--gohugoio.netlify.app/installation/linux/#package-managers
[linux-repository-packages]: https://deploy-preview-3475--gohugoio.netlify.app/installation/linux/#repository-packages
[linux-build-from-source]: https://deploy-preview-3475--gohugoio.netlify.app/installation/linux/#build-from-source

[macos-editions]: https://deploy-preview-3475--gohugoio.netlify.app/installation/macos/#editions
[macos-package-managers]: https://deploy-preview-3475--gohugoio.netlify.app/installation/macos/#package-managers
[macos-build-from-source]: https://deploy-preview-3475--gohugoio.netlify.app/installation/macos/#build-from-source

[windows-editions]: https://deploy-preview-3475--gohugoio.netlify.app/installation/windows/#editions
[windows-package-managers]: https://deploy-preview-3475--gohugoio.netlify.app/installation/windows/#package-managers
[windows-build-from-source]: https://deploy-preview-3475--gohugoio.netlify.app/installation/windows/#build-from-source

[#14728]: https://github.com/gohugoio/hugo/pull/14728
[#14753]: https://github.com/gohugoio/hugo/pull/14753
[#14754]: https://github.com/gohugoio/hugo/pull/14754
[#14759]: https://github.com/gohugoio/hugo/pull/14759