### PR TITLE
Remove Commento from comments integration list

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -53,7 +53,6 @@ Open-source commenting systems:
 - [Cactus Comments](https://cactus.chat/docs/integrations/hugo/)
 - [Comentario](https://gitlab.com/comentario/comentario/)
 - [Comma](https://github.com/Dieterbe/comma/)
-- [Commento](https://commento.io/)
 - [Discourse](https://meta.discourse.org/t/embed-discourse-comments-on-another-website-via-javascript/31963)
 - [Giscus](https://giscus.app/)
 - [Isso](https://isso-comments.de/)


### PR DESCRIPTION
Remove Commento from the list of comment integrations. Commento seems to be abandoned (https://forum.cloudron.io/topic/11231/what-ever-happened-to-commento-looking-for-disqus-alternative/2), and the website seems to be offline.