### PR TITLE
theme: Render function/method link titles as inline code

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -44,6 +44,12 @@ disableAliases = true
     searchable = false
   [cascade.target]
     kind = '{home,section,taxonomy,term}'
+[[cascade]]
+  [cascade.params]
+    isFunctionOrMethod = true
+  [cascade.target]
+    path = '{/functions/**,/methods/**}'
+    kind = 'page'
 
 [frontmatter]
   date        = ['date'] # do not add publishdate; it will affect page sorting

--- a/layouts/_shortcodes/quick-reference.html
+++ b/layouts/_shortcodes/quick-reference.html
@@ -24,7 +24,11 @@ immediate descendants.
 		{{ with .Pages }}
 			{{ range . }}
 				{{/* Use page Path as the link destination for render hook to resolve correctly. */}}
+				{{ if .Params.isFunctionOrMethod }}
+[`{{ .LinkTitle }}`]({{ .Path }}){{/* Do not indent. */}}
+				{{ else }}
 [{{ .LinkTitle }}]({{ .Path }}){{/* Do not indent. */}}
+				{{ end }}
 : {{ .Description }}{{/* Do not indent. */}}
 			{{ end }}
 		{{ end }}

--- a/layouts/_shortcodes/render-list-of-pages-in-section.html
+++ b/layouts/_shortcodes/render-list-of-pages-in-section.html
@@ -57,7 +57,11 @@ if any of the pages in the filter do not exist.
 						{{- $linkTitle = printf "%s%s" . $linkTitle }}
 					{{- end }}
 					{{- /* Use page Path as the link destination for render hook to resolve correctly. */}}
+					{{- if $page.Params.isFunctionOrMethod }}
+[`{{ $linkTitle }}`]({{ $page.Path }}){{/* Do not indent. */}}
+					{{- else }}
 [{{ $linkTitle }}]({{ $page.Path }}){{/* Do not indent. */}}
+					{{- end }}
 : {{ $page.Description }}{{/* Do not indent. */}}
 				{{ end }}
 			{{- end }}

--- a/layouts/_shortcodes/render-table-of-pages-in-section.html
+++ b/layouts/_shortcodes/render-table-of-pages-in-section.html
@@ -70,7 +70,11 @@ if any of the pages in the filter do not exist.
 						{{- $linkTitle = printf "%s%s" . $linkTitle }}
 					{{- end }}
 					{{- /* Use page Path as the link destination for render hook to resolve correctly. */}}
+					{{- if $page.Params.isFunctionOrMethod }}
 [`{{ $linkTitle }}`]({{ $page.Path }})|{{ $page.Description }}{{/* Do not indent. */}}
+					{{- else }}
+[{{ $linkTitle }}]({{ $page.Path }})|{{ $page.Description }}{{/* Do not indent. */}}
+					{{- end }}
 				{{- end }}
 			{{- end }}
 		{{- else }}


### PR DESCRIPTION
This cascades `params.isFunctionOrMethod = true` to pages describing functions and methods. If true, the shortcodes wrap the link title in backticks. This is consistent with recent changes in:

- https://github.com/gohugoio/hugoDocs/pull/3523
- https://github.com/gohugoio/hugoDocs/pull/3530

Affected files:

- layouts/_shortcodes/quick-reference.html
- layouts/_shortcodes/render-list-of-pages-in-section.html
- layouts/_shortcodes/render-table-of-pages-in-section.html