### PR TITLE
content: Add gotmplfmt to list of VS Code extensions

### DIFF
--- a/content/en/tools/editors.md
+++ b/content/en/tools/editors.md
@@ -8,59 +8,57 @@ weight: 10
 
 ## Visual Studio Code
 
+[gotmplfmt](https://marketplace.visualstudio.com/items?itemName=GoHugoIO.gotmplfmt)
+: Developed and maintained by the Hugo authors, this extension formats [templates](g) using the [gotmplfmt](https://github.com/gohugoio/gotmplfmt) CLI.
+
 [Front Matter](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter)
-: Once you go for a static site, you need to think about how you are going to manage your articles. Front matter is a tool that helps you maintain the metadata/front matter of your articles like: creation date, modified date, slug, tile, SEO check, and more.
+: This extension maintains article metadata such as creation date, modified date, slug, title, SEO check, and more.
 
 [Hugo Helper](https://marketplace.visualstudio.com/items?itemName=rusnasonov.vscode-hugo)
-: Hugo Helper is a plugin for Visual Studio Code that has some useful commands for Hugo. The source code can be found on its [GitHub repository](https://github.com/rusnasonov/vscode-hugo).
+: This extension provides some useful commands. The source code is available on its [GitHub repository](https://github.com/rusnasonov/vscode-hugo).
 
 [Hugo Language and Syntax Support](https://marketplace.visualstudio.com/items?itemName=budparr.language-hugo-vscode)
-: Hugo Language and Syntax Support is a Visual Studio Code plugin for Hugo syntax highlighting and snippets. The source code can be found on its [GitHub repository](https://github.com/budparr/language-hugo-vscode).
-
-[Hugo Themer](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-hugo-themer)
-: Hugo Themer is an extension to help you while developing themes. It allows you to easily navigate through your theme files.
-
-[Hugofy](https://marketplace.visualstudio.com/items?itemName=akmittal.hugofy)
-: Hugofy is a plugin for Visual Studio Code to "make life easier" when developing with Hugo. The source code can be found on its [GitHub repository](https://github.com/akmittal/hugofy-vscode).
-
-[Prettier Plugin for Go Templates](https://github.com/NiklasPor/prettier-plugin-go-template)
-: Format Hugo templates using this [Prettier](https://prettier.io/) plugin. See [installation instructions](https://discourse.gohugo.io/t/38403).
-
-[Syntax Highlighting for Hugo Shortcodes](https://marketplace.visualstudio.com/items?itemName=kaellarkin.hugo-shortcode-syntax)
-: This extension adds some syntax highlighting for Shortcodes, making visual identification of individual pieces easier.
+: This extension provides syntax highlighting and snippets. The source code is available on its [GitHub repository](https://github.com/budparr/language-hugo-vscode).
 
 [Hugo Shortcodes](https://marketplace.visualstudio.com/items?itemName=thuliteio.hugo-shortcodes)
-: Hugo Shortcodes is a Visual Studio Code extension that adds syntax highlighting and intelligent completions for Hugo shortcodes in Markdown, including shortcode names and arguments discovered from workspace templates. The source code can be found on its [GitHub repository](https://github.com/thuliteio/hugo-shortcodes).
+: This extension adds syntax highlighting and intelligent completions for shortcodes in Markdown, including shortcode names and arguments discovered from workspace templates. The source code is available on its [GitHub repository](https://github.com/thuliteio/hugo-shortcodes).
+
+[Hugo Themer](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-hugo-themer)
+: This extension simplifies theme development, making it easy to navigate theme files.
+
+[Hugofy](https://marketplace.visualstudio.com/items?itemName=akmittal.hugofy)
+: This extension streamlines project development. The source code is available on its [GitHub repository](https://github.com/akmittal/hugofy-vscode).
+
+[Syntax Highlighting for Hugo Shortcodes](https://marketplace.visualstudio.com/items?itemName=kaellarkin.hugo-shortcode-syntax)
+: This extension adds syntax highlighting for [shortcodes](g), making visual identification of individual pieces easier.
 
 ## JetBrains IDEs
 
 [Smart Hugo](https://smarthugo.dev)
-: Plugin for IntelliJ IDEA, WebStorm, PhpStorm, and other JetBrains IDEs that adds Hugo template support including syntax highlighting, actions completion, code formatting, and optional advanced features.
+: This plugin for IntelliJ IDEA, WebStorm, PhpStorm, and other JetBrains IDEs adds template support including syntax highlighting, actions completion, code formatting, and optional advanced features.
 
 ## Emacs
 
 [emacs-easy-hugo](https://github.com/masasam/emacs-easy-hugo)
-: Emacs major mode for managing hugo blogs. Note that Hugo also supports [Org-mode][formats].
+: This major Emacs mode supports writing blogs using various markup formats, including Markdown, Org mode, AsciiDoc, reStructuredText, mmark, and HTML.
 
 [ox-hugo.el](https://ox-hugo.scripter.co)
-: Native Org-mode exporter that exports to Blackfriday Markdown with Hugo front-matter. `ox-hugo` supports two common Org blogging flows --- exporting multiple Org subtrees in a single file to multiple Hugo posts, and exporting a single Org file to a single Hugo post. It also leverages the Org tag and property inheritance features. See [Why ox-hugo?](https://ox-hugo.scripter.co/doc/why-ox-hugo/) for more.
+: This native Org mode exporter exports to Blackfriday Markdown with [front-matter](g). It supports two common Org blogging flows: exporting multiple Org subtrees in a single file to multiple posts, and exporting a single Org file to a single post. It also leverages the Org tag and property inheritance features. See [Why ox-hugo?](https://ox-hugo.scripter.co/doc/why-ox-hugo/) for more.
 
 ## Sublime Text
 
-[Hugofy](https://github.com/akmittal/Hugofy)
-: Hugofy is a plugin for Sublime Text 3 to make life easier to use Hugo static site generator.
-
 [Hugo Snippets](https://packagecontrol.io/packages/Hugo%20Snippets)
-: Hugo Snippets is a useful plugin for adding automatic snippets to Sublime Text&nbsp;3.
+: This plugin adds automatic snippets.
+
+[Hugofy](https://github.com/akmittal/Hugofy)
+: This plugin streamlines project development.
 
 ## Vim
 
 [Vim Hugo Helper]: https://github.com/robertbasic/vim-hugo-helper
 
 [Vim Hugo Helper]
-: A small Vim plugin that facilitates authoring pages and blog posts with Hugo.
+: This plugin facilitates authoring pages and blog posts.
 
 [vim-hugo](https://github.com/phelipetls/vim-hugo)
-: A Vim plugin with syntax highlighting for templates and a few other features.
-
-[formats]: /content-management/formats/
+: This plugin provides syntax highlighting for templates and a few other features.


### PR DESCRIPTION
Also removes reference to the Prettier Plugin for Go Templates which is no longer maintained.

<https://deploy-preview-3490--gohugoio.netlify.app/tools/editors/#gotmplfmt>