### PR TITLE
content: Document that the language code in a file name must be lowercase

### DIFF
--- a/content/en/content-management/multilingual.md
+++ b/content/en/content-management/multilingual.md
@@ -30,6 +30,9 @@ Their language is assigned according to the language code added as a suffix to t
 By having the same path and base file name, the content pieces are linked together as translated pages.
 
 > [!note]
+> The language code in a file name must be lowercase. For example, use `about.en-us.md` instead of `about.en-US.md`.
+
+> [!note]
 > If a file has no language code, it will be assigned the default language.
 
 ### Translation by content directory


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

Closes #3308.

## What changed

Added a one-line `[!note]` admonition under **Translation by file name**
in `content/en/content-management/multilingual.md`:

> The language code in a file name must be lowercase. For example, use
> `about.en-us.md` instead of `about.en-US.md`.

## Why

Issue #3308 reports that this requirement is undocumented. The wording
matches @jmooring's guidance on the upstream bug report
[gohugoio/hugo#12829](https://github.com/gohugoio/hugo/issues/12829#issuecomment-2363019028):
> "use a lowercase language identifier when naming your content files.
> For example, use `index.en-us.md` instead of `index.en-US.md`."

The new note is placed next to the existing default-language `[!note]`
so readers naming their first translated file see it immediately.

## How verified

- Inspected the diff: +3 lines, no other changes.
- Pure Markdown content edit (no template/shortcode involvement); skipped
  `hugo --renderToMemory` since the existing admonition syntax used in the
  same file confirms `[!note]` is rendered as expected.

Happy for a maintainer to reword if the phrasing is off.
