### PR TITLE
content: Add FastComments to the list of commenting systems

### DIFF
--- a/content/en/content-management/comments.md
+++ b/content/en/content-management/comments.md
@@ -43,6 +43,7 @@ Commercial commenting systems:
 
 - [Commentix](https://www.commentix.com/)
 - [Emote](https://emote.com/)
+- [FastComments](https://fastcomments.com/commenting-system-for-hugo) (dedicated Hugo plugin)
 - [Graph Comment](https://graphcomment.com/)
 - [Hyvor Talk](https://talk.hyvor.com/)
 - [IntenseDebate](https://intensedebate.com/)


### PR DESCRIPTION
Hello! I created a dedicated Hugo plugin for FastComments which we will maintain.

Adds FastComments to the Commercial commenting systems list on the Comments page, placed alphabetically.

FastComments is a commercial commenting and live-chat service with an official Hugo integration published as a theme component / Hugo Module (https://github.com/FastComments/fastcomments-hugo). The linked page is a live Hugo demo of the widgets that also links to the install guide.
