### PR TITLE
Add hugo-zbsearch module to search tools documentation

### DIFF
--- a/content/en/tools/search.md
+++ b/content/en/tools/search.md
@@ -41,6 +41,9 @@ A static website with a dynamic search function? Yes, Hugo provides an alternati
 [INFINI Pizza for WebAssembly][]
 : Pizza is a super-lightweight yet fully featured search engine written in Rust. You can quickly add offline search functionality to your Hugo website in just five minutes with only three lines of code. For a step-by-step guide on integrating it with Hugo, check out [this blog tutorial][].
 
+[hugo-zbsearch][]
+: A Hugo Module providing client-side full-text search powered by [ZBSearch][] (community fork of Orama). Supports 27 languages with stemming, typo tolerance, field boosting, and works with any theme. The search index is built at compile time and runs entirely in the browser — no server or external services required. Distributed as a Hugo Module with zero configuration needed beyond `hugo mod get`.
+
 ## Commercial
 
 [Algolia DocSearch][]
@@ -60,6 +63,7 @@ A static website with a dynamic search function? Yes, Hugo provides an alternati
 [GitHub Gist for Fuse.js integration]: https://gist.github.com/eddiewebb/735feb48f50f0ddd65ae5606a1cb41ae
 [GitHub Gist for Hugo Workflow]: https://gist.github.com/sebz/efddfc8fdcb6b480f567
 [Hugo Lyra]: https://github.com/paolomainardi/hugo-lyra
+[hugo-zbsearch]: https://github.com/serenasensini/hugo-zbsearch
 [INFINI Pizza for WebAssembly]: https://github.com/infinilabs/pizza-docsearch
 [JS & Fuse.js tutorial]: https://makewithhugo.com/add-search-to-a-hugo-site/
 [Lyra]: https://github.com/LyraSearch/lyra


### PR DESCRIPTION
This PR adds [hugo-zbsearch](https://github.com/serenasensini/hugo-zbsearch) to the list of open-source search tools.

hugo-zbsearch is a Hugo Module that provides client-side full-text search powered by [ZBSearch](https://zbsearch.dev) — the community fork of [Orama](https://github.com/oramasearch/orama), created and maintained by [Michele Riva](https://github.com/micheleriva) (Orama's original founder and author) and the original team.

The lineage is: **Lyra → Orama → ZBSearch**. The existing "Hugo Lyra" entry on this page references Lyra, which evolved into Orama and is now continued as ZBSearch by the same author. hugo-zbsearch uses the current, actively maintained library.

Key differentiators from existing entries:
- **Hugo Module**: native distribution via `hugo mod get` — no Gulp, Grunt, or external build tools
- **27 languages**: real stemming support (not just English)
- **Typo tolerance**: finds results even with spelling mistakes
- **Theme-agnostic**: works with any Hugo theme without modifications
- **Actively maintained**: ZBSearch is the current evolution of the Lyra/Orama lineage, maintained by the original author
- **Secure**: XSS-safe, CSP-compatible, no inline scripts

References:
- hugo-zbsearch repo: https://github.com/serenasensini/hugo-zbsearch
- ZBSearch: https://zbsearch.dev
- ZBSearch GitHub: https://github.com/micheleriva/zbsearch