### PR TITLE
content: Format "nil" as code

### DIFF
--- a/content/en/functions/collections/Where.md
+++ b/content/en/functions/collections/Where.md
@@ -368,7 +368,7 @@ Is rendered to:
 To exclude a page with an undefined field from a boolean _inequality_ test:
 
 1. Create a slice using a boolean comparison
-1. Create a slice using a nil comparison
+1. Create a slice using a `nil` comparison
 1. Subtract the second slice from the first slice using the [`collections.Complement`][] function.
 
 This template:

--- a/content/en/functions/go-template/try.md
+++ b/content/en/functions/go-template/try.md
@@ -103,7 +103,7 @@ Instead of failing the build, we can catch the error and emit a warning:
 In the above, note that the [context](g) within the last conditional block is the `TryValue` object returned by the `try` statement. At this point neither the `Err` nor `Value` methods returned anything, so the current context is not useful. Use the `$` to access the [template context][] if needed.
 
 > [!NOTE]
-> Hugo does not classify an HTTP response with status code 404 as an error. In this case `resources.GetRemote` returns nil.
+> Hugo does not classify an HTTP response with status code 404 as an error. In this case `resources.GetRemote` returns `nil`.
 
 [`resources.GetRemote`]: /functions/resources/getremote/
 [`text/template`]: https://pkg.go.dev/text/template

--- a/content/en/functions/resources/GetRemote.md
+++ b/content/en/functions/resources/GetRemote.md
@@ -155,7 +155,7 @@ When retrieving remote data, use the [`transform.Unmarshal`][] function to [unma
 Use the [`try`][] statement to capture HTTP request errors. If you do not handle the error yourself, Hugo will fail the build.
 
 > [!NOTE]
-> Hugo does not classify an HTTP response with status code 404 as an error. In this case `resources.GetRemote` returns nil.
+> Hugo does not classify an HTTP response with status code 404 as an error. In this case `resources.GetRemote` returns `nil`.
 
 ```go-html-template
 {{ $url := "https://broken-example.org/images/a.jpg" }}

--- a/content/en/functions/strings/FindRESubmatch.md
+++ b/content/en/functions/strings/FindRESubmatch.md
@@ -11,7 +11,7 @@ params:
 aliases: [/functions/findresubmatch]
 ---
 
-By default, `findRESubmatch` finds all matches. You can limit the number of matches with an optional LIMIT argument. A return value of nil indicates no match.
+By default, `findRESubmatch` finds all matches. You can limit the number of matches with an optional LIMIT argument. A return value of `nil` indicates no match.
 
 {{% include "/_common/functions/regular-expressions.md" %}}
 

--- a/content/en/methods/menu-entry/PageRef.md
+++ b/content/en/methods/menu-entry/PageRef.md
@@ -26,7 +26,7 @@ If a matching page is found:
 If a matching page is not found:
 
 - The [`URL`][] method returns the entry's `url` property if set, else an empty string
-- The [`Page`][] method returns nil
+- The [`Page`][] method returns `nil`
 - The [`HasMenuCurrent`][] and [`IsMenuCurrent`][] methods on a `Page` object return `false`
 
 > [!NOTE]

--- a/content/en/methods/page/GetPage.md
+++ b/content/en/methods/page/GetPage.md
@@ -14,7 +14,7 @@ The `GetPage` method is also available on a `Site` object. See [details][].
 
 When using the `GetPage` method on the `Page` object, specify a path relative to the current directory or relative to the `content` directory.
 
-If Hugo cannot resolve the path to a page, the method returns nil. If the path is ambiguous, Hugo throws an error and fails the build.
+If Hugo cannot resolve the path to a page, the method returns `nil`. If the path is ambiguous, Hugo throws an error and fails the build.
 
 Consider this content structure:
 

--- a/content/en/methods/page/GitInfo.md
+++ b/content/en/methods/page/GitInfo.md
@@ -44,7 +44,7 @@ Hugo retrieves commit metadata for files tracked within your project's local rep
 Hugo also retrieves commit metadata for content provided by modules. This allows you to display commit data for remote repositories that are mounted as content directories, such as when aggregating documentation from multiple sources.
 
 > [!NOTE]
-> The `GitInfo` method returns nil for module content in these cases:
+> The `GitInfo` method returns `nil` for module content in these cases:
 >
 > - The module is vendored via `hugo mod vendor`
 > - A [module replacement][] is configured via a `replace` directive in `go.mod` or the [`replacements`][] configuration parameter

--- a/content/en/methods/page/Parent.md
+++ b/content/en/methods/page/Parent.md
@@ -41,7 +41,7 @@ content/
 └── _index.md             <-- parent: nil
 ```
 
-In the example above, note the parent section of the home page is nil. Code defensively by verifying existence of the parent section before calling methods on its `Page` object. To create a link to the parent section page of the current page:
+In the example above, note the parent section of the home page is `nil`. Code defensively by verifying existence of the parent section before calling methods on its `Page` object. To create a link to the parent section page of the current page:
 
 ```go-html-template
 {{ with .Parent }}

--- a/content/en/methods/page/Resources.md
+++ b/content/en/methods/page/Resources.md
@@ -18,7 +18,7 @@ To work with global or remote resources, see the [`resources`][] functions.
 Use these methods on the `Resources` object.
 
 `ByType`
-: (`resource.Resources`) Returns a collection of page resources of the given [media type][], or nil if none found. The media type is typically one of `image`, `text`, `audio`, `video`, or `application`.
+: (`resource.Resources`) Returns a collection of page resources of the given [media type][], or `nil` if none found. The media type is typically one of `image`, `text`, `audio`, `video`, or `application`.
 
   ```go-html-template
   {{ range .Resources.ByType "image" }}
@@ -29,7 +29,7 @@ Use these methods on the `Resources` object.
   When working with global resources instead of page resources, use the [`resources.ByType`][] function.
 
 `Get`
-: (`resource.Resource`) Returns a page resource from the given path, or nil if none found.
+: (`resource.Resource`) Returns a page resource from the given path, or `nil` if none found.
 
   ```go-html-template
   {{ with .Resources.Get "images/a.jpg" }}
@@ -40,7 +40,7 @@ Use these methods on the `Resources` object.
   When working with global resources instead of page resources, use the [`resources.Get`][] function.
 
 `GetMatch`
-: (`resource.Resource`) Returns the first page resource from paths matching the given [glob pattern](g), or nil if none found.
+: (`resource.Resource`) Returns the first page resource from paths matching the given [glob pattern](g), or `nil` if none found.
 
   ```go-html-template
   {{ with .Resources.GetMatch "images/*.jpg" }}
@@ -51,7 +51,7 @@ Use these methods on the `Resources` object.
   When working with global resources instead of page resources, use the [`resources.GetMatch`][] function.
 
 `Match`
-: (`resource.Resources`) Returns a collection of page resources from paths matching the given [glob pattern](g), or nil if none found.
+: (`resource.Resources`) Returns a collection of page resources from paths matching the given [glob pattern](g), or `nil` if none found.
 
   ```go-html-template
   {{ range .Resources.Match "images/*.jpg" }}

--- a/content/en/methods/site/GetPage.md
+++ b/content/en/methods/site/GetPage.md
@@ -13,7 +13,7 @@ The `GetPage` method is also available on `Page` objects, allowing you to specif
 
 When using the `GetPage` method on a `Site` object, specify a path relative to the `content` directory.
 
-If Hugo cannot resolve the path to a page, the method returns nil.
+If Hugo cannot resolve the path to a page, the method returns `nil`.
 
 Consider this content structure:
 

--- a/content/en/methods/taxonomy/Page.md
+++ b/content/en/methods/taxonomy/Page.md
@@ -9,7 +9,7 @@ params:
     signatures: [TAXONOMY.Page]
 ---
 
-This `TAXONOMY` method returns nil if the taxonomy has no terms, so you must code defensively:
+This `TAXONOMY` method returns `nil` if the taxonomy has no terms, so you must code defensively:
 
 ```go-html-template
 {{ with .Site.Taxonomies.tags.Page }}

--- a/content/en/troubleshooting/audit/index.md
+++ b/content/en/troubleshooting/audit/index.md
@@ -57,7 +57,7 @@ _Tested with GNU Bash 5.1 and GNU grep 3.7._
 : This is the placeholder produced instead of the default value or an empty string if a translation is missing.
 
 `(<nil>)`
-: This string will appear in the rendered HTML when passing a nil value to the `printf` function.
+: This string will appear in the rendered HTML when passing a `nil` value to the `printf` function.
 
 `(&lt;nil&gt;)`
 : Same as above when the value returned from the `printf` function has not been passed through the [`safe.HTML`][] function.


### PR DESCRIPTION
This is consistent with the Go documentation.