### PR TITLE
docs(install/windows): split the Bash command into PowerShell and Command Prompt blocks

### DIFF
--- a/content/en/installation/windows.md
+++ b/content/en/installation/windows.md
@@ -47,7 +47,85 @@ To uninstall the extended edition of Hugo:
 winget uninstall --name "Hugo (Extended)"
 ```
 
-{{% include "/_common/installation/04-build-from-source.md" %}}
+## Build from source
+
+To build Hugo from source you must install:
+
+1. [Git]
+1. [Go] version 1.25.0 or later
+
+> [!note]
+> The Bash-style `KEY=VALUE cmd` syntax used in the macOS and Linux build-from-source instructions does not work in PowerShell or Command Prompt. Use the code block matching your shell.
+
+### Standard edition
+
+To build and install the standard edition:
+
+PowerShell:
+
+```powershell
+$env:CGO_ENABLED=0; go install github.com/gohugoio/hugo@latest
+```
+
+Command Prompt:
+
+```bat
+set CGO_ENABLED=0
+go install github.com/gohugoio/hugo@latest
+```
+
+### Deploy edition
+
+{{< new-in v0.159.2 />}}
+
+To build and install the deploy edition:
+
+PowerShell:
+
+```powershell
+$env:CGO_ENABLED=0; go install -tags withdeploy github.com/gohugoio/hugo@latest
+```
+
+Command Prompt:
+
+```bat
+set CGO_ENABLED=0
+go install -tags withdeploy github.com/gohugoio/hugo@latest
+```
+
+### Extended edition
+
+To build and install the extended edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
+
+PowerShell:
+
+```powershell
+$env:CGO_ENABLED=1; go install -tags extended github.com/gohugoio/hugo@latest
+```
+
+Command Prompt:
+
+```bat
+set CGO_ENABLED=1
+go install -tags extended github.com/gohugoio/hugo@latest
+```
+
+### Extended/deploy edition
+
+To build and install the extended/deploy edition, first install a C compiler such as [GCC] or [Clang] and then run the following command:
+
+PowerShell:
+
+```powershell
+$env:CGO_ENABLED=1; go install -tags extended,withdeploy github.com/gohugoio/hugo@latest
+```
+
+Command Prompt:
+
+```bat
+set CGO_ENABLED=1
+go install -tags extended,withdeploy github.com/gohugoio/hugo@latest
+```
 
 > [!note]
 > See these [detailed instructions](https://discourse.gohugo.io/t/41370) to install GCC on Windows.
@@ -66,5 +144,9 @@ Latest version available?|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mar
 [^2]: Easy if a previous version is still installed.
 
 [Chocolatey]: https://chocolatey.org/
+[Clang]: https://clang.llvm.org/
+[GCC]: https://gcc.gnu.org/
+[Git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+[Go]: https://go.dev/doc/install
 [Scoop]: https://scoop.sh/
 [Winget]: https://learn.microsoft.com/en-us/windows/package-manager/


### PR DESCRIPTION
Closes #3481

## What

The Windows installation page shows a single Bash command for
`go install`, which fails in PowerShell and Command Prompt because
neither shell understands the `KEY=VALUE cmd` env-prefix syntax. This
PR splits it into two annotated code blocks (one PowerShell, one CMD)
with a one-line preamble pointing readers to the right one.

Because the `Build from source` section is currently sourced from a
shell-agnostic shared include (`_common/installation/04-build-from-source.md`)
used by macOS, Linux, BSD, and Windows, this PR inlines a Windows-specific
version of that section on `content/en/installation/windows.md` only.
The macOS, Linux, and BSD pages are untouched. All four editions
(standard, deploy, extended, extended/deploy) get matching PowerShell
and Command Prompt blocks; the install command and module path are
unchanged.

## Why

Most Windows users running these commands are in PowerShell or CMD,
not WSL/git-bash; the current command silently fails for them.

## Verification

- `hugo --renderToMemory` builds cleanly (859 pages, 0 errors) against
  the changes.
- `markdownlint-cli2` and `cspell` (the two repo lint workflows) both
  pass on the edited file.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by
a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** for review. Happy to iterate.

Made with [Cursor](https://cursor.com)