### PR TITLE
docs(showcase): fix broken Hartwell blog link

### DIFF
--- a/content/en/showcase/hartwell-insurance/index.md
+++ b/content/en/showcase/hartwell-insurance/index.md
@@ -60,4 +60,4 @@ This project was such a blast to develop, it's a real pleasure to put new techno
 
 ---
 
-_This was originally posted on [my website](http://www.trysmudford.com/perfomance-wins-with-hugo-and-netlify/)_
+_This was originally posted on [my website](https://www.trysmudford.com/blog/performance-wins-with-hugo-and-netlify/)_


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Broken link: `http://www.trysmudford.com/perfomance-wins-with-hugo-and-netlify/` → `https://www.trysmudford.com/blog/performance-wins-with-hugo-and-netlify/` in `content/en/showcase/hartwell-insurance/index.md` (404; sitemap has `/blog/performance-wins-with-hugo-and-netlify/`).
