### PR TITLE
docs: clarify LiveReload for mounted global resources

### DIFF
--- a/content/en/render-hooks/images.md
+++ b/content/en/render-hooks/images.md
@@ -128,6 +128,8 @@ source = 'static'
 target = 'assets'
 {{< /code-toggle >}}
 
+When using `hugo server`, do not fingerprint CSS or JavaScript in development. To preserve LiveReload, conditionally fingerprint these resources only outside of development mode. See&nbsp;[`hugo.IsDevelopment`](/functions/hugo/isdevelopment/).
+
 Note that the embedded image render hook does not perform image processing. Its sole purpose is to resolve Markdown image destinations.
 
 {{% include "/_common/render-hooks/pageinner.md" %}}

--- a/content/en/render-hooks/links.md
+++ b/content/en/render-hooks/links.md
@@ -104,6 +104,8 @@ source = 'static'
 target = 'assets'
 {{< /code-toggle >}}
 
+When using `hugo server`, do not fingerprint CSS or JavaScript in development. To preserve LiveReload, conditionally fingerprint these resources only outside of development mode. See&nbsp;[`hugo.IsDevelopment`](/functions/hugo/isdevelopment/).
+
 {{% include "/_common/render-hooks/pageinner.md" %}}
 
 [`RenderShortcodes`]: /methods/page/rendershortcodes

--- a/content/en/shortcodes/figure.md
+++ b/content/en/shortcodes/figure.md
@@ -106,4 +106,6 @@ source = 'static'
 target = 'assets'
 {{< /code-toggle >}}
 
+When using `hugo server`, do not fingerprint CSS or JavaScript in development. To preserve LiveReload, conditionally fingerprint these resources only outside of development mode. See&nbsp;[`hugo.IsDevelopment`](/functions/hugo/isdevelopment/).
+
 [source code]: <{{% eturl figure %}}>


### PR DESCRIPTION
## Summary

- clarify the `static` to `assets` mount guidance in the figure and embedded render hook docs
- document that CSS and JavaScript should not be fingerprinted during `hugo server`
- point readers to `hugo.IsDevelopment` for the recommended development/production split

## Context

This updates the docs site guidance for mounted global resources so the recommended development setup matches current LiveReload behavior.

The issue reported in the `hugo` repository as gohugoio/hugo#7740 is one example of the confusion this can cause: mounting `static` to `assets` is valid, but fingerprinting CSS or JavaScript during development can interfere with `hugo server` refresh behavior. This PR documents the recommended pattern instead of changing runtime behavior.

## Validation

- ran `./check.sh` in the `hugo` repository
- built a local Hugo binary from the current `hugo` checkout with `go install`
- attempted a `hugo --panicOnWarning` build in `hugoDocs`; the build then required the repo's JavaScript dependencies, which are not installed in this environment

Closes gohugoio/hugo#7740