### PR TITLE
theme: Darken inline code elements in content for better readability

### DIFF
--- a/assets/css/components/content.css
+++ b/assets/css/components/content.css
@@ -27,7 +27,7 @@
   /* pre */
   @apply prose-pre:text-gray-800 prose-pre:border-1 prose-pre:border-gray-100 prose-pre:bg-light dark:prose-pre:bg-dark dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10;
   /* code */
-  @apply prose-code:px-0.5 prose-code:text-gray-500 prose-code:dark:text-gray-300 border-none;
+  @apply prose-code:px-0.5 prose-code:text-gray-600 prose-code:dark:text-gray-300 border-none;
   @apply prose-code:before:hidden prose-code:after:hidden prose-code:font-mono;
   @apply prose-table:prose-th:prose-code:text-white;
   /* tables */


### PR DESCRIPTION
This subtle change was driven by https://github.com/gohugoio/hugoDocs/pull/3523.

#### Before

<img width="666" height="309" alt="prose-code-text-gray-500" src="https://github.com/user-attachments/assets/cc5f168a-fce1-4320-84e4-1727948cc696" />


#### After

<img width="659" height="308" alt="prose-code-text-gray-600" src="https://github.com/user-attachments/assets/af22b522-4dc2-4fa1-89be-e756a133d2b7" />

<https://deploy-preview-3525--gohugoio.netlify.app/content-management/front-matter/#description>

#### Accessibility

This change also improves the contrast ratio:

| | Hex | Contrast ratio | WCAG AA (4.5:1) | WCAG AAA (7:1) |
|---|---|---|---|---|
| Before (`gray-500`) | `#6b7280` | ~4.6:1 | Pass (barely) | Fail |
| After (`gray-600`) | `#4b5563` | ~7.6:1 | Pass | Pass |