### PR TITLE
Link to Docs instead of Getting started in the home page

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -4,6 +4,6 @@ linkTitle: About
 description: Learn about Hugo and its features, privacy protections, and security model.
 categories: []
 keywords: []
-weight: 10
+weight: 7
 aliases: [/about-hugo/,/docs/]
 ---

--- a/content/en/getting-started/_index.md
+++ b/content/en/getting-started/_index.md
@@ -3,6 +3,6 @@ title: Getting started
 description: How to get started with Hugo.
 categories: []
 keywords: []
-weight: 10
+weight: 8
 aliases: [/overview/introduction/]
 ---

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -27,7 +27,7 @@
 				fun again.
 			</div>
 			<div class="mt-10 flex items-center justify-center gap-x-6">
-				{{ with site.GetPage "/getting-started" }}
+				{{ with site.GetPage "/documentation" }}
 					<a
 						href="{{ .RelPermalink }}"
 						class="rounded-md uppercase tracking-wide bg-blue-600  hover:bg-blue-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"


### PR DESCRIPTION
Also, adjust some page weights to pull the Getting Started page in section listings.

I have looked at some GA stats and the Getting Started page obviously gets lots of hits, but is a little of a dead end as it is now set up. I suggest we try linking to the Docs section instead and see if that brings the numbers up.
