### PR TITLE
content: Replace h3 method sequences with description lists

### DIFF
--- a/content/en/_common/methods/media-type/core-methods.md
+++ b/content/en/_common/methods/media-type/core-methods.md
@@ -1,0 +1,14 @@
+`Type`
+: (`string`) Returns the media type.
+
+`MainType`
+: (`string`) Returns the main type of the media type.
+
+`SubType`
+: (`string`) Returns the subtype of the media type.
+
+`Suffixes`
+: (`slice`) Returns a slice of possible file suffixes for the media type.
+
+`FirstSuffix.Suffix`
+: (`string`) Returns the first of the possible file suffixes for the media type.

--- a/content/en/_common/store-methods.md
+++ b/content/en/_common/store-methods.md
@@ -4,83 +4,78 @@
 
 ## Methods
 
-### Set
+Use these methods on the scratch pad.
 
-Sets the value of the given key.
+`Set`
+: Sets the value of the given key.
 
-```go-html-template
-{{ .Store.Set "greeting" "Hello" }}
-```
-
-### Get
-
-Gets the value of the given key.
-
-```go-html-template
-{{ .Store.Set "greeting" "Hello" }}
-{{ .Store.Get "greeting" }} → Hello
-```
-
-### Add
-
-Adds the given value to the existing value(s) of the given key.
-
-For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
-
-```go-html-template
-{{ .Store.Set "greeting" "Hello" }}
-{{ .Store.Add "greeting" "Welcome" }}
-{{ .Store.Get "greeting" }} → HelloWelcome
-```
-
-```go-html-template
-{{ .Store.Set "total" 3 }}
-{{ .Store.Add "total" 7 }}
-{{ .Store.Get "total" }} → 10
-```
-
-```go-html-template
-{{ .Store.Set "greetings" (slice "Hello") }}
-{{ .Store.Add "greetings" (slice "Welcome" "Cheers") }}
-{{ .Store.Get "greetings" }} → [Hello Welcome Cheers]
-```
-
-### SetInMap
-
-Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
-
-```go-html-template
-{{ .Store.SetInMap "greetings" "english" "Hello" }}
-{{ .Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ .Store.Get "greetings" }} → map[english:Hello french:Bonjour]
+  ```go-html-template
+  {{ .Store.Set "greeting" "Hello" }}
   ```
 
-### DeleteInMap
+`Get`
+: (`any`) Gets the value of the given key.
 
-Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
+  ```go-html-template
+  {{ .Store.Set "greeting" "Hello" }}
+  {{ .Store.Get "greeting" }} → Hello
+  ```
 
-```go-html-template
-{{ .Store.SetInMap "greetings" "english" "Hello" }}
-{{ .Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ .Store.DeleteInMap "greetings" "english" }}
-{{ .Store.Get "greetings" }} → map[french:Bonjour]
-```
+`Add`
+: Adds the given value to the existing value(s) of the given key.
 
-### GetSortedMapValues
+  For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
 
-Returns an array of values from `key` sorted by `mapKey`.
+  ```go-html-template
+  {{ .Store.Set "greeting" "Hello" }}
+  {{ .Store.Add "greeting" "Welcome" }}
+  {{ .Store.Get "greeting" }} → HelloWelcome
+  ```
 
-```go-html-template
-{{ .Store.SetInMap "greetings" "english" "Hello" }}
-{{ .Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ .Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
-```
+  ```go-html-template
+  {{ .Store.Set "total" 3 }}
+  {{ .Store.Add "total" 7 }}
+  {{ .Store.Get "total" }} → 10
+  ```
 
-### Delete
+  ```go-html-template
+  {{ .Store.Set "greetings" (slice "Hello") }}
+  {{ .Store.Add "greetings" (slice "Welcome" "Cheers") }}
+  {{ .Store.Get "greetings" }} → [Hello Welcome Cheers]
+  ```
 
-Removes the given key.
+`SetInMap`
+: Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
 
-```go-html-template
-{{ .Store.Set "greeting" "Hello" }}
-{{ .Store.Delete "greeting" }}
-```
+  ```go-html-template
+  {{ .Store.SetInMap "greetings" "english" "Hello" }}
+  {{ .Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ .Store.Get "greetings" }} → map[english:Hello french:Bonjour]
+  ```
+
+`DeleteInMap`
+: Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
+
+  ```go-html-template
+  {{ .Store.SetInMap "greetings" "english" "Hello" }}
+  {{ .Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ .Store.DeleteInMap "greetings" "english" }}
+  {{ .Store.Get "greetings" }} → map[french:Bonjour]
+  ```
+
+`GetSortedMapValues`
+: (`[]any`) Returns an array of values from `key` sorted by `mapKey`.
+
+  ```go-html-template
+  {{ .Store.SetInMap "greetings" "english" "Hello" }}
+  {{ .Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ .Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
+  ```
+
+`Delete`
+: Removes the given key.
+
+  ```go-html-template
+  {{ .Store.Set "greeting" "Hello" }}
+  {{ .Store.Delete "greeting" }}
+  ```

--- a/content/en/content-management/content-adapters.md
+++ b/content/en/content-management/content-adapters.md
@@ -31,98 +31,91 @@ Each content adapter is named `_content.gotmpl` and uses the same [syntax] as te
 
 Use these methods within a content adapter.
 
-### AddPage
+`AddPage`
+: Adds a page to the site.
 
-Adds a page to the site.
-
-```go-html-template {file="content/books/_content.gotmpl"}
-{{ $content := dict
-  "mediaType" "text/markdown"
-  "value" "The _Hunchback of Notre Dame_ was written by Victor Hugo."
-}}
-{{ $page := dict
-  "content" $content
-  "kind" "page"
-  "path" "the-hunchback-of-notre-dame"
-  "title" "The Hunchback of Notre Dame"
-}}
-{{ .AddPage $page }}
-```
-
-### AddResource
-
-Adds a page resource to the site.
-
-```go-html-template {file="content/books/_content.gotmpl"}
-{{ with resources.Get "images/a.jpg" }}
+  ```go-html-template {file="content/books/_content.gotmpl"}
   {{ $content := dict
-    "mediaType" .MediaType.Type
-    "value" .
+    "mediaType" "text/markdown"
+    "value" "The _Hunchback of Notre Dame_ was written by Victor Hugo."
   }}
-  {{ $resource := dict
+  {{ $page := dict
     "content" $content
-    "path" "the-hunchback-of-notre-dame/cover.jpg"
+    "kind" "page"
+    "path" "the-hunchback-of-notre-dame"
+    "title" "The Hunchback of Notre Dame"
   }}
-  {{ $.AddResource $resource }}
-{{ end }}
-```
+  {{ .AddPage $page }}
+  ```
 
-Then retrieve the new page resource with something like:
+`AddResource`
+: Adds a page resource to the site.
 
-```go-html-template {file="layouts/page.html"}
-{{ with .Resources.Get "cover.jpg" }}
-  <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
-{{ end }}
-```
+  ```go-html-template {file="content/books/_content.gotmpl"}
+  {{ with resources.Get "images/a.jpg" }}
+    {{ $content := dict
+      "mediaType" .MediaType.Type
+      "value" .
+    }}
+    {{ $resource := dict
+      "content" $content
+      "path" "the-hunchback-of-notre-dame/cover.jpg"
+    }}
+    {{ $.AddResource $resource }}
+  {{ end }}
+  ```
 
-### Site
+  Then retrieve the new page resource with something like:
 
-Returns the `Site` to which the pages will be added.
+  ```go-html-template {file="layouts/page.html"}
+  {{ with .Resources.Get "cover.jpg" }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+  ```
 
-```go-html-template {file="content/books/_content.gotmpl"}
-{{ .Site.Title }}
-```
+`Site`
+: (`Site`) Returns the site to which the pages will be added.
 
-> [!note]
-> Note that the `Site` returned isn't fully built when invoked from the content adapters; if you try to call methods that depends on pages, e.g. `.Site.Pages`, you will get an error saying "this method cannot be called before the site is fully initialized".
+  ```go-html-template {file="content/books/_content.gotmpl"}
+  {{ .Site.Title }}
+  ```
 
-### Store
+  > [!note]
+  > The `Site` object is not fully initialized while Hugo executes a content adapter.
+  > Methods that depend on built pages, such as `Site.Pages`, are unavailable at this stage and return an error.
 
-Returns a persistent "scratch pad" to store and manipulate data. The main use case for this is to transfer values between executions when [EnableAllLanguages](#enablealllanguages) is set. See [examples](/methods/page/store/).
+`Store`
+: (`maps.Scratch`) Returns a persistent "scratch pad" to store and manipulate data. The main use case for this is to transfer values between executions when [EnableAllLanguages](#enablealllanguages) is set. See [examples](/methods/page/store/).
 
-```go-html-template {file="content/books/_content.gotmpl"}
-{{ .Store.Set "key" "value" }}
-{{ .Store.Get "key" }}
-```
+  ```go-html-template {file="content/books/_content.gotmpl"}
+  {{ .Store.Set "key" "value" }}
+  {{ .Store.Get "key" }}
+  ```
 
-### EnableAllLanguages
+`EnableAllLanguages`
+: By default, Hugo executes the content adapter only once for the first matching site in the [sites matrix](g). Use this method to expand execution to all languages while maintaining the current role and version.
 
-By default, Hugo executes the content adapter only once for the first matching site in the [sites matrix](g). Use this method to expand execution to all languages while maintaining the current role and version.
+  For more fine-grained control, define a `sites.matrix` in front matter or in a content mount.
 
-For more fine-grained control, define a `sites.matrix` in front matter or in a content mount.
+  ```go-html-template {file="content/books/_content.gotmpl"}
+  {{ .EnableAllLanguages }}
+  {{ $content := dict
+    "mediaType" "text/markdown"
+    "value" "The _Hunchback of Notre Dame_ was written by Victor Hugo."
+  }}
+  {{ $page := dict
+    "content" $content
+    "kind" "page"
+    "path" "the-hunchback-of-notre-dame"
+    "title" "The Hunchback of Notre Dame"
+  }}
+  {{ .AddPage $page }}
+  ```
 
-```go-html-template {file="content/books/_content.gotmpl"}
-{{ .EnableAllLanguages }}
-{{ $content := dict
-  "mediaType" "text/markdown"
-  "value" "The _Hunchback of Notre Dame_ was written by Victor Hugo."
-}}
-{{ $page := dict
-  "content" $content
-  "kind" "page"
-  "path" "the-hunchback-of-notre-dame"
-  "title" "The Hunchback of Notre Dame"
-}}
-{{ .AddPage $page }}
-```
+`EnableAllDimensions`
+: By default, Hugo executes the content adapter only once for the first matching site in the [sites matrix](g). Use this method to expand execution to every possible combination of language, version, and role.
 
-### EnableAllDimensions
-
-By default, Hugo executes the content adapter only once for the first matching site in the [sites matrix](g). Use this method to expand execution to every possible combination of language, version, and role.
-
-For more fine-grained control, define a `sites.matrix` in front matter or in a content mount.
-
-{{< new-in v0.153.0 />}}
+  For more fine-grained control, define a `sites.matrix` in front matter or in a content mount.
 
 ## Page map
 

--- a/content/en/functions/collections/NewScratch.md
+++ b/content/en/functions/collections/NewScratch.md
@@ -14,106 +14,100 @@ Use the `collections.NewScratch` function to create a locally scoped [scratch pa
 
 ## Methods
 
-### Set
+Use these methods on the scratch pad.
 
-Sets the value of the given key.
+`Set`
+: Sets the value of the given key.
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "greeting" "Hello" }}
-```
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "greeting" "Hello" }}
+  ```
 
-### Get
+`Get`
+: (`any`) Gets the value of the given key.
 
-Gets the value of the given key.
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "greeting" "Hello" }}
+  {{ $s.Get "greeting" }} → Hello
+  ```
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "greeting" "Hello" }}
-{{ $s.Get "greeting" }} → Hello
-```
+`Add`
+: Adds the given value to existing value(s) of the given key.
 
-### Add
+  For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
 
-Adds the given value to existing value(s) of the given key.
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "greeting" "Hello" }}
+  {{ $s.Add "greeting" "Welcome" }}
+  {{ $s.Get "greeting" }} → HelloWelcome
+  ```
 
-For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "total" 3 }}
+  {{ $s.Add "total" 7 }}
+  {{ $s.Get "total" }} → 10
+  ```
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "greeting" "Hello" }}
-{{ $s.Add "greeting" "Welcome" }}
-{{ $s.Get "greeting" }} → HelloWelcome
-```
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "greetings" (slice "Hello") }}
+  {{ $s.Add "greetings" (slice "Welcome" "Cheers") }}
+  {{ $s.Get "greetings" }} → [Hello Welcome Cheers]
+  ```
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "total" 3 }}
-{{ $s.Add "total" 7 }}
-{{ $s.Get "total" }} → 10
-```
+`SetInMap`
+: Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "greetings" (slice "Hello") }}
-{{ $s.Add "greetings" (slice "Welcome" "Cheers") }}
-{{ $s.Get "greetings" }} → [Hello Welcome Cheers]
-```
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.SetInMap "greetings" "english" "Hello" }}
+  {{ $s.SetInMap "greetings" "french" "Bonjour" }}
+  {{ $s.Get "greetings" }} → map[english:Hello french:Bonjour]
+  ```
 
-### SetInMap
+`DeleteInMap`
+: Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
 
-Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.SetInMap "greetings" "english" "Hello" }}
+  {{ $s.SetInMap "greetings" "french" "Bonjour" }}
+  {{ $s.DeleteInMap "greetings" "english" }}
+  {{ $s.Get "greetings" }} → map[french:Bonjour]
+  ```
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.SetInMap "greetings" "english" "Hello" }}
-{{ $s.SetInMap "greetings" "french" "Bonjour" }}
-{{ $s.Get "greetings" }} → map[english:Hello french:Bonjour]
-```
+`GetSortedMapValues`
+: (`[]any`) Returns an array of values from `key` sorted by `mapKey`.
 
-### DeleteInMap
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.SetInMap "greetings" "english" "Hello" }}
+  {{ $s.SetInMap "greetings" "french" "Bonjour" }}
+  {{ $s.GetSortedMapValues "greetings" }} → [Hello Bonjour]
+  ```
 
-Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
+`Delete`
+: Removes the given key.
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.SetInMap "greetings" "english" "Hello" }}
-{{ $s.SetInMap "greetings" "french" "Bonjour" }}
-{{ $s.DeleteInMap "greetings" "english" }}
-{{ $s.Get "greetings" }} → map[french:Bonjour]
-```
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.Set "greeting" "Hello" }}
+  {{ $s.Delete "greeting" }}
+  ```
 
-### GetSortedMapValues
+`Values`
+: (`map`) Returns the raw backing map. Do not use with `Store` methods on a `Page` object due to concurrency issues.
 
-Returns an array of values from `key` sorted by `mapKey`.
+  ```go-html-template
+  {{ $s := newScratch }}
+  {{ $s.SetInMap "greetings" "english" "Hello" }}
+  {{ $s.SetInMap "greetings" "french" "Bonjour" }}
 
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.SetInMap "greetings" "english" "Hello" }}
-{{ $s.SetInMap "greetings" "french" "Bonjour" }}
-{{ $s.GetSortedMapValues "greetings" }} → [Hello Bonjour]
-```
-
-### Delete
-
-Removes the given key.
-
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.Set "greeting" "Hello" }}
-{{ $s.Delete "greeting" }}
-```
-
-### Values
-
-Returns the raw backing map. Do not use with `Store` methods on a `Page` object due to concurrency issues.
-
-```go-html-template
-{{ $s := newScratch }}
-{{ $s.SetInMap "greetings" "english" "Hello" }}
-{{ $s.SetInMap "greetings" "french" "Bonjour" }}
-
-{{ $map := $s.Values }}
-```
+  {{ $map := $s.Values }}
+  ```
 
 {{% include "_common/scratch-pad-scope.md" %}}

--- a/content/en/functions/diagrams/Goat.md
+++ b/content/en/functions/diagrams/Goat.md
@@ -14,7 +14,7 @@ Useful in a [code block render hook], the `diagrams.Goat` function returns an SV
 
 ## Methods
 
-The SVGDiagram object has the following methods:
+Use these methods on the `SVGDiagram` object.
 
 `Inner`
 : (`template.HTML`) Returns the SVG child elements without a wrapping `svg` element, allowing you to create your own wrapper.

--- a/content/en/functions/go-template/try.md
+++ b/content/en/functions/go-template/try.md
@@ -16,15 +16,13 @@ The `try` statement is a non-standard extension to Go's [`text/template`][] pack
 
 ## Methods
 
-The `TryValue` object encapsulates the result of evaluating the expression, and provides two methods:
+Use these methods on the `TryValue` object.
 
-### Err
+`Err`
+: (`string`) Returns a string representation of the error thrown by the expression, if an error occurred, or returns `nil` if the expression evaluated without errors.
 
-(`string`) Returns a string representation of the error thrown by the expression, if an error occurred, or returns `nil` if the expression evaluated without errors.
-
-### Value
-
-(`any`) Returns the result of the expression if the evaluation was successful, or returns `nil` if an error occurred while evaluating the expression.
+`Value`
+: (`any`) Returns the result of the expression if the evaluation was successful, or returns `nil` if an error occurred while evaluating the expression.
 
 ## Explanation
 

--- a/content/en/functions/hugo/Deps.md
+++ b/content/en/functions/hugo/Deps.md
@@ -10,25 +10,31 @@ params:
     signatures: [hugo.Deps]
 ---
 
-The `hugo.Deps` function returns a slice of project dependencies, either Hugo Modules or local theme components. Each dependency contains:
+The `hugo.Deps` function returns a slice of project dependencies, either Hugo Modules or local theme components.
+
+## Methods
+
+Use these methods on each `hugo.Dependency` object returned by `hugo.Deps`.
 
 `Owner`
 : (`hugo.Dependency`) In the dependency tree, this is the first module that defines this module as a dependency (e.g., `github.com/gohugoio/hugo-mod-bootstrap-scss/v5`).
 
 `Path`
-: (`string`) The module path or the path below your `themes` directory (e.g., `github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2`).
+: (`string`) Returns the module path or the path below your `themes` directory (e.g., `github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2`).
 
 `Replace`
-: (`hugo.Dependency`) Replaced by this dependency.
+: (`hugo.Dependency`) Returns the dependency that replaces this dependency.
 
 `Time`
-: (`time.Time`) The time that the version was created (e.g., `2022-02-13 15:11:28 +0000 UTC`).
+: (`time.Time`) Returns the time that the version was created (e.g., `2022-02-13 15:11:28 +0000 UTC`).
 
 `Vendor`
 : (`bool`) Reports whether the dependency is vendored.
 
 `Version`
-: (`string`) The module version (e.g., `v2.21100.20000`).
+: (`string`) Returns the module version (e.g., `v2.21100.20000`).
+
+## Example
 
 An example table listing the dependencies:
 

--- a/content/en/functions/hugo/Store.md
+++ b/content/en/functions/hugo/Store.md
@@ -15,86 +15,81 @@ Use the `hugo.Store` function to create a globally scoped [scratch pad](g) to st
 
 ## Methods
 
-### Set
+Use these methods on the scratch pad.
 
-Sets the value of the given key.
+`Set`
+: Sets the value of the given key.
 
-```go-html-template
-{{ hugo.Store.Set "greeting" "Hello" }}
-```
-
-### Get
-
-Gets the value of the given key.
-
-```go-html-template
-{{ hugo.Store.Set "greeting" "Hello" }}
-{{ hugo.Store.Get "greeting" }} → Hello
-```
-
-### Add
-
-Adds the given value to the existing value(s) of the given key.
-
-For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
-
-```go-html-template
-{{ hugo.Store.Set "greeting" "Hello" }}
-{{ hugo.Store.Add "greeting" "Welcome" }}
-{{ hugo.Store.Get "greeting" }} → HelloWelcome
-```
-
-```go-html-template
-{{ hugo.Store.Set "total" 3 }}
-{{ hugo.Store.Add "total" 7 }}
-{{ hugo.Store.Get "total" }} → 10
-```
-
-```go-html-template
-{{ hugo.Store.Set "greetings" (slice "Hello") }}
-{{ hugo.Store.Add "greetings" (slice "Welcome" "Cheers") }}
-{{ hugo.Store.Get "greetings" }} → [Hello Welcome Cheers]
-```
-
-### SetInMap
-
-Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
-
-```go-html-template
-{{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
-{{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ hugo.Store.Get "greetings" }} → map[english:Hello french:Bonjour]
-```
-
-### DeleteInMap
-
-Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
-
-```go-html-template
-{{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
-{{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ hugo.Store.DeleteInMap "greetings" "english" }}
-{{ hugo.Store.Get "greetings" }} → map[french:Bonjour]
+  ```go-html-template
+  {{ hugo.Store.Set "greeting" "Hello" }}
   ```
 
-### GetSortedMapValues
+`Get`
+: (`any`) Gets the value of the given key.
 
-Returns an array of values from `key` sorted by `mapKey`.
+  ```go-html-template
+  {{ hugo.Store.Set "greeting" "Hello" }}
+  {{ hugo.Store.Get "greeting" }} → Hello
+  ```
 
-```go-html-template
-{{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
-{{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ hugo.Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
-```
+`Add`
+: Adds the given value to the existing value(s) of the given key.
 
-### Delete
+  For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
 
-Removes the given key.
+  ```go-html-template
+  {{ hugo.Store.Set "greeting" "Hello" }}
+  {{ hugo.Store.Add "greeting" "Welcome" }}
+  {{ hugo.Store.Get "greeting" }} → HelloWelcome
+  ```
 
-```go-html-template
-{{ hugo.Store.Set "greeting" "Hello" }}
-{{ hugo.Store.Delete "greeting" }}
-```
+  ```go-html-template
+  {{ hugo.Store.Set "total" 3 }}
+  {{ hugo.Store.Add "total" 7 }}
+  {{ hugo.Store.Get "total" }} → 10
+  ```
+
+  ```go-html-template
+  {{ hugo.Store.Set "greetings" (slice "Hello") }}
+  {{ hugo.Store.Add "greetings" (slice "Welcome" "Cheers") }}
+  {{ hugo.Store.Get "greetings" }} → [Hello Welcome Cheers]
+  ```
+
+`SetInMap`
+: Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
+
+  ```go-html-template
+  {{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ hugo.Store.Get "greetings" }} → map[english:Hello french:Bonjour]
+  ```
+
+`DeleteInMap`
+: Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
+
+  ```go-html-template
+  {{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ hugo.Store.DeleteInMap "greetings" "english" }}
+  {{ hugo.Store.Get "greetings" }} → map[french:Bonjour]
+  ```
+
+`GetSortedMapValues`
+: (`[]any`) Returns an array of values from `key` sorted by `mapKey`.
+
+  ```go-html-template
+  {{ hugo.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ hugo.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ hugo.Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
+  ```
+
+`Delete`
+: Removes the given key.
+
+  ```go-html-template
+  {{ hugo.Store.Set "greeting" "Hello" }}
+  {{ hugo.Store.Delete "greeting" }}
+  ```
 
 {{% include "_common/scratch-pad-scope.md" %}}
 

--- a/content/en/functions/templates/Current.md
+++ b/content/en/functions/templates/Current.md
@@ -19,6 +19,8 @@ The `templates.Current` function provides introspection capabilities, allowing y
 
 ## Methods
 
+Use these methods on the `CurrentTemplateInfo` object.
+
 `Ancestors`
 : (`tpl.CurrentTemplateInfos`) Returns a slice containing information about each template in the current execution chain, starting from the parent of the current template and going up towards the initial template called. It excludes any base template applied via `define` and `block`. You can chain the `Reverse` method to this result to get the slice in chronological execution order.
 

--- a/content/en/methods/output-format/MediaType.md
+++ b/content/en/methods/output-format/MediaType.md
@@ -11,26 +11,22 @@ params:
 
 {{% include "/_common/methods/output-formats/to-use-this-method.md" %}}
 
+## Example
+
 ```go-html-template
 {{ with .Site.Home.OutputFormats.Get "rss" }}
   {{ with .MediaType }}
-    {{ .Type }}       → application/rss+xml
-    {{ .MainType }}   → application
-    {{ .SubType }}    → rss
+    {{ .Type }} → application/rss+xml
+    {{ .MainType }} → application
+    {{ .SubType }} → rss
+    {{ .Suffixes }} → [rss]
+    {{ .FirstSuffix.Suffix }} → rss
   {{ end }}
 {{ end }}
 ```
 
 ## Methods
 
-### MainType
+Use these methods on the `MediaType` object.
 
-(`string`) Returns the main type of the output format's media type.
-
-### SubType
-
-(`string`) Returns the subtype of the current format's media type.
-
-### Type
-
-(`string`) Returns the current format's media type.
+{{% include "/_common/methods/media-type/core-methods.md" %}}

--- a/content/en/methods/page/File.md
+++ b/content/en/methods/page/File.md
@@ -26,118 +26,109 @@ content/
 
 ## Methods
 
+Use these methods on the `File` object.
+
 > [!note]
 > The path separators (slash or backslash) in `Path`, `Dir`, and `Filename` depend on the operating system.
 
-### BaseFileName
+`BaseFileName`
+: (`string`) The file name, excluding the extension.
 
-(`string`) The file name, excluding the extension.
+  ```go-html-template
+  {{ with .File }}
+    {{ .BaseFileName }}
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .File }}
-  {{ .BaseFileName }}
-{{ end }}
-```
+`ContentBaseName`
+: (`string`) If the page is a branch or leaf bundle, the name of the containing directory, else the `TranslationBaseName`.
 
-### ContentBaseName
+  ```go-html-template
+  {{ with .File }}
+    {{ .ContentBaseName }}
+  {{ end }}
+  ```
 
-(`string`) If the page is a branch or leaf bundle, the name of the containing directory, else the `TranslationBaseName`.
+`Dir`
+: (`string`) The file path, excluding the file name, relative to the `content` directory.
 
-```go-html-template
-{{ with .File }}
-  {{ .ContentBaseName }}
-{{ end }}
-```
+  ```go-html-template
+  {{ with .File }}
+    {{ .Dir }}
+  {{ end }}
+  ```
 
-### Dir
+`Ext`
+: (`string`) The file extension.
 
-(`string`) The file path, excluding the file name, relative to the `content` directory.
+  ```go-html-template
+  {{ with .File }}
+    {{ .Ext }}
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .File }}
-  {{ .Dir }}
-{{ end }}
-```
+`Filename`
+: (`string`) The absolute file path.
 
-### Ext
+  ```go-html-template
+  {{ with .File }}
+    {{ .Filename }}
+  {{ end }}
+  ```
 
-(`string`) The file extension.
+`IsContentAdapter`
+: (`bool`) Reports whether the file is a [content adapter].
 
-```go-html-template
-{{ with .File }}
-  {{ .Ext }}
-{{ end }}
-```
+  ```go-html-template
+  {{ with .File }}
+    {{ .IsContentAdapter }}
+  {{ end }}
+  ```
 
-### Filename
+`LogicalName`
+: (`string`) The file name.
 
-(`string`) The absolute file path.
+  ```go-html-template
+  {{ with .File }}
+    {{ .LogicalName }}
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .File }}
-  {{ .Filename }}
-{{ end }}
-```
+`Path`
+: (`string`) The file path, relative to the `content` directory.
 
-### IsContentAdapter
+  ```go-html-template
+  {{ with .File }}
+    {{ .Path }}
+  {{ end }}
+  ```
 
-(`bool`) Reports whether the file is a [content adapter].
+`Section`
+: (`string`) The name of the top-level section in which the file resides.
 
-```go-html-template
-{{ with .File }}
-  {{ .IsContentAdapter }}
-{{ end }}
-```
+  ```go-html-template
+  {{ with .File }}
+    {{ .Section }}
+  {{ end }}
+  ```
 
-### LogicalName
+`TranslationBaseName`
+: (`string`) The file name, excluding the extension and language identifier.
 
-(`string`) The file name.
+  ```go-html-template
+  {{ with .File }}
+    {{ .TranslationBaseName }}
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .File }}
-  {{ .LogicalName }}
-{{ end }}
-```
+`UniqueID`
+: (`string`) The MD5 hash of `.File.Path`.
 
-### Path
-
-(`string`) The file path, relative to the `content` directory.
-
-```go-html-template
-{{ with .File }}
-  {{ .Path }}
-{{ end }}
-```
-
-### Section
-
-(`string`) The name of the top-level section in which the file resides.
-
-```go-html-template
-{{ with .File }}
-  {{ .Section }}
-{{ end }}
-```
-
-### TranslationBaseName
-
-(`string`) The file name, excluding the extension and language identifier.
-
-```go-html-template
-{{ with .File }}
-  {{ .TranslationBaseName }}
-{{ end }}
-```
-
-### UniqueID
-
-(`string`) The MD5 hash of `.File.Path`.
-
-```go-html-template
-{{ with .File }}
-  {{ .UniqueID }}
-{{ end }}
-```
+  ```go-html-template
+  {{ with .File }}
+    {{ .UniqueID }}
+  {{ end }}
+  ```
 
 ## Examples
 

--- a/content/en/methods/page/Fragments.md
+++ b/content/en/methods/page/Fragments.md
@@ -19,82 +19,80 @@ In a URL, whether absolute or relative, the [fragment](g) links to an `id` attri
 
 Hugo assigns an `id` attribute to each Markdown [ATX] and [setext] heading within the page content. You can override the `id` with a [Markdown attribute](g) as needed. This creates the relationship between an entry in the [table of contents] (TOC) and a heading on the page.
 
-Use the `Fragments` method on a `Page` object to create a table of contents with the `Fragments.ToHTML` method, or by [walking](g) the `Fragments.Map` data structure.
+Use the `Fragments` method on a `Page` object to create a table of contents with the `Fragments.ToHTML` method, or by [walking](g) the `Fragments.Map` data structure. Use the methods below to inspect, validate, and render page fragments.
 
 ## Methods
 
-### Headings
+Use these methods on the `Fragments` object.
 
-(`slice`) A slice of maps of all headings on the page, with first-level keys for each heading. Each map contains the following keys: `ID`, `Level`, `Title` and `Headings`. To inspect the data structure:
+`Headings`
+: (`slice`) A slice of maps of all headings on the page, with first-level keys for each heading. Each map contains the following keys: `ID`, `Level`, `Title` and `Headings`. To inspect the data structure:
 
-```go-html-template
-<pre>{{ debug.Dump .Fragments.Headings }}</pre>
-```
+  ```go-html-template
+  <pre>{{ debug.Dump .Fragments.Headings }}</pre>
+  ```
 
-### HeadingsMap
+`HeadingsMap`
+: (`map`) A nested map of all headings on the page. Each map contains the following keys: `ID`, `Level`, `Title` and `Headings`. To inspect the data structure:
 
-(`map`) A nested map of all headings on the page. Each map contains the following keys: `ID`, `Level`, `Title` and `Headings`. To inspect the data structure:
+  ```go-html-template
+  <pre>{{ debug.Dump .Fragments.HeadingsMap }}</pre>
+  ```
 
-```go-html-template
-<pre>{{ debug.Dump .Fragments.HeadingsMap }}</pre>
-```
+`Identifiers`
+: (`slice`) A slice containing the `id` attribute of each heading on the page. If so configured, will also contain the `id` attribute of each description term (i.e., `dt` element) on the page.
 
-### Identifiers
+  See [configure Markup](/configuration/markup/#parserautodefinitiontermid).
 
-(`slice`) A slice containing the `id` attribute of each heading on the page. If so configured, will also contain the `id` attribute of each description term (i.e., `dt` element) on the page.
+  To inspect the data structure:
 
-See [configure Markup](/configuration/markup/#parserautodefinitiontermid).
+  ```go-html-template
+  <pre>{{ debug.Dump .Fragments.Identifiers }}</pre>
+  ```
 
-To inspect the data structure:
+`Identifiers.Contains ID`
+: (`bool`) Reports whether one or more headings on the page has the given `id` attribute, useful for validating fragments within a link [render hook](g).
 
-```go-html-template
-<pre>{{ debug.Dump .Fragments.Identifiers }}</pre>
-```
+  ```go-html-template
+  {{ .Fragments.Identifiers.Contains "section-2" }} → true
+  ```
 
-### Identifiers.Contains ID
+`Identifiers.Count ID`
+: (`int`) The number of headings on a page with the given `id` attribute, useful for detecting duplicates.
 
-(`bool`) Reports whether one or more headings on the page has the given `id` attribute, useful for validating fragments within a link [render hook](g).
+  ```go-html-template
+  {{ .Fragments.Identifiers.Count "section-2" }} → 1
+  ```
 
-```go-html-template
-{{ .Fragments.Identifiers.Contains "section-2" }} → true
-```
+`ToHTML`
+: (`template.HTML`) Returns a TOC as a nested list, either ordered or unordered, identical to the HTML returned by the [`TableOfContents`] method. This method take three arguments: the start level&nbsp;(`int`), the end level&nbsp;(`int`), and a boolean (`true` to return an ordered list, `false` to return an unordered list).
 
-### Identifiers.Count ID
+  Use this method when you want to control the start level, end level, or list type independently from the table of contents settings in your project configuration.
 
-(`int`) The number of headings on a page with the given `id` attribute, useful for detecting duplicates.
+  ```go-html-template
+  {{ $startLevel := 2 }}
+  {{ $endLevel := 3 }}
+  {{ $ordered := true }}
+  {{ .Fragments.ToHTML $startLevel $endLevel $ordered }}
+  ```
 
-```go-html-template
-{{ .Fragments.Identifiers.Count "section-2" }} → 1
-```
+  Hugo renders this to:
 
-### ToHTML
+  ```html
+  <nav id="TableOfContents">
+    <ol>
+      <li><a href="#section-1">Section 1</a>
+        <ol>
+          <li><a href="#section-11">Section 1.1</a></li>
+          <li><a href="#section-12">Section 1.2</a></li>
+        </ol>
+      </li>
+      <li><a href="#section-2">Section 2</a></li>
+    </ol>
+  </nav>
+  ```
 
-(`template.HTML`) Returns a TOC as a nested list, either ordered or unordered, identical to the HTML returned by the [`TableOfContents`] method. This method take three arguments: the start level&nbsp;(`int`), the end level&nbsp;(`int`), and a boolean (`true` to return an ordered list, `false` to return an unordered list).
-
-Use this method when you want to control the start level, end level, or list type independently from the table of contents settings in your project configuration.
-
-```go-html-template
-{{ $startLevel := 2 }}
-{{ $endLevel := 3 }}
-{{ $ordered := true }}
-{{ .Fragments.ToHTML $startLevel $endLevel $ordered }}
-```
-
-Hugo renders this to:
-
-```html
-<nav id="TableOfContents">
-  <ol>
-    <li><a href="#section-1">Section 1</a>
-      <ol>
-        <li><a href="#section-11">Section 1.1</a></li>
-        <li><a href="#section-12">Section 1.2</a></li>
-      </ol>
-    </li>
-    <li><a href="#section-2">Section 2</a></li>
-  </ol>
-</nav>
-```
+## Notes
 
 > [!note]
 > It is safe to use the `Fragments` methods within a render hook, even for the current page.

--- a/content/en/methods/page/GitInfo.md
+++ b/content/en/methods/page/GitInfo.md
@@ -45,113 +45,105 @@ Hugo also retrieves commit metadata for content provided by modules. This allows
 
 ## Methods
 
-### AbbreviatedHash
+Use these methods on the `GitInfo` object.
 
-(`string`) Returns the seven-character shortened version of the commit hash.
+`AbbreviatedHash`
+: (`string`) Returns the seven-character shortened version of the commit hash.
 
-```go-html-template
-{{ with .GitInfo }}
-  {{ .AbbreviatedHash }} → aab9ec0
-{{ end }}
-```
-
-### AuthorDate
-
-(`time.Time`) Returns the date the author originally created the commit.
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .AuthorDate.Format "2006-01-02" }} → 2023-10-09
-{{ end }}
-```
-
-### AuthorEmail
-
-(`string`) Returns the author's email address, respecting [gitmailmap][].
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .AuthorEmail }} → jsmith@example.org
-{{ end }}
-```
-
-### AuthorName
-
-(`string`) Returns the author's name, respecting [gitmailmap][].
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .AuthorName }} → John Smith
-{{ end }}
-```
-
-### CommitDate
-
-(`time.Time`) Returns the date the commit was applied to the branch.
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .CommitDate.Format "2006-01-02" }} → 2023-10-09
-{{ end }}
-```
-
-### Hash
-
-(`string`) Returns the full SHA-1 commit hash.
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .Hash }} → aab9ec0b31ebac916a1468c4c9c305f2bebf78d4
-{{ end }}
-```
-
-### Subject
-
-(`string`) Returns the first line of the commit message (the summary).
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .Subject }} → Add tutorials
-{{ end }}
-```
-
-### Body
-
-(`string`) Returns the full content of the commit message, excluding the subject line.
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ .Body }} → Two new pages added.
-{{ end }}
-```
-
-### Ancestors
-
-(`gitmap.GitInfos`) Returns a list of previous commits for this specific file, ordered from most recent to oldest.
-
-For example, to list the last 5 commits:
-
-```go-html-template
-{{ with .GitInfo }}
-  {{ range .Ancestors | first 5 }} 
-    {{ .CommitDate.Format "2006-01-02" }}: {{ .Subject }}
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .AbbreviatedHash }} → aab9ec0
   {{ end }}
-{{ end }}
-```
+  ```
 
-To reverse the order:
+`AuthorDate`
+: (`time.Time`) Returns the date the author originally created the commit.
 
-```go-html-template
-{{ with .GitInfo }}
-  {{ range .Ancestors.Reverse | first 5 }} 
-    {{ .CommitDate.Format "2006-01-02" }}: {{ .Subject }}
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .AuthorDate.Format "2006-01-02" }} → 2023-10-09
   {{ end }}
-{{ end }}
-```
+  ```
 
-### Parent
+`AuthorEmail`
+: (`string`) Returns the author's email address, respecting [gitmailmap][].
 
-(`*gitmap.GitInfo`) Returns the most recent ancestor commit for the file, if any.
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .AuthorEmail }} → jsmith@example.org
+  {{ end }}
+  ```
+
+`AuthorName`
+: (`string`) Returns the author's name, respecting [gitmailmap][].
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .AuthorName }} → John Smith
+  {{ end }}
+  ```
+
+`CommitDate`
+: (`time.Time`) Returns the date the commit was applied to the branch.
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .CommitDate.Format "2006-01-02" }} → 2023-10-09
+  {{ end }}
+  ```
+
+`Hash`
+: (`string`) Returns the full SHA-1 commit hash.
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .Hash }} → aab9ec0b31ebac916a1468c4c9c305f2bebf78d4
+  {{ end }}
+  ```
+
+`Subject`
+: (`string`) Returns the first line of the commit message (the summary).
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .Subject }} → Add tutorials
+  {{ end }}
+  ```
+
+`Body`
+: (`string`) Returns the full content of the commit message, excluding the subject line.
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ .Body }} → Two new pages added.
+  {{ end }}
+  ```
+
+`Ancestors`
+: (`gitmap.GitInfos`) Returns a list of previous commits for this specific file, ordered from most recent to oldest.
+
+  For example, to list the last 5 commits:
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ range .Ancestors | first 5 }} 
+      {{ .CommitDate.Format "2006-01-02" }}: {{ .Subject }}
+    {{ end }}
+  {{ end }}
+  ```
+
+  To reverse the order:
+
+  ```go-html-template
+  {{ with .GitInfo }}
+    {{ range .Ancestors.Reverse | first 5 }} 
+      {{ .CommitDate.Format "2006-01-02" }}: {{ .Subject }}
+    {{ end }}
+  {{ end }}
+  ```
+
+`Parent`
+: (`*gitmap.GitInfo`) Returns the most recent ancestor commit for the file, if any.
 
 ## Last modified date
 

--- a/content/en/methods/page/Language.md
+++ b/content/en/methods/page/Language.md
@@ -15,6 +15,8 @@ You can also use the `Language` method on a `Site` object. See&nbsp;[details][].
 
 ## Methods
 
+Use these methods on the `Language` object.
+
 The examples below assume the following language definition.
 
 {{< code-toggle file=hugo >}}
@@ -25,83 +27,64 @@ locale = 'de-DE'
 weight = 2
 {{< /code-toggle >}}
 
-### Direction
+`Direction`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`direction`][] from the language definition.
 
-{{< new-in 0.158.0 />}}
+  ```go-html-template
+  {{ .Language.Direction }} → ltr
+  ```
 
-(`string`) Returns the [`direction`][] from the language definition.
+`IsDefault`
+: {{< new-in 0.153.0 />}}
+: (`bool`) Reports whether this is the [default language](g).
 
-```go-html-template
-{{ .Language.Direction }} → ltr
-```
+  ```go-html-template
+  {{ .Language.IsDefault }} → true
+  ```
 
-### IsDefault
+`Label`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`label`][] from the language definition.
 
-{{< new-in 0.153.0 />}}
+  ```go-html-template
+  {{ .Language.Label }} → Deutsch
+  ```
 
-(`bool`) Reports whether this is the [default language](g).
+`Lang`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Name`](#name) instead.
 
-```go-html-template
-{{ .Language.IsDefault }} → true
-```
+`LanguageCode`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Locale`](#locale) instead.
 
-### Label
-
-{{< new-in 0.158.0 />}}
-
-(`string`) Returns the [`label`][] from the language definition.
-
-```go-html-template
-{{ .Language.Label }} → Deutsch
-```
-
-### Lang
-
-{{<deprecated-in 0.158.0 />}}
-
-Use [`Name`](#name) instead.
-
-### LanguageCode
-
-{{<deprecated-in 0.158.0 />}}
-
-Use [`Locale`](#locale) instead.
-
-### LanguageDirection
-
-{{<deprecated-in 0.158.0 />}}
+`LanguageDirection`
+: {{<deprecated-in 0.158.0 />}}
 
 Use [`Direction`](#direction) instead.
+`LanguageName`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Label`](#label) instead.
 
-### LanguageName
+`Locale`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`locale`][] from the language definition, falling back to [`Name`](#name).
 
-{{<deprecated-in 0.158.0 />}}
+  ```go-html-template
+  {{ .Language.Locale }} → de-DE
+  ```
 
-Use [`Label`](#label) instead.
+`Name`
+: {{< new-in 0.153.0 />}}
+: (`string`) Returns the language tag as defined by [RFC 5646][]. This is the lowercased key from the language definition.
 
-### Locale
+  ```go-html-template
+  {{ .Language.Name }} → de
+  ```
 
-{{< new-in 0.158.0 />}}
-
-(`string`) Returns the [`locale`][] from the language definition, falling back to [`Name`](#name).
-
-```go-html-template
-{{ .Language.Locale }} → de-DE
-```
-
-### Name
-
-{{< new-in 0.153.0 />}}
-
-(`string`) Returns the language tag as defined by [RFC 5646][]. This is the lowercased key from the language definition.
-
-```go-html-template
-{{ .Language.Name }} → de
-```
-
-### Weight
-
-{{<deprecated-in 0.158.0 />}}
+`Weight`
+: {{<deprecated-in 0.158.0 />}}
 
 ## Example
 

--- a/content/en/methods/page/OutputFormats.md
+++ b/content/en/methods/page/OutputFormats.md
@@ -15,39 +15,38 @@ The `OutputFormats` method on a `Page` object returns a slice of `OutputFormat` 
 
 ## Methods
 
-### Canonical
+Use these methods on the `OutputFormats` object.
 
-{{< new-in "0.154.4" />}}
+`Canonical`
+: {{< new-in "0.154.4" />}}
+: (`page.OutputFormat`) Returns the [canonical output format](g) for the current page, if defined. Once you have captured the object, use any of its [associated methods][].
 
-(`page.OutputFormat`) Returns the [canonical output format](g) for the current page, if defined. Once you have captured the object, use any of its [associated methods][].
+  ```go-html-template
+  {{ with .Site.Home.OutputFormats.Canonical }}
+    {{ .MediaType.Type }} → text/html
+    {{ .MediaType.MainType }} → text
+    {{ .MediaType.SubType }} → html
+    {{ .Name }} → html
+    {{ .Permalink }} → https://example.org/
+    {{ .Rel }} → canonical
+    {{ .RelPermalink }} → /
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .Site.Home.OutputFormats.Canonical }}
-  {{ .MediaType.Type }} → text/html
-  {{ .MediaType.MainType }} → text
-  {{ .MediaType.SubType }} → html
-  {{ .Name }} → html
-  {{ .Permalink }} → https://example.org/
-  {{ .Rel }} → canonical
-  {{ .RelPermalink }} → /
-{{ end }}
-```
+`Get`
+: (`page.OutputFormat`) Returns the `OutputFormat` object with the given identifier. Once you have captured the object, use any of its [associated methods][].
 
-### Get
-
-(`page.OutputFormat`) Returns the `OutputFormat` object with the given identifier. Once you have captured the object, use any of its [associated methods][].
-
-```go-html-template
-{{ with .Site.Home.OutputFormats.Get "rss" }}
-  {{ .MediaType.Type }} → application/rss+xml
-  {{ .MediaType.MainType }} → application
-  {{ .MediaType.SubType }} → rss
-  {{ .Name }} → rss
-  {{ .Permalink }} → https://example.org/index.xml
-  {{ .Rel }} → alternate
-  {{ .RelPermalink }} → /index.xml
-{{ end }}
-```
+  ```go-html-template
+  {{ with .Site.Home.OutputFormats.Get "rss" }}
+    {{ .MediaType.Type }} → application/rss+xml
+    {{ .MediaType.MainType }} → application
+    {{ .MediaType.SubType }} → rss
+    {{ .Name }} → rss
+    {{ .Permalink }} → https://example.org/index.xml
+    {{ .Rel }} → alternate
+    {{ .RelPermalink }} → /index.xml
+  {{ end }}
+  ```
 
 ## Examples
 

--- a/content/en/methods/page/Resources.md
+++ b/content/en/methods/page/Resources.md
@@ -15,66 +15,62 @@ To work with global or remote resources, see the [`resources`] functions.
 
 ## Methods
 
-### ByType
+Use these methods on the `Resources` object.
 
-(`resource.Resources`) Returns a collection of page resources of the given [media type], or nil if none found. The media type is typically one of `image`, `text`, `audio`, `video`, or `application`.
+`ByType`
+: (`resource.Resources`) Returns a collection of page resources of the given [media type], or nil if none found. The media type is typically one of `image`, `text`, `audio`, `video`, or `application`.
 
-```go-html-template
-{{ range .Resources.ByType "image" }}
-  <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
-{{ end }}
-```
+  ```go-html-template
+  {{ range .Resources.ByType "image" }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+  ```
 
-When working with global resources instead of page resources, use the [`resources.ByType`] function.
+  When working with global resources instead of page resources, use the [`resources.ByType`] function.
 
-### Get
+`Get`
+: (`resource.Resource`) Returns a page resource from the given path, or nil if none found.
 
-(`resource.Resource`) Returns a page resource from the given path, or nil if none found.
+  ```go-html-template
+  {{ with .Resources.Get "images/a.jpg" }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+  ```
 
-```go-html-template
-{{ with .Resources.Get "images/a.jpg" }}
-  <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
-{{ end }}
-```
+  When working with global resources instead of page resources, use the [`resources.Get`] function.
 
-When working with global resources instead of page resources, use the [`resources.Get`] function.
+`GetMatch`
+: (`resource.Resource`) Returns the first page resource from paths matching the given [glob pattern](g), or nil if none found.
 
-### GetMatch
+  ```go-html-template
+  {{ with .Resources.GetMatch "images/*.jpg" }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+  ```
 
-(`resource.Resource`) Returns the first page resource from paths matching the given [glob pattern](g), or nil if none found.
+  When working with global resources instead of page resources, use the [`resources.GetMatch`] function.
 
-```go-html-template
-{{ with .Resources.GetMatch "images/*.jpg" }}
-  <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
-{{ end }}
-```
+`Match`
+: (`resource.Resources`) Returns a collection of page resources from paths matching the given [glob pattern](g), or nil if none found.
 
-When working with global resources instead of page resources, use the [`resources.GetMatch`] function.
+  ```go-html-template
+  {{ range .Resources.Match "images/*.jpg" }}
+    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
+  {{ end }}
+  ```
 
-### Match
+  When working with global resources instead of page resources, use the [`resources.Match`] function.
 
-(`resource.Resources`) Returns a collection of page resources from paths matching the given [glob pattern](g), or nil if none found.
+`Mount`
+: {{< new-in 0.140.0 />}}
+: (`ResourceGetter`) Mounts the given resources from the two arguments base (`string`) to the given target path (`string`) and returns an object that implements [Get](#get). Note that leading slashes in target marks an absolute path. Relative target paths allows you to mount resources relative to another set, e.g. a [Page bundle](/content-management/page-bundles/):
 
-```go-html-template
-{{ range .Resources.Match "images/*.jpg" }}
-  <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
-{{ end }}
-```
+  ```go-html-template
+  {{ $common := resources.Match "/js/headlessui/*.*" }}
+  {{ $importContext := (slice $.Page ($common.Mount "/js/headlessui" ".")) }}
+  ```
 
-When working with global resources instead of page resources, use the [`resources.Match`] function.
-
-### Mount
-
-{{< new-in 0.140.0 />}}
-
-(`ResourceGetter`) Mounts the given resources from the two arguments base (`string`) to the given target path (`string`) and returns an object that implements [Get](#get). Note that leading slashes in target marks an absolute path. Relative target paths allows you to mount resources relative to another set, e.g. a [Page bundle](/content-management/page-bundles/):
-
-```go-html-template
-{{ $common := resources.Match "/js/headlessui/*.*" }}
-{{ $importContext := (slice $.Page ($common.Mount "/js/headlessui" ".")) }}
-```
-
-This method is currently only useful in [js.Batch](/functions/js/batch/#import-context).
+  This method is currently only useful in [js.Batch](/functions/js/batch/#import-context).
 
 ## Pattern matching
 

--- a/content/en/methods/page/Sitemap.md
+++ b/content/en/methods/page/Sitemap.md
@@ -13,29 +13,28 @@ Access to the `Sitemap` method on a `Page` object is restricted to [sitemap temp
 
 ## Methods
 
-### ChangeFreq
+Use these methods on the `Sitemap` object.
 
-(`string`) How frequently a page is likely to change. Valid values are `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, and `never`. With the default value of `""` Hugo will omit this field from the sitemap. See&nbsp;[details](https://www.sitemaps.org/protocol.html#changefreqdef).
+`ChangeFreq`
+: (`string`) How frequently a page is likely to change. Valid values are `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, and `never`. With the default value of `""` Hugo will omit this field from the sitemap. See&nbsp;[details](https://www.sitemaps.org/protocol.html#changefreqdef).
 
-```go-html-template
-{{ .Sitemap.ChangeFreq }}
-```
+  ```go-html-template
+  {{ .Sitemap.ChangeFreq }}
+  ```
 
-### Disable
+`Disable`
+: (`bool`) Whether to disable page inclusion. Default is `false`. Set to `true` in front matter to exclude the page.
 
-(`bool`) Whether to disable page inclusion. Default is `false`. Set to `true` in front matter to exclude the page.
+  ```go-html-template
+  {{ .Sitemap.Disable }}
+  ```
 
-```go-html-template
-{{ .Sitemap.Disable }}
-```
+`Priority`
+: (`float`) The priority of a page relative to any other page on the site. Valid values range from 0.0 to 1.0. With the default value of `-1` Hugo will omit this field from the sitemap. See&nbsp;[details](https://www.sitemaps.org/protocol.html#prioritydef).
 
-### Priority
-
-(`float`) The priority of a page relative to any other page on the site. Valid values range from 0.0 to 1.0. With the default value of `-1` Hugo will omit this field from the sitemap. See&nbsp;[details](https://www.sitemaps.org/protocol.html#prioritydef).
-
-```go-html-template
-{{ .Sitemap.Priority }}
-```
+  ```go-html-template
+  {{ .Sitemap.Priority }}
+  ```
 
 ## Example
 

--- a/content/en/methods/resource/Colors.md
+++ b/content/en/methods/resource/Colors.md
@@ -24,13 +24,11 @@ This method is fast, but if you downscale your image first, you can further impr
 
 Each color in the slice is an object with the following methods:
 
-### ColorHex
+`ColorHex`
+: (`string`) Returns the [hexadecimal color][] value, prefixed with a hash sign.
 
-(`string`) Returns the [hexadecimal color][] value, prefixed with a hash sign.
-
-### Luminance
-
-(`float64`) Returns the [relative luminance][] of the color in the sRGB colorspace in the range [0, 1]. A value of `0` represents the darkest black, while a value of `1` represents the lightest white.
+`Luminance`
+: (`float64`) Returns the [relative luminance][] of the color in the sRGB colorspace in the range [0, 1]. A value of `0` represents the darkest black, while a value of `1` represents the lightest white.
 
 > [!note]
 > Image filters such as [`images.Dither`][], [`images.Padding`][], and [`images.Text`][] accept either hexadecimal color values or `images.Color` objects as arguments. Hugo renders an `images.Color` object as a hexadecimal color value.

--- a/content/en/methods/resource/Data.md
+++ b/content/en/methods/resource/Data.md
@@ -36,29 +36,25 @@ The `Data` method on a resource returned by the [`resources.GetRemote`] function
 
 ## Methods
 
-### ContentLength
+Use these methods on the `Data` object.
 
-(`int`) The content length in bytes.
+`ContentLength`
+: (`int`) The content length in bytes.
 
-### ContentType
+`ContentType`
+: (`string`) The content type.
 
-(`string`) The content type.
+`Headers`
+: (`map[string][]string`) A map of response headers matching those requested in the [`responseHeaders`] option passed to the `resources.GetRemote` function. The header name matching is case-insensitive. In most cases there will be one value per header key.
 
-### Headers
+`Status`
+: (`string`) The HTTP status text.
 
-(`map[string][]string`) A map of response headers matching those requested in the [`responseHeaders`] option passed to the `resources.GetRemote` function. The header name matching is case-insensitive. In most cases there will be one value per header key.
+`StatusCode`
+: (`int`) The HTTP status code.
 
-### Status
-
-(`string`) The HTTP status text.
-
-### StatusCode
-
-(`int`) The HTTP status code.
-
-### TransferEncoding
-
-(`string`) The transfer encoding.
+`TransferEncoding`
+: (`string`) The transfer encoding.
 
 [`resources.GetRemote`]: /functions/resources/getremote/
 [`responseHeaders`]: /functions/resources/getremote/#responseheaders

--- a/content/en/methods/resource/MediaType.md
+++ b/content/en/methods/resource/MediaType.md
@@ -11,56 +11,20 @@ params:
 
 {{% include "/_common/methods/resource/global-page-remote-resources.md" %}}
 
-The `MediaType` method on a `Resource` object returns an object with additional methods.
-
-## Methods
-
-### Type
-
-(`string`) The resource's media type.
+## Example
 
 ```go-html-template
 {{ with resources.Get "images/a.jpg" }}
   {{ .MediaType.Type }} → image/jpeg
-{{ end }}
-```
-
-### MainType
-
-(`string`) The main type of the resource's media type.
-
-```go-html-template
-{{ with resources.Get "images/a.jpg" }}
   {{ .MediaType.MainType }} → image
-{{ end }}
-```
-
-### SubType
-
-(`string`) The subtype of the resource's media type. This may or may not correspond to the file suffix.
-
-```go-html-template
-{{ with resources.Get "images/a.jpg" }}
   {{ .MediaType.SubType }} → jpeg
-{{ end }}
-```
-
-### Suffixes
-
-(`slice`) A slice of possible file suffixes for the resource's media type.
-
-```go-html-template
-{{ with resources.Get "images/a.jpg" }}
   {{ .MediaType.Suffixes }} → [jpg jpeg jpe jif jfif]
-{{ end }}
-```
-
-### FirstSuffix.Suffix
-
-(`string`) The first of the possible file suffixes for the resource's media type.
-
-```go-html-template
-{{ with resources.Get "images/a.jpg" }}
   {{ .MediaType.FirstSuffix.Suffix }} → jpg
 {{ end }}
 ```
+
+## Methods
+
+Use these methods on the `MediaType` object.
+
+{{% include "/_common/methods/media-type/core-methods.md" %}}

--- a/content/en/methods/resource/Meta.md
+++ b/content/en/methods/resource/Meta.md
@@ -36,48 +36,42 @@ Use the [`reflect.IsImageResourceWithMeta`][] function to verify that a resource
 
 ## Methods
 
-### Date
+Use these methods on the `Meta` object.
 
-(`time.Time`) Returns the image creation date/time. Format with the [`time.Format`][] function.
+`Date`
+: (`time.Time`) Returns the image creation date/time. Format with the [`time.Format`][] function.
 
-### Lat
+`Lat`
+: (`float64`) Returns the GPS latitude in degrees from Exif metadata, with a fallback to XMP metadata.
 
-(`float64`) Returns the GPS latitude in degrees from Exif metadata, with a fallback to XMP metadata.
+`Long`
+: (`float64`) Returns the GPS longitude in degrees from Exif metadata, with a fallback to XMP metadata.
 
-### Long
+`Orientation`
+: (`int`) Returns the value of the Exif `Orientation` tag, one of eight possible values.
 
-(`float64`) Returns the GPS longitude in degrees from Exif metadata, with a fallback to XMP metadata.
+  Value|Description
+  :--|:--
+  `1`|Horizontal (normal)
+  `2`|Mirrored horizontal
+  `3`|Rotated 180 degrees
+  `4`|Mirrored vertical
+  `5`|Mirrored horizontal and rotated 270 degrees clockwise
+  `6`|Rotated 90 degrees clockwise
+  `7`|Mirrored horizontal and rotated 90 degrees clockwise
+  `8`|Rotated 270 degrees clockwise
 
-### Orientation
+  > [!tip]
+  > Use the [`images.AutoOrient`][] image filter to rotate and flip an image as needed per its Exif orientation tag
 
-(`int`) Returns the value of the Exif `Orientation` tag, one of eight possible values.
+`Exif`
+: (`meta.Tags`) Returns a collection of available Exif fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
 
-Value|Description
-:--|:--
-`1`|Horizontal (normal)
-`2`|Mirrored horizontal
-`3`|Rotated 180 degrees
-`4`|Mirrored vertical
-`5`|Mirrored horizontal and rotated 270 degrees clockwise
-`6`|Rotated 90 degrees clockwise
-`7`|Mirrored horizontal and rotated 90 degrees clockwise
-`8`|Rotated 270 degrees clockwise
-{class="!mt-0"}
+`IPTC`
+: (`meta.Tags`) Returns a collection of available IPTC fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
 
-> [!tip]
-> Use the [`images.AutoOrient`][] image filter to rotate and flip an image as needed per its Exif orientation tag
-
-### Exif
-
-(`meta.Tags`) Returns a collection of available Exif fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
-
-### IPTC
-
-(`meta.Tags`) Returns a collection of available IPTC fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
-
-### XMP
-
-(`meta.Tags`) Returns a collection of available XMP fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
+`XMP`
+: (`meta.Tags`) Returns a collection of available XMP fields for this image. Availability is determined by the [`sources`][] setting and specific fields are managed via the [`fields`][] setting, both of which are managed in your project configuration.
 
 ## Examples
 

--- a/content/en/methods/site/Language.md
+++ b/content/en/methods/site/Language.md
@@ -15,6 +15,8 @@ You can also use the `Language` method on a `Page` object. See&nbsp;[details][].
 
 ## Methods
 
+Use these methods on the `Language` object.
+
 The examples below assume the following language definition.
 
 {{< code-toggle file=hugo >}}
@@ -25,83 +27,64 @@ locale = 'de-DE'
 weight = 2
 {{< /code-toggle >}}
 
-### Direction
+`Direction`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`direction`][] from the language definition.
 
-{{< new-in 0.158.0 />}}
+  ```go-html-template
+  {{ .Site.Language.Direction }} → ltr
+  ```
 
-(`string`) Returns the [`direction`][] from the language definition.
+`IsDefault`
+: {{< new-in 0.153.0 />}}
+: (`bool`) Reports whether this is the [default language](g).
 
-```go-html-template
-{{ .Site.Language.Direction }} → ltr
-```
+  ```go-html-template
+  {{ .Site.Language.IsDefault }} → true
+  ```
 
-### IsDefault
+`Label`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`label`][] from the language definition.
 
-{{< new-in 0.153.0 />}}
+  ```go-html-template
+  {{ .Site.Language.Label }} → Deutsch
+  ```
 
-(`bool`) Reports whether this is the [default language](g).
+`Lang`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Name`](#name) instead.
 
-```go-html-template
-{{ .Site.Language.IsDefault }} → true
-```
+`LanguageCode`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Locale`](#locale) instead.
 
-### Label
+`LanguageDirection`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Direction`](#direction) instead.
 
-{{< new-in 0.158.0 />}}
+`LanguageName`
+: {{<deprecated-in 0.158.0 />}}
+: Use [`Label`](#label) instead.
 
-(`string`) Returns the [`label`][] from the language definition.
+`Locale`
+: {{< new-in 0.158.0 />}}
+: (`string`) Returns the [`locale`][] from the language definition, falling back to [`Name`](#name).
 
-```go-html-template
-{{ .Site.Language.Label }} → Deutsch
-```
+  ```go-html-template
+  {{ .Site.Language.Locale }} → de-DE
+  ```
 
-### Lang
+`Name`
+: {{< new-in 0.153.0 />}}
+: (`string`) Returns the language tag as defined by [RFC 5646][]. This is the lowercased key from the language definition.
 
-{{<deprecated-in 0.158.0 />}}
+  ```go-html-template
+  {{ .Site.Language.Name }} → de
+  ```
 
-Use [`Name`](#name) instead.
-
-### LanguageCode
-
-{{<deprecated-in 0.158.0 />}}
-
-Use [`Locale`](#locale) instead.
-
-### LanguageDirection
-
-{{<deprecated-in 0.158.0 />}}
-
-Use [`Direction`](#direction) instead.
-
-### LanguageName
-
-{{<deprecated-in 0.158.0 />}}
-
-Use [`Label`](#label) instead.
-
-### Locale
-
-{{< new-in 0.158.0 />}}
-
-(`string`) Returns the [`locale`][] from the language definition, falling back to [`Name`](#name).
-
-```go-html-template
-{{ .Site.Language.Locale }} → de-DE
-```
-
-### Name
-
-{{< new-in 0.153.0 />}}
-
-(`string`) Returns the language tag as defined by [RFC 5646][]. This is the lowercased key from the language definition.
-
-```go-html-template
-{{ .Site.Language.Name }} → de
-```
-
-### Weight
-
-{{<deprecated-in 0.158.0 />}}
+`Weight`
+: {{<deprecated-in 0.158.0 />}}
 
 ## Example
 

--- a/content/en/methods/site/Role.md
+++ b/content/en/methods/site/Role.md
@@ -11,22 +11,24 @@ params:
 
 {{< new-in 0.153.0 />}}
 
+## Overview
+
 The `Role` method on a `Site` object returns the `Role` object for the given site, derived from the role definition in your project configuration.
 
 ## Methods
 
-### IsDefault
+Use these methods on the `Role` object.
 
-(`bool`) Reports whether this is the [default role](g).
+`IsDefault`
+: (`bool`) Reports whether this is the [default role](g).
 
-```go-html-template
-{{ .Site.Role.IsDefault }} → true
-```
+  ```go-html-template
+  {{ .Site.Role.IsDefault }} → true
+  ```
 
-### Name
+`Name`
+: (`string`) Returns the role name. This is the lowercased key from your project configuration.
 
-(`string`) Returns the role name. This is the lowercased key from your project configuration.
-
-```go-html-template
-{{ .Site.Role.Name }} → guest
-```
+  ```go-html-template
+  {{ .Site.Role.Name }} → guest
+  ```

--- a/content/en/methods/site/Store.md
+++ b/content/en/methods/site/Store.md
@@ -15,86 +15,81 @@ Use the `Store` method on a `Site` object to create a [scratch pad](g) to store 
 
 ## Methods
 
-### Set
+Use these methods on the scratch pad.
 
-Sets the value of a given key.
+`Set`
+: Sets the value of a given key.
 
-```go-html-template
-{{ site.Store.Set "greeting" "Hello" }}
-```
-
-### Get
-
-Gets the value of a given key.
-
-```go-html-template
-{{ site.Store.Set "greeting" "Hello" }}
-{{ site.Store.Get "greeting" }} → Hello
-```
-
-### Add
-
-Adds a given value to existing value(s) of the given key.
-
-For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
-
-```go-html-template
-{{ site.Store.Set "greeting" "Hello" }}
-{{ site.Store.Add "greeting" "Welcome" }}
-{{ site.Store.Get "greeting" }} → HelloWelcome
-```
-
-```go-html-template
-{{ site.Store.Set "total" 3 }}
-{{ site.Store.Add "total" 7 }}
-{{ site.Store.Get "total" }} → 10
-```
-
-```go-html-template
-{{ site.Store.Set "greetings" (slice "Hello") }}
-{{ site.Store.Add "greetings" (slice "Welcome" "Cheers") }}
-{{ site.Store.Get "greetings" }} → [Hello Welcome Cheers]
+  ```go-html-template
+  {{ site.Store.Set "greeting" "Hello" }}
   ```
 
-### SetInMap
+`Get`
+: (`any`) Gets the value of a given key.
 
-Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
+  ```go-html-template
+  {{ site.Store.Set "greeting" "Hello" }}
+  {{ site.Store.Get "greeting" }} → Hello
+  ```
 
-```go-html-template
-{{ site.Store.SetInMap "greetings" "english" "Hello" }}
-{{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ site.Store.Get "greetings" }} → map[english:Hello french:Bonjour]
-```
+`Add`
+: Adds a given value to existing value(s) of the given key.
 
-### DeleteInMap
+  For single values, `Add` accepts values that support Go's `+` operator. If the first `Add` for a key is an array or slice, the following adds will be appended to that list.
 
-Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
+  ```go-html-template
+  {{ site.Store.Set "greeting" "Hello" }}
+  {{ site.Store.Add "greeting" "Welcome" }}
+  {{ site.Store.Get "greeting" }} → HelloWelcome
+  ```
 
-```go-html-template
-{{ site.Store.SetInMap "greetings" "english" "Hello" }}
-{{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ site.Store.DeleteInMap "greetings" "english" }}
-{{ site.Store.Get "greetings" }} → map[french:Bonjour]
-```
+  ```go-html-template
+  {{ site.Store.Set "total" 3 }}
+  {{ site.Store.Add "total" 7 }}
+  {{ site.Store.Get "total" }} → 10
+  ```
 
-### GetSortedMapValues
+  ```go-html-template
+  {{ site.Store.Set "greetings" (slice "Hello") }}
+  {{ site.Store.Add "greetings" (slice "Welcome" "Cheers") }}
+  {{ site.Store.Get "greetings" }} → [Hello Welcome Cheers]
+  ```
 
-Returns an array of values from `key` sorted by `mapKey`.
+`SetInMap`
+: Takes a `key`, `mapKey` and `value` and adds a map of `mapKey` and `value` to the given `key`.
 
-```go-html-template
-{{ site.Store.SetInMap "greetings" "english" "Hello" }}
-{{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
-{{ site.Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
-```
+  ```go-html-template
+  {{ site.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ site.Store.Get "greetings" }} → map[english:Hello french:Bonjour]
+  ```
 
-### Delete
+`DeleteInMap`
+: Takes a `key` and `mapKey` and removes the map of `mapKey` from the given `key`.
 
-Removes the given key.
+  ```go-html-template
+  {{ site.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ site.Store.DeleteInMap "greetings" "english" }}
+  {{ site.Store.Get "greetings" }} → map[french:Bonjour]
+  ```
 
-```go-html-template
-{{ site.Store.Set "greeting" "Hello" }}
-{{ site.Store.Delete "greeting" }}
-```
+`GetSortedMapValues`
+: (`[]any`) Returns an array of values from `key` sorted by `mapKey`.
+
+  ```go-html-template
+  {{ site.Store.SetInMap "greetings" "english" "Hello" }}
+  {{ site.Store.SetInMap "greetings" "french" "Bonjour" }}
+  {{ site.Store.GetSortedMapValues "greetings" }} → [Hello Bonjour]
+  ```
+
+`Delete`
+: Removes the given key.
+
+  ```go-html-template
+  {{ site.Store.Set "greeting" "Hello" }}
+  {{ site.Store.Delete "greeting" }}
+  ```
 
 {{% include "_common/scratch-pad-scope.md" %}}
 

--- a/content/en/methods/site/Version.md
+++ b/content/en/methods/site/Version.md
@@ -11,22 +11,24 @@ params:
 
 {{< new-in 0.153.0 />}}
 
+## Overview
+
 The `Version` method on a `Site` object returns the `Version` object for the given site, derived from the version definition in your project configuration.
 
 ## Methods
 
-### IsDefault
+Use these methods on the `Version` object.
 
-(`bool`) Reports whether this is the [default version](g).
+`IsDefault`
+: (`bool`) Reports whether this is the [default version](g).
 
-```go-html-template
-{{ .Site.Version.IsDefault }} → true
-```
+  ```go-html-template
+  {{ .Site.Version.IsDefault }} → true
+  ```
 
-### Name
+`Name`
+: (`string`) Returns the version name. This is the lowercased key from your project configuration.
 
-(`string`) Returns the version name. This is the lowercased key from your project configuration.
-
-```go-html-template
-{{ .Site.Version.Name }} → v1.0.0
-```
+  ```go-html-template
+  {{ .Site.Version.Name }} → v1.0.0
+  ```

--- a/content/en/templates/shortcode.md
+++ b/content/en/templates/shortcode.md
@@ -70,7 +70,7 @@ foo|rss|en|`layouts/_shortcodes/foo.xml`
 
 ## Methods
 
-Use these methods in your _shortcode_ templates. Refer to each methods's documentation for details and examples.
+Use these methods in your _shortcode_ templates. Refer to each method's documentation for details and examples.
 
 {{% render-list-of-pages-in-section path=/methods/shortcode %}}
 


### PR DESCRIPTION
The `h3` construct was used prior to the implementation of `autoDefinitionTermID` in v0.144.0.