### PR TITLE
Update Homebrew's Sass installation instruction to `brew install dart-sass`

### DIFF
--- a/content/en/functions/css/Sass.md
+++ b/content/en/functions/css/Sass.md
@@ -292,9 +292,9 @@ When you install Dart Sass somewhere in your PATH, Hugo will find it.
 
 OS      | Package manager | Site               | Installation
 :-------|:----------------|:-------------------|:-----------------------------
-Linux   | Homebrew        | [brew.sh][]        | `brew install sass/sass/sass`
+Linux   | Homebrew        | [brew.sh][]        | `brew install dart-sass`
 Linux   | Snap            | [snapcraft.io][]   | `sudo snap install dart-sass`
-macOS   | Homebrew        | [brew.sh][]        | `brew install sass/sass/sass`
+macOS   | Homebrew        | [brew.sh][]        | `brew install dart-sass`
 Windows | Chocolatey      | [chocolatey.org][] | `choco install sass`
 Windows | Scoop           | [scoop.sh][]       | `scoop install sass`
 


### PR DESCRIPTION
## Problem

`brew install sass/sass/sass` requires an additional step of `brew tap dart-lang/dart`, creating unnecessary frictions for users:

<img height="180" alt="Screenshot 2026-06-17 at 22 00 19" src="https://github.com/user-attachments/assets/156e7156-d654-42d0-b095-dc74ece55e97" />

## Cause

This is because the official repo of Sass requires building Dart Sass from source: see the Formula file
https://github.com/sass/homebrew-sass/blob/1db6e8372c08136fff895e0fd34977e420801411/Formula/sass.rb#L23
which calls Dart to compile at installation time:
https://github.com/sass/homebrew-sass/blob/1db6e8372c08136fff895e0fd34977e420801411/Formula/sass.rb#L64

## Solution

Advise users to install the prebuilt Dart Sass binary with `brew install dart-sass` ([brew.sh info page](https://formulae.brew.sh/formula/dart-sass#default)).