### PR TITLE
content: Add front matter example to the taxonomies page

### DIFF
--- a/content/en/content-management/taxonomies.md
+++ b/content/en/content-management/taxonomies.md
@@ -69,6 +69,18 @@ Moonrise Kingdom            <- Value
     ...
 ```
 
+### Assign terms in front matter
+
+Continuing with the example above, assign the terms for each movie in its front matter. Use the plural name of each taxonomy as the field name, and assign the terms as an array, even when a movie has only one term for a given taxonomy:
+
+{{< code-toggle file=content/movies/unbreakable.md fm=true >}}
+title = 'Unbreakable'
+actors = ['Bruce Willis','Samuel L. Jackson']
+directors = ['M. Night Shyamalan']
+{{< /code-toggle >}}
+
+Each term is a string, and a taxonomy is a flat list of terms rather than a nested data structure. To associate additional data with a term, create a page for the term as described in [Metadata](#metadata).
+
 ### Default destinations
 
 When taxonomies are used Hugo will automatically create both a page listing all the taxonomy's terms and individual pages with lists of content associated with each term. For example, a `categories` taxonomy declared in your configuration and used in your content front matter will create the following pages:


### PR DESCRIPTION
Adds a front matter example to the movie taxonomy section. The section illustrates the relationships between taxonomies, terms, and values with plain-text diagrams, but never shows the corresponding front matter, so it was not obvious how terms are actually assigned or what they look like in each configuration format.

The new example reuses the data already shown in the diagrams (the actors and director of *Unbreakable*) and renders in TOML, YAML, and JSON via the existing `code-toggle` shortcode. A short follow-up sentence answers the question raised in the issue by noting that a taxonomy is a flat list of string terms rather than a nested data structure, and links to the existing Metadata section for associating richer data with a term.

Closes #3251.