### PR TITLE
content: Document fallback rendering for fenced code blocks

### DIFF
--- a/content/en/content-management/markdown-attributes.md
+++ b/content/en/content-management/markdown-attributes.md
@@ -48,10 +48,7 @@ block = true # default is false
 
 ## Standalone images
 
-By default, when the [Goldmark] Markdown renderer encounters a standalone image element (no other elements or text on the same line), it wraps the image element within a paragraph element per the [CommonMark specification].
-
-[CommonMark specification]: https://spec.commonmark.org/current/
-[Goldmark]: https://github.com/yuin/goldmark
+By default, when the [Goldmark][] Markdown renderer encounters a standalone image element (no other elements or text on the same line), it wraps the image element within a paragraph element per the [CommonMark specification][].
 
 If you were to place an attribute list beneath an image element, Hugo would apply the attributes to the surrounding paragraph, not the image.
 
@@ -64,9 +61,10 @@ wrapStandAloneImageWithinParagraph = false # default is true
 
 ## Usage
 
-You may add [global HTML attributes], or HTML attributes specific to the current element type. Consistent with its content security model, Hugo removes HTML event attributes such as `onclick` and `onmouseover`.
+You may add [global HTML attributes][], or HTML attributes specific to the current element type. Consistent with its content security model, Hugo removes HTML event attributes such as `onclick` and `onmouseover`.
 
-[global HTML attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
+> [!note]
+> Within fenced code blocks, Hugo interprets the `style` attribute as a syntax highlighting [option][option] rather than a global HTML attribute.
 
 The attribute list consists of one or more key-value pairs, separated by spaces or commas, wrapped by braces. You must quote string values that contain spaces. Unlike HTML, boolean attributes must have both key and value.
 
@@ -112,6 +110,10 @@ This is a paragraph.
 {class=foo}
 ````
 
-As shown above, the attribute list for fenced code blocks is not limited to HTML attributes. You can also configure syntax highlighting by passing one or more of [these options](/functions/transform/highlight/#options).
+As shown above, the attribute list for fenced code blocks is not limited to HTML attributes. You can also configure syntax highlighting by passing one or more of [these options][option].
 
+[CommonMark specification]: https://spec.commonmark.org/current/
+[global HTML attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
+[Goldmark]: https://github.com/yuin/goldmark
 [render hook templates]: /render-hooks/introduction/
+[option]: /functions/transform/highlight/#options

--- a/content/en/content-management/syntax-highlighting.md
+++ b/content/en/content-management/syntax-highlighting.md
@@ -8,12 +8,9 @@ aliases: [/extras/highlighting/,/extras/highlight/,/tools/syntax-highlighting/]
 
 Hugo provides several methods to add syntax highlighting to code examples:
 
-- Use the [`transform.Highlight`] function within your templates
-- Use the [`highlight`] shortcode with any [content format](g)
+- Use the [`transform.Highlight`][] function within your templates
+- Use the [`highlight`][] shortcode with any [content format](g)
 - Use fenced code blocks with the Markdown content format
-
-[`transform.Highlight`]: /functions/transform/highlight/
-[`highlight`]: /shortcodes/highlight/
 
 ## Fenced code blocks
 
@@ -29,13 +26,10 @@ CODE
 : The code to highlight.
 
 LANG
-: The language of the code to highlight. Choose from one of the [supported languages]. This value is case-insensitive.
+: The language of the code to highlight. Choose from one of the [supported languages][]. This value is case-insensitive. If omitted or unsupported, Hugo renders the text as a plain text block without syntax highlighting. Consistent with the [CommonMark specification][], fenced code blocks require a known language identifier to trigger semantic syntax highlighting.
 
 OPTIONS
-: One or more space-separated or comma-separated key-value pairs wrapped in braces. Set default values for each option in your [project configuration]. The key names are case-insensitive.
-
-[supported languages]: #languages
-[project configuration]: /configuration/markup/#highlight
+: One or more space-separated or comma-separated key-value pairs wrapped in braces. Set default values for each option in your [project configuration][]. The key names are case-insensitive.
 
 For example, with this Markdown:
 
@@ -95,8 +89,14 @@ Hugo renders this to:
 
 These are the supported languages. Use one of the identifiers, not the language name, when specifying a language for:
 
-- The [`transform.Highlight`] function
-- The [`highlight`] shortcode
+- The [`transform.Highlight`][] function
+- The [`highlight`][] shortcode
 - Fenced code blocks
 
 {{< chroma-lexers >}}
+
+[`highlight`]: /shortcodes/highlight/
+[`transform.Highlight`]: /functions/transform/highlight/
+[CommonMark specification]: https://spec.commonmark.org/0.31.2/#indented-code-blocks
+[project configuration]: /configuration/markup/#highlight
+[supported languages]: #languages


### PR DESCRIPTION
Describe how Hugo renders fenced code blocks when the language identifier in the info string is missing or unsupported.

Closes #3476

<https://deploy-preview-3491--gohugoio.netlify.app/content-management/syntax-highlighting/#lang>