### PR TITLE
Add DeployHQ host-and-deploy page

### DIFF
--- a/content/en/host-and-deploy/host-on-deployhq.md
+++ b/content/en/host-and-deploy/host-on-deployhq.md
@@ -1,0 +1,80 @@
+---
+title: Host on DeployHQ
+description: Deploy your site to your own server with DeployHQ.
+categories: []
+keywords: []
+---
+
+[DeployHQ][] is a Git-based deployment automation service. It connects to your GitHub, GitLab, or Bitbucket repository, runs your build commands on its build agents, and transfers the resulting files to the destination of your choice — an SSH, SFTP, or FTP server, Amazon S3, Azure Blob Storage, or Rackspace Cloud Files.
+
+DeployHQ does not host your site. It builds your Hugo project and copies the contents of the `public/` directory to a server or bucket that you already control. Use it when you want push-to-deploy automation on top of a VPS, shared host, or object storage bucket.
+
+## Assumptions
+
+- Working familiarity with [Git][] for version control
+- Completion of the Hugo [Quick Start][]
+- A [DeployHQ account][signup] (a free tier is available)
+- A remote repository on GitHub, GitLab, or Bitbucket containing your Hugo project
+- A destination server reachable over SSH, SFTP, or FTP, or a supported cloud storage bucket
+- A Hugo website on your local machine that you are ready to publish
+
+## BaseURL
+
+Set the [`baseURL`][] in your site configuration to the public URL of the destination server, for example `https://www.example.org/`. DeployHQ does not rewrite URLs at deploy time.
+
+## Create a project
+
+Log in to DeployHQ and create a new project. Connect the project to the remote repository that contains your Hugo site and select the branch you want to deploy, typically `main`.
+
+## Configure a server
+
+Within the project, add a server. DeployHQ refers to each deployment destination as a server, whether it is a real host or a cloud storage bucket.
+
+- Choose the protocol that matches your destination: SSH/SFTP, FTP, Amazon S3, Azure Blob Storage, or Rackspace Cloud Files.
+- Enter the hostname, credentials or key, and the absolute path to your webroot, for example `/var/www/example.org`.
+- Set the deployment branch to match the branch you selected when creating the project.
+
+You can add multiple servers to the same project — for example, a staging server fed by a `staging` branch and a production server fed by `main`.
+
+## Configure the build pipeline
+
+DeployHQ runs build commands on its own infrastructure and uploads the resulting artifacts to your server. Configure the build pipeline from the project settings.
+
+Set the build commands:
+
+```sh
+hugo --minify
+```
+
+Set the build output directory to `public`. DeployHQ will transfer the contents of `public/` to the path you configured on the server, leaving the rest of the webroot untouched.
+
+If your site requires a specific Hugo version, pin it in the build pipeline. The following snippet downloads a specific release into the build environment before running Hugo:
+
+```sh {copy=true}
+HUGO_VERSION=0.161.1
+curl -sLJO "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+tar -xf "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+./hugo --minify
+```
+
+## Deploy
+
+Trigger the first deployment manually from the DeployHQ dashboard to verify the build succeeds and the files arrive in the expected webroot. Once the deployment is green, enable automatic deployments so that every push to the configured branch triggers a new build and upload.
+
+DeployHQ keeps a record of every deployment. If a release breaks your site, you can roll back to the previous successful deployment from the project's deployment history.
+
+> [!note]
+> DeployHQ's build environment is ephemeral. Anything your build needs — environment variables, theme submodules, Node.js dependencies for asset pipelines — must be declared in the project configuration or fetched as part of the build commands.
+
+## Other resources
+
+- [DeployHQ documentation][]
+- [DeployHQ guides][]
+
+[DeployHQ]: https://www.deployhq.com/
+[DeployHQ documentation]: https://www.deployhq.com/support
+[DeployHQ guides]: https://www.deployhq.com/guides
+[Git]: https://git-scm.com/
+[Quick Start]: /getting-started/quick-start/
+[`baseURL`]: /configuration/all/#baseurl
+[signup]: https://www.deployhq.com/signup


### PR DESCRIPTION
Adds a new page under `content/en/host-and-deploy/` that documents how to deploy a Hugo site with DeployHQ.

DeployHQ is a Git-based deployment automation service: it connects to a GitHub, GitLab, or Bitbucket repository, runs build commands (here, `hugo --minify`), and transfers the resulting `public/` directory to the user's own SSH/SFTP/FTP server or to cloud storage such as Amazon S3 or Azure Blob. Unlike Netlify, Render, GitHub Pages, or Cloudflare Pages, DeployHQ does not host the site — it complements the existing pages by covering the common "I already have a VPS / shared host and want push-to-deploy" workflow that Hugo users currently have to assemble manually with rsync or rclone.

The page follows the same structure and tone as the existing `host-on-sourcehut-pages.md` and `host-on-firebase.md` pages: YAML front matter with the four required fields, sentence-case ATX headings, second-person active voice, collapsed link references, and a closing "Other resources" section. No images, no shortcodes. More on DeployHQ: https://www.deployhq.com.
