### PR TITLE
content: Clarify output format details

### DIFF
--- a/content/en/configuration/output-formats.md
+++ b/content/en/configuration/output-formats.md
@@ -148,7 +148,7 @@ To access output formats, each `Page` object provides two methods: [`OutputForma
 
 ## Link to output formats
 
-By default, a `Page` object's [`Permalink`][] and [`RelPermalink`][] methods return the URL of the [primary output format](g), typically `html`. This behavior remains consistent regardless of the template used.
+The URL returned by a `Page` object's [`Permalink`][] and [`RelPermalink`][] methods depends on the current output format. For output formats with [`permalinkable`](#permalinkable) set to `true`, such as `html` and `amp`, the methods return that format's own URL. For all other output formats, the methods return the URL of the page's [primary output format](g).
 
 For example, in `page.json.json`, you'll see:
 

--- a/content/en/configuration/outputs.md
+++ b/content/en/configuration/outputs.md
@@ -26,9 +26,9 @@ home = ['html','rss','json']
 Notice in this example that we only specified the `home` page kind. You don't need to include entries for other page kinds unless you intend to modify their default output formats.
 
 > [!NOTE]
-> The order of the output formats in the arrays above is important. The first element will be the _primary output format_ for that page kind, and in most cases that should be `html` as shown in the default configuration.
+> The order of the output formats in the arrays above is important. The first element will be the [primary output format](g) for that page kind, and in most cases that should be `html` as shown in the default configuration.
 >
-> The primary output format for a given page kind determines the value returned by the [`Permalink`][] and [`RelPermalink`][] methods on a `Page` object.
+> The primary output format determines the value returned by the [`Permalink`][] and [`RelPermalink`][] methods on a `Page` object. For output formats with [`permalinkable`][] set to `true`, such as `html` and `amp`, those methods return that format's own URL regardless of its position in the list.
 >
 > See the [link to output formats][] section for details.
 
@@ -45,5 +45,6 @@ In its default configuration, Hugo will render both the `html` and `json` output
 
 [`Permalink`]: /methods/page/permalink/
 [`RelPermalink`]: /methods/page/relpermalink/
+[`permalinkable`]: /configuration/output-formats/#permalinkable
 [configure output formats]: /configuration/output-formats/
 [link to output formats]: configuration/output-formats/#link-to-output-formats

--- a/content/en/quick-reference/glossary/canonical-output-format.md
+++ b/content/en/quick-reference/glossary/canonical-output-format.md
@@ -2,7 +2,7 @@
 title: canonical output format
 ---
 
-The _canonical output format_ is the [_output format_](g) for the current page where the format's [`rel`][] property is set to `canonical` in your project configuration, if such a format exists. If there is only one _output format_ for the current page, that is the _canonical output format_, regardless of whether the format's `rel` property is set to `canonical`.
+The _canonical output format_ is the [_output format_](g) for the current page where the format's [`rel`][] property is set to `canonical` in your project configuration, if such a format exists. If there is only one _output format_ for the current page and it is a predefined format, Hugo automatically treats it as the _canonical output format_ regardless of whether its `rel` property is set to `canonical`. Custom output formats are not subject to this rule; `rel` must be explicitly set to `canonical`.
 
   By default, `html` is the only predefined _output format_ with this setting; the `rel` property for all others is set to `alternate`. If two or more _output formats_ for the current page have their `rel` property set to `canonical`, the _canonical output format_ is the first one specified in:
 

--- a/content/en/quick-reference/glossary/primary-output-format.md
+++ b/content/en/quick-reference/glossary/primary-output-format.md
@@ -3,8 +3,6 @@ title: primary output format
 details: /configuration/outputs/
 ---
 
-A _primary output format_ defines the default URL returned by the [`Permalink`][] and [`RelPermalink`][] methods for a given [_page kind_](g). It is specified as the first entry within the [outputs configuration][] for that page kind.
+The _primary output format_ for a given [_page kind_](g) is the first entry in the [outputs configuration][].
 
-  [`Permalink`]: /methods/page/permalink/
-  [`RelPermalink`]: /methods/page/relpermalink/
   [outputs configuration]: /configuration/outputs/


### PR DESCRIPTION
Closes #3632

- [`configuration/output-formats/#link-to-output-formats`](https://deploy-preview-3635--gohugoio.netlify.app/configuration/output-formats/#link-to-output-formats)
- [`configuration/outputs/#outputs-per-page-kind`](https://deploy-preview-3635--gohugoio.netlify.app/configuration/outputs/#outputs-per-page-kind)
- [`quick-reference/glossary/#canonical-output-format`](https://deploy-preview-3635--gohugoio.netlify.app/quick-reference/glossary/#canonical-output-format)
- [`quick-reference/glossary/#primary-output-format`](https://deploy-preview-3635--gohugoio.netlify.app/quick-reference/glossary/#primary-output-format)