### PR TITLE
content: Document page matcher usage for cascading values

### DIFF
--- a/content/en/_common/configuration/page-matcher.md
+++ b/content/en/_common/configuration/page-matcher.md
@@ -1,0 +1,22 @@
+---
+_comment: Do not remove front matter.
+---
+
+A _page matcher_ filters pages by logical path, page kind, environment, or site. Specify filtering criteria using any combination of the following keywords.
+
+environment
+: (`string`) A [glob pattern](g) matching the build [environment](g). For example: `{staging,production}`.
+
+kind
+: (`string`) A [glob pattern](g) matching the [page kind](g). For example: `{taxonomy,term}`.
+
+lang
+: {{< deprecated-in 0.153.0 />}}
+: Use [`sites`](#sites) instead.
+
+path
+: (`string`) A [glob pattern](g) matching the page's [logical path](g). For example: `{/books,/books/**}`.
+
+sites
+: {{< new-in 0.153.0 />}}
+: (`map`) A [sites matrix](g) matching any combination of [content dimensions](g) including language, version, and role.

--- a/content/en/_common/permalink-tokens.md
+++ b/content/en/_common/permalink-tokens.md
@@ -45,11 +45,11 @@ _comment: Do not remove front matter.
 
 `:filename`
 : {{< deprecated-in v0.144.0 />}}
-:  Use `:contentbasename` instead.
+: Use `:contentbasename` instead.
 
 `:slugorfilename`
 : {{< deprecated-in v0.144.0 />}}
-:  Use `:slugorcontentbasename` instead.
+: Use `:slugorcontentbasename` instead.
 
 `:contentbasename`
 : {{< new-in 0.144.0 />}}

--- a/content/en/configuration/cascade.md
+++ b/content/en/configuration/cascade.md
@@ -9,9 +9,9 @@ keywords: []
 You can configure your site to cascade front matter values to the home page and any of its descendants. However, this cascading will be prevented if the descendant already defines the field, or if a closer ancestor [node](g) has already cascaded a value for the same field through its front matter's `cascade` key.
 
 > [!note]
-> You can also configure cascading behavior within a page's front matter. See&nbsp;[details].
+> You can also configure cascading behavior within a page's front matter. See&nbsp;[details][].
 
-For example, to cascade a "color" parameter to the home page and all its descendants:
+For example, to cascade the `color` page parameter to all pages:
 
 {{< code-toggle file=hugo >}}
 [cascade.params]
@@ -24,51 +24,38 @@ color = 'red'
 We deprecated the `_target` front matter key in favor of `target` in v0.156.0 on 2026-02-17. Remove footnote #1 on or after 2027-05-17 (15 months after deprecation).
 -->
 
-The `target`[^1] keyword allows you to target specific pages or [environments](g). For example, to cascade a "color" parameter to pages within the "articles" section, including the "articles" section page itself:
+The `target` key accepts a [page matcher](g) to limit cascaded values to a subset of pages.[^1] If a target is not specified, values cascade to all pages.
 
-[^1]: The `_target` alias for `target` is deprecated and will be removed in a future release.
+{{% include "/_common/configuration/page-matcher.md" %}}
+
+For example, to cascade the `color` page parameter to the "articles" section and its descendants, but only for the English (`en`) and German (`de`) language sites:
 
 {{< code-toggle file=hugo >}}
 [cascade.params]
 color = 'red'
 [cascade.target]
 path = '{/articles,/articles/**}'
+[cascade.target.sites.matrix]
+languages = '{en,de}'
 {{< /code-toggle >}}
-
-Use any combination of these keywords to target pages and/or environments:
-
-environment
-: (`string`) A [glob pattern](g) matching the build [environment](g). For example: `{staging,production}`.
-
-kind
-: (`string`) A [glob pattern](g) matching the [page kind](g). For example: `{taxonomy,term}`.
-
-lang
-: (`string`) A [glob pattern](g) matching the [page language]. For example: `{en,de}`.
-
-path
-: (`string`) A [glob pattern](g) matching the page's [logical path](g). For example: `{/books,/books/**}`.
 
 ## Array
 
-Define an array of cascade parameters to apply different values to different targets. For example:
+Define an array of cascade maps to apply different values to different targets. For example:
 
 {{< code-toggle file=hugo >}}
 [[cascade]]
 [cascade.params]
 color = 'red'
 [cascade.target]
-path = '/books/**'
-kind = 'page'
-lang = '{en,de}'
+path = '{/articles,/articles/**}'
 [[cascade]]
 [cascade.params]
 color = 'blue'
 [cascade.target]
-path = '/films/**'
-kind = 'page'
-environment = 'production'
+path = '{/tutorials,/tutorials/**}'
 {{< /code-toggle >}}
 
+[^1]: The `_target` alias for `target` is deprecated and will be removed in a future release.
+
 [details]: /content-management/front-matter/#cascade-1
-[page language]: /methods/page/language/

--- a/content/en/content-management/front-matter.md
+++ b/content/en/content-management/front-matter.md
@@ -16,7 +16,7 @@ The front matter at the top of each content file is metadata that:
 - Controls the published structure of your site
 - Determines template selection
 
-Provide front matter using a serialization format, one of [JSON], [TOML], or [YAML]. Hugo determines the front matter format by examining the delimiters that separate the front matter from the page content.
+Provide front matter using a serialization format, one of [JSON][], [TOML][], or [YAML][]. Hugo determines the front matter format by examining the delimiters that separate the front matter from the page content.
 
 See examples of front matter delimiters by toggling between the serialization formats below.
 
@@ -36,78 +36,76 @@ Front matter fields may be [boolean](g), [integer](g), [float](g), [string](g), 
 The most common front matter fields are `date`, `draft`, `title`, and `weight`, but you can specify metadata using any of fields below.
 
 > [!note]
-> The field names below are reserved. For example, you cannot create a custom field named `type`. Create custom fields under the `params` key. See the [parameters] section for details.
-
-[parameters]: #parameters
+> The field names below are reserved. For example, you cannot create a custom field named `type`. Create custom fields under the `params` key. See the [parameters](#parameters) section for details.
 
 aliases
-: (`[]string`) An array of one or more [page-relative](g) or [site-relative](g) paths that should redirect to the current page. Hugo resolves these to [server-relative](g) URLs during the build process. Access these values from a template using the [`Aliases`] method on a `Page` object. See the [aliases] section for details.
+: (`[]string`) An array of one or more [page-relative](g) or [site-relative](g) paths that should redirect to the current page. Hugo resolves these to [server-relative](g) URLs during the build process. Access these values from a template using the [`Aliases`][] method on a `Page` object. See the [aliases][] section for details.
 
 build
-: (`map`) A map of [build options].
+: (`map`) A map of [build options][].
 
 cascade
-: (`map`) A map (or a slice of maps) of front matter keys whose values are passed down to the page's descendants unless overwritten by self or a closer ancestor's cascade. See the [cascade] section for details.
+: (`map`) A map (or array of maps) of front matter keys whose values are passed down to the page's descendants unless overwritten by self or a closer ancestor's cascade. See the [cascade][] section for details.
 
 date
-: (`string`) The date associated with the page, typically the creation date. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`Date`] method on a `Page` object.
+: (`string`) The date associated with the page, typically the creation date. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`Date`][] method on a `Page` object.
 
 description
-: (`string`) Conceptually different than the page `summary`, the description is typically rendered within a `meta` element within the `head` element of the published HTML file. Access this value from a template using the [`Description`] method on a `Page` object.
+: (`string`) Conceptually different than the page `summary`, the description is typically rendered within a `meta` element within the `head` element of the published HTML file. Access this value from a template using the [`Description`][] method on a `Page` object.
 
 draft
-: (`bool`) Whether to disable rendering unless you pass the `--buildDrafts` flag to the `hugo` command. Access this value from a template using the [`Draft`] method on a `Page` object.
+: (`bool`) Whether to disable rendering unless you pass the `--buildDrafts` flag to the `hugo` command. Access this value from a template using the [`Draft`][] method on a `Page` object.
 
 expiryDate
-: (`string`) The page expiration date. On or after the expiration date, the page will not be rendered unless you pass the `--buildExpired` flag to the `hugo` command. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`ExpiryDate`] method on a `Page` object.
+: (`string`) The page expiration date. On or after the expiration date, the page will not be rendered unless you pass the `--buildExpired` flag to the `hugo` command. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`ExpiryDate`][] method on a `Page` object.
 
 headless
-: (`bool`) Applicable to [leaf bundles], whether to set the `render` and `list` [build options] to `never`, creating a headless bundle of [page resources].
+: (`bool`) Applicable to [leaf bundles][], whether to set the `render` and `list` [build options][] to `never`, creating a headless bundle of [page resources][].
 
 isCJKLanguage
-: (`bool`) Whether the content language is in the [CJK](g) family. This value determines how Hugo calculates word count, and affects the values returned by the [`WordCount`], [`FuzzyWordCount`], [`ReadingTime`], and [`Summary`] methods on a `Page` object.
+: (`bool`) Whether the content language is in the [CJK](g) family. This value determines how Hugo calculates word count, and affects the values returned by the [`WordCount`][], [`FuzzyWordCount`][], [`ReadingTime`][], and [`Summary`][] methods on a `Page` object.
 
 keywords
-: (`[]string`) An array of keywords, typically rendered within a `meta` element within the `head` element of the published HTML file, or used as a [taxonomy](g) to classify content. Access these values from a template using the [`Keywords`] method on a `Page` object.
+: (`[]string`) An array of keywords, typically rendered within a `meta` element within the `head` element of the published HTML file, or used as a [taxonomy](g) to classify content. Access these values from a template using the [`Keywords`][] method on a `Page` object.
 
 lastmod
-: (`string`) The date that the page was last modified. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`Lastmod`] method on a `Page` object.
+: (`string`) The date that the page was last modified. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`Lastmod`][] method on a `Page` object.
 
 layout
-: (`string`) Provide a template name to [target a specific template],  overriding the default [template lookup order]. Set the value to the base file name of the template, excluding its extension. Access this value from a template using the [`Layout`] method on a `Page` object.
+: (`string`) Provide a template name to [target a specific template][],  overriding the default [template lookup order][]. Set the value to the base file name of the template, excluding its extension. Access this value from a template using the [`Layout`][] method on a `Page` object.
 
 linkTitle
-: (`string`) Typically a shorter version of the `title`. Access this value from a template using the [`LinkTitle`] method on a `Page` object.
+: (`string`) Typically a shorter version of the `title`. Access this value from a template using the [`LinkTitle`][] method on a `Page` object.
 
 markup
-: (`string`) An identifier corresponding to one of the supported [content formats]. If not provided, Hugo determines the content renderer based on the file extension.
+: (`string`) An identifier corresponding to one of the supported [content formats][]. If not provided, Hugo determines the content renderer based on the file extension.
 
 menus
-: (`string`, `[]string`, or `map`) If set, Hugo adds the page to the given menu or menus. See the [menus] page for details.
+: (`string`, `[]string`, or `map`) If set, Hugo adds the page to the given menu or menus. See the [menus][] page for details.
 
 modified
 : Alias to [lastmod](#lastmod).
 
 outputs
-: (`[]string`) The [output formats] to render. See [configure outputs] for more information.
+: (`[]string`) The [output formats][] to render. See [configure outputs][] for more information.
 
 params
-: (`map`) A map of custom [page parameters].
+: (`map`) A map of custom [page parameters][].
 
 pubdate
 : Alias to [publishDate](#publishdate).
 
 publishDate
-: (`string`) The page publication date. Before the publication date, the page will not be rendered unless you pass the `--buildFuture` flag to the `hugo` command. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`PublishDate`] method on a `Page` object.
+: (`string`) The page publication date. Before the publication date, the page will not be rendered unless you pass the `--buildFuture` flag to the `hugo` command. Note that the TOML format also supports unquoted date/time values. See the [dates](#dates) section for examples. Access this value from a template using the [`PublishDate`][] method on a `Page` object.
 
 published
 : Alias to [publishDate](#publishdate).
 
 resources
-: (`map array`) An array of maps to provide metadata for [page resources].
+: (`map array`) An array of maps to provide metadata for [page resources][].
 
 sitemap
-: (`map`) A map of sitemap options. See the [sitemap templates] page for details. Access these values from a template using the [`Sitemap`] method on a `Page` object.
+: (`map`) A map of sitemap options. See the [sitemap templates][] page for details. Access these values from a template using the [`Sitemap`][] method on a `Page` object.
 
 sites
 : {{< new-in 0.153.0 />}}
@@ -128,28 +126,28 @@ sites
   <!-- markdownlint-enable MD049 -->
 
 slug
-: (`string`) Overrides the last segment of the URL path. Not applicable to `home`, `section`, `taxonomy`, or `term` pages. See the [URL management] page for details. Access this value from a template using the [`Slug`] method on a `Page` object.
+: (`string`) Overrides the last segment of the URL path. Not applicable to `home`, `section`, `taxonomy`, or `term` pages. See the [URL management][] page for details. Access this value from a template using the [`Slug`][] method on a `Page` object.
 
 summary
-: (`string`) Conceptually different than the page `description`, the summary either summarizes the content or serves as a teaser to encourage readers to visit the page. Access this value from a template using the [`Summary`] method on a `Page` object.
+: (`string`) Conceptually different than the page `description`, the summary either summarizes the content or serves as a teaser to encourage readers to visit the page. Access this value from a template using the [`Summary`][] method on a `Page` object.
 
 title
-: (`string`) The page title. Access this value from a template using the [`Title`] method on a `Page` object.
+: (`string`) The page title. Access this value from a template using the [`Title`][] method on a `Page` object.
 
 translationKey
-: (`string`) An arbitrary value used to relate two or more translations of the same page, useful when the translated pages do not share a common path. Access this value from a template using the [`TranslationKey`] method on a `Page` object.
+: (`string`) An arbitrary value used to relate two or more translations of the same page, useful when the translated pages do not share a common path. Access this value from a template using the [`TranslationKey`][] method on a `Page` object.
 
 type
-: (`string`) The [content type](g), overriding the value derived from the top-level section in which the page resides. Access this value from a template using the [`Type`] method on a `Page` object.
+: (`string`) The [content type](g), overriding the value derived from the top-level section in which the page resides. Access this value from a template using the [`Type`][] method on a `Page` object.
 
 unpublishdate
 : Alias to [expirydate](#expirydate).
 
 url
-: (`string`) Overrides the entire URL path. Applicable to regular pages and section pages. See the [URL management] page for details.
+: (`string`) Overrides the entire URL path. Applicable to regular pages and section pages. See the [URL management][] page for details.
 
 weight
-: (`int`) The page [weight](g), used to order the page within a [page collection](g). Access this value from a template using the [`Weight`] method on a `Page` object.
+: (`int`) The page [weight](g), used to order the page within a [page collection](g). Access this value from a template using the [`Weight`][] method on a `Page` object.
 
 ## Parameters
 
@@ -164,15 +162,15 @@ weight = 10
 author = 'John Smith'
 {{< /code-toggle >}}
 
-Access these values from a template using the [`Params`] or [`Param`] method on a `Page` object.
+Access these values from a template using the [`Params`][] or [`Param`][] method on a `Page` object.
 
-Hugo provides [embedded templates] to optionally insert meta data within the `head` element of your rendered pages. These embedded templates expect the following front matter parameters:
+Hugo provides [embedded templates][] to optionally insert meta data within the `head` element of your rendered pages. These embedded templates expect the following front matter parameters:
 
 Parameter|Data type|Used by these embedded templates
 :--|:--|:--
-`audio`|`[]string`|[`opengraph.html`]
-`images`|`[]string`|[`opengraph.html`], [`schema.html`], [`twitter_cards.html`]
-`videos`|`[]string`|[`opengraph.html`]
+`audio`|`[]string`|[`opengraph.html`][]
+`images`|`[]string`|[`opengraph.html`][], [`schema.html`][], [`twitter_cards.html`][]
+`videos`|`[]string`|[`opengraph.html`][]
 
 The embedded templates will skip a parameter if not provided in front matter, but will throw an error if the data type is unexpected.
 
@@ -207,7 +205,7 @@ You can add taxonomy terms to the front matter of any these [page kinds](g):
 - `taxonomy`
 - `term`
 
-Access taxonomy terms from a template using the [`Params`] or [`GetTerms`] method on a `Page` object. For example:
+Access taxonomy terms from a template using the [`Params`][] or [`GetTerms`][] method on a `Page` object. For example:
 
 ```go-html-template {file="layouts/page.html"}
 {{ with .GetTerms "tags" }}
@@ -220,22 +218,20 @@ Access taxonomy terms from a template using the [`Params`] or [`GetTerms`] metho
 {{ end }}
 ```
 
-[`GetTerms`]: /methods/page/getterms/
-
 ## Cascade
+
+> [!note]
+> For multilingual projects, defining cascade values in your project configuration is often more efficient. This avoids repeating the same cascade values for each language. See&nbsp;[details](/configuration/cascade/).
 
 A [node](g) can cascade front matter values to its descendants. However, this cascading will be prevented if the descendant already defines the field, or if a closer ancestor node has already cascaded a value for that same field.
 
-For example, to cascade a "color" parameter from the home page to all its descendants:
+For example, to cascade the `color` page parameter from the home page to all its descendants:
 
 {{< code-toggle file=content/_index.md fm=true >}}
 title = 'Home'
 [cascade.params]
 color = 'red'
 {{< /code-toggle >}}
-
-{{< new-in 0.153.0 />}}
-From Hugo 0.153.0, you can also set the [sites](#sites) front matter as cascade front matter values, which means that you can e.g. apply one or more languages to the `target` pages.
 
 ### Target
 
@@ -243,38 +239,22 @@ From Hugo 0.153.0, you can also set the [sites](#sites) front matter as cascade 
 We deprecated the `_target` front matter key in favor of `target` in v0.156.0 on 2026-02-17. Remove footnote #1 on or after 2027-05-17 (15 months after deprecation).
 -->
 
-The `target`[^1] keyword allows you to target specific pages or [environments](g). For example, to cascade a "color" parameter from the home page only to pages within the "articles" section, including the "articles" section page itself:
+The `target` key accepts a [page matcher](g) to limit cascaded values to a subset of pages.[^1] If a target is not specified, values cascade to all descendant pages.
 
-[^1]: The `_target` alias for `target` is deprecated and will be removed in a future release.
+{{% include "/_common/configuration/page-matcher.md" %}}
 
-{{< code-toggle file=content/_index.md fm=true >}}
-title = 'Home'
+For example, to cascade the `color` page parameter from the home page to the "articles" section and its descendants:
+
+{{< code-toggle file=hugo >}}
 [cascade.params]
 color = 'red'
 [cascade.target]
 path = '{/articles,/articles/**}'
-[cascade.target.sites.matrix]
-languages = ['en','fr']
 {{< /code-toggle >}}
-
-Use any combination of these keywords to target pages and/or environments:
-
-environment
-: (`string`) A [glob pattern](g) matching the build [environment](g). For example: `{staging,production}`.
-
-kind
-: (`string`) A [glob pattern](g) matching the [page kind](g). For example: `{taxonomy,term}`.
-
-path
-: (`string`) A [glob pattern](g) matching the page's [logical path](g). For example: `{/books,/books/**}`.
-
-sites
-: {{< new-in 0.153.0 />}}
-: (`map`) A map to define [sites matrix](g) for the target, as in: Which sites should receive the cascaded values.
 
 ### Array
 
-Define an array of cascade parameters to apply different values to different targets. For example:
+Define an array of cascade maps to apply different values to different targets. For example:
 
 {{< code-toggle file=content/_index.md fm=true >}}
 title = 'Home'
@@ -282,24 +262,17 @@ title = 'Home'
 [cascade.params]
 color = 'red'
 [cascade.target]
-path = '{/books/**}'
-kind = 'page'
+path = '{/articles,/articles/**}'
 [[cascade]]
 [cascade.params]
 color = 'blue'
 [cascade.target]
-path = '{/films/**}'
-kind = 'page'
+path = '{/tutorials,/tutorials/**}'
 {{< /code-toggle >}}
-
-> [!note]
-> For multilingual projects, defining cascade values in your project configuration is often more efficient. This avoids repeating the same cascade values on the home, section, taxonomy, or term page for each language. See&nbsp;[details](/configuration/cascade/).
->
-> If you choose to define cascade values in front matter for a multilingual project, you must create a corresponding home, section, taxonomy, or term page for every language.
 
 ## Emacs Org Mode
 
-If your [content format] is [Emacs Org Mode], you may provide front matter using Org Mode keywords. For example:
+If your [content format][] is [Emacs Org Mode][], you may provide front matter using Org Mode keywords. For example:
 
 ```text {file="content/example.org"}
 #+TITLE: Example
@@ -319,9 +292,6 @@ Note that you can also specify array elements on a single line:
 #+TAGS[]: red blue
 ```
 
-[content format]: /content-management/formats/
-[emacs org mode]: https://orgmode.org/
-
 ## Dates
 
 When populating a date field, whether a [custom page parameter](#parameters) or one of the four predefined fields ([`date`](#date), [`expiryDate`](#expirydate), [`lastmod`](#lastmod), [`publishDate`](#publishdate)), use one of these parsable formats:
@@ -334,6 +304,13 @@ To override the default time zone, set the [`timeZone`](/configuration/all/#time
 1. The time zone specified in your project configuration
 1. The `Etc/UTC` time zone
 
+[^1]: The `_target` alias for `target` is deprecated and will be removed in a future release.
+
+[URL management]: /content-management/urls/#slug
+[`GetTerms`]: /methods/page/getterms/
+[`Param`]: /methods/page/param/
+[`Params`]: /methods/page/params/
+[`Summary`]: /methods/page/summary/
 [`aliases`]: /methods/page/aliases/
 [`date`]: /methods/page/date/
 [`description`]: /methods/page/description/
@@ -345,14 +322,11 @@ To override the default time zone, set the [`timeZone`](/configuration/all/#time
 [`layout`]: /methods/page/layout/
 [`linktitle`]: /methods/page/linktitle/
 [`opengraph.html`]: <{{% eturl opengraph %}}>
-[`Param`]: /methods/page/param/
-[`Params`]: /methods/page/params/
 [`publishdate`]: /methods/page/publishdate/
 [`readingtime`]: /methods/page/readingtime/
 [`schema.html`]: <{{% eturl schema %}}>
 [`sitemap`]: /methods/page/sitemap/
 [`slug`]: /methods/page/slug/
-[`Summary`]: /methods/page/summary/
 [`title`]: /methods/page/title/
 [`translationkey`]: /methods/page/translationkey/
 [`twitter_cards.html`]: <{{% eturl twitter_cards %}}>
@@ -363,7 +337,9 @@ To override the default time zone, set the [`timeZone`](/configuration/all/#time
 [build options]: /content-management/build-options/
 [cascade]: #cascade-1
 [configure outputs]: /configuration/outputs/#outputs-per-page
+[content format]: /content-management/formats/
 [content formats]: /content-management/formats/#classification
+[emacs org mode]: https://orgmode.org/
 [embedded templates]: /templates/embedded/
 [json]: https://www.json.org/
 [leaf bundles]: /content-management/page-bundles/#leaf-bundles
@@ -375,5 +351,4 @@ To override the default time zone, set the [`timeZone`](/configuration/all/#time
 [target a specific template]: /templates/lookup-order/#target-a-template
 [template lookup order]: /templates/lookup-order/
 [toml]: https://toml.io/
-[URL management]: /content-management/urls/#slug
 [yaml]: https://yaml.org/

--- a/content/en/quick-reference/glossary/page-matcher.md
+++ b/content/en/quick-reference/glossary/page-matcher.md
@@ -1,0 +1,8 @@
+---
+title: page matcher
+---
+
+A _page matcher_ is a set of criteria used to filter pages by [_logical path_](g), [_page kind_](g), [_environment_](g), or [_site_](g). For example, use page matchers when configuring [cascade][] and [permalink][] targets.
+
+  [cascade]: /configuration/cascade/
+  [permalink]: /configuration/permalinks/


### PR DESCRIPTION
Closes #3435

Prerequisite for properly documenting configuration of permalink via arrays. 

<https://deploy-preview-3493--gohugoio.netlify.app/configuration/cascade/#target>
<https://deploy-preview-3493--gohugoio.netlify.app/content-management/front-matter/#target>
<https://deploy-preview-3493--gohugoio.netlify.app/quick-reference/glossary/#page-matcher>