### PR TITLE
content: Document the src attribute in the Page Resources metadata reference

### DIFF
--- a/content/en/content-management/page-resources.md
+++ b/content/en/content-management/page-resources.md
@@ -111,6 +111,9 @@ The page resources' metadata is managed from the corresponding page's front matt
 > [!note]
 > Resources of type `page` get `Title` etc. from their own front matter.
 
+src
+: (`string`) A [glob pattern](g) that matches one or more page resources by file path, relative to the page bundle. Required. When the pattern matches multiple resources, the same metadata is applied to each.
+
 name
 : (`string`) Sets the value returned in `Name`.
 


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

Closes #3296.

## What changed

Added a `src` definition to the metadata description list in
`content/en/content-management/page-resources.md`, immediately above the
existing `name` definition:

```
src
: (`string`) A glob pattern that matches one or more page resources by
  file path, relative to the page bundle. Required. When the pattern
  matches multiple resources, the same metadata is applied to each.
```

## Why

Issue #3296 reports that the **Metadata** table on the Page Resources
page lists `name`, `title`, and `params`, but never explicitly documents
`src` — even though every example in the same section uses it and the
later note (about ordering of metadata rules) refers to it as if it
were already defined.

Adding the entry makes the reference self-contained and matches the
shape of the surrounding description list.

## How verified

- Inspected the diff: +3 lines, no other changes.
- Pure Markdown content edit (no template/shortcode involvement);
  skipped `hugo --renderToMemory` since the existing description-list
  entries on the same page already use the same `term : (`type`)
  description` pattern.

Wording happy to be tightened by a maintainer if "Required" / "glob
pattern" doesn't match house style.
